### PR TITLE
Add Laravel Cloud deployment skill

### DIFF
--- a/skills/deploying-laravel-cloud/SKILL.md
+++ b/skills/deploying-laravel-cloud/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: deploying-laravel-cloud
+description: "Deploys and manages Laravel applications on Laravel Cloud using the `cloud` CLI. Use when the user wants to deploy an app, ship to cloud, create/manage environments, databases, caches, domains, instances, background processes, or any Laravel Cloud infrastructure. Triggers on deploy, ship, cloud management, environment setup, database provisioning, and similar cloud operations."
+---
+# Deploying with Laravel Cloud CLI
+
+## Setup
+
+```sh
+composer global require laravel/cloud-cli
+cloud auth -n
+```
+
+## Commands
+
+Commands follow a CRUD pattern: `resource:list`, `resource:get`, `resource:create`, `resource:update`, `resource:delete`.
+
+Available resources: `application`, `environment`, `instance`, `database-cluster`, `database`, `cache`, `bucket`, `domain`, `websocket-cluster`, `background-process`, `command`, `deployment`.
+
+Some resources have additional commands (e.g., `domain:verify`, `database:open`, `instance:sizes`, `cache:types`). Discover these via `cloud -h`.
+
+Never hardcode command signatures. Always run `cloud <command> -h` to discover options at runtime.
+
+## CLI Flags
+
+Always add `-n` to every command — prevents the CLI from hanging.
+Never use `-q` or `--silent` — they suppress all output.
+
+Flag combos per operation:
+- Read (`:list`, `:get`) → `--json -n`
+- Create (`:create`) → `--json -n`
+- Update (`:update`) → `--json -n --force`
+- Delete (`:delete`) → `-n --force` (no `--json`)
+- Environment variables → `-n --force`
+- Deploy/ship → `-n` with all options passed explicitly (no `--json`)
+
+## Deployment Workflow
+
+Determine the task and follow the matching path:
+
+First deploy? → `cloud ship -n` (discover options via `cloud ship -h`)
+
+Existing app? →
+```sh
+cloud repo:config
+cloud deploy {app_name} {environment} -n --open
+cloud deploy:monitor -n
+```
+
+Environment variables? → `cloud environment:variables -n --force`
+
+Provision infrastructure? → `cloud <resource>:create --json -n`
+
+Custom domain? → `cloud domain:create --json -n` then `cloud domain:verify -n`
+
+For multi-step operations, see [reference/checklists.md](reference/checklists.md).
+
+Not sure what the user needs? → ask them before running anything.
+
+## When a Command Fails
+
+1. Read the error output
+2. Check resource status with `:list --json -n` or `:get --json -n`
+3. Auth error? → `cloud auth -n`
+4. Fix the issue, re-run the command
+5. If the same error repeats after one fix, stop and ask the user
+
+Always run `cloud deploy:monitor -n` after every deploy. If it fails, show the user what went wrong before attempting a fix.
+
+## Subagent Delegation
+
+Delegate high-output operations to subagents (using the Task tool) to keep the main context window small. Only the summary comes back — verbose output stays in the subagent's context.
+
+Delegate these to a subagent:
+- `cloud deploy:monitor -n` — deployment logs can be very long
+- `cloud deployment:get --json -n` — full deployment details
+- `cloud <resource>:list --json -n` — listing many resources produces large JSON
+- Fetching docs from https://cloud.laravel.com/docs/llms.txt via `WebFetch`
+
+Keep in the main context:
+- Short commands like `:create`, `:delete`, `:update` — output is small
+- `cloud deploy -n` — you need the deployment ID immediately
+- Any command where you need the result for the next step right away
+
+## Rules
+
+Follow exact steps:
+- Flag selection — always use the documented combos above
+- Deploy sequence — deploy then monitor, never skip monitoring
+- Destructive commands — always confirm with user first, show the command and wait for approval
+- Error loop — diagnose, fix once, ask user if it fails again
+
+Use your judgment:
+- Instance sizes, regions, cluster types — ask the user if not specified
+- Which resources to provision — based on what the user describes
+- Order of provisioning — no strict sequence required
+- How to present output — summarize, show raw, or extract fields based on context
+
+## Config
+
+1. Global: `~/.config/cloud/config.json` — auth tokens and preferences
+2. Repo-local: `.cloud/config.json` — app and environment defaults (set by `cloud repo:config`)
+3. CLI arguments override both
+
+## Documentation
+
+Laravel Cloud Docs: https://cloud.laravel.com/docs/llms.txt
+
+When the user asks how something works or needs an explanation of a Laravel Cloud feature, fetch the docs from the URL above using `WebFetch` and use it to provide accurate answers.
+
+## When Stuck
+
+- Fetch https://cloud.laravel.com/docs/llms.txt for official documentation
+- Run `cloud <command> -h` for any command's options
+- Run `cloud -h` to discover commands

--- a/skills/deploying-laravel-cloud/reference/checklists.md
+++ b/skills/deploying-laravel-cloud/reference/checklists.md
@@ -1,0 +1,54 @@
+# Checklists for Multi-Step Operations
+
+Use these checklists when performing complex setups. Copy the relevant checklist and track progress as you go.
+
+## Full environment setup (app + database + cache + domain)
+
+```
+- [ ] Create or select the application
+- [ ] Create the environment
+- [ ] Provision the database (`database-cluster:create` then `database:create`)
+- [ ] Provision the cache (`cache:create`)
+- [ ] Set environment variables (`environment:variables`)
+- [ ] Attach custom domain (`domain:create` then `domain:verify`)
+- [ ] Deploy (`deploy` then `deploy:monitor`)
+- [ ] Verify the deployment is live
+```
+
+## New app from scratch
+
+```
+- [ ] Run `cloud ship -n` with required options
+- [ ] Monitor deployment status
+- [ ] Set environment variables if needed
+- [ ] Verify the app is accessible
+```
+
+## Adding a database to an existing environment
+
+```
+- [ ] Check existing database clusters (`database-cluster:list --json -n`)
+- [ ] Create a new cluster if needed (`database-cluster:create --json -n`)
+- [ ] Create the database on the cluster (`database:create --json -n`)
+- [ ] Update environment variables with connection details if needed
+- [ ] Redeploy if the app needs to pick up new config
+```
+
+## Adding a cache to an existing environment
+
+```
+- [ ] Check existing caches (`cache:list --json -n`)
+- [ ] Create the cache (`cache:create --json -n`)
+- [ ] Update environment variables with cache connection details if needed
+- [ ] Redeploy if the app needs to pick up new config
+```
+
+## Custom domain setup
+
+```
+- [ ] Create the domain (`domain:create --json -n`)
+- [ ] Get DNS records to configure (`domain:get --json -n`)
+- [ ] Tell the user to add the DNS records at their registrar
+- [ ] Verify the domain (`domain:verify -n`)
+- [ ] Confirm verification passed
+```


### PR DESCRIPTION
Adds a Agent skill for deploying and managing Laravel applications on Laravel Cloud using the `cloud` CLI.

### Approach

- Adds a `SKILL.md` that teaches Claude how to use the `cloud` CLI — command patterns, flag conventions, deployment workflow, error handling, and when to delegate to subagents
- Includes a `reference/checklists.md` with step-by-step checklists for multi-step operations like full environment setup, database provisioning, cache setup, and custom domain configuration