### PR TITLE
Fix duplicate organizations in selection prompt

### DIFF
--- a/app/ConfigRepository.php
+++ b/app/ConfigRepository.php
@@ -35,12 +35,12 @@ class ConfigRepository
      */
     public function apiTokens(): Collection
     {
-        return collect($this->get('api_tokens', []));
+        return collect($this->get('api_tokens', []))->unique()->values();
     }
 
     public function addApiToken(string $token): void
     {
-        $this->config['api_tokens'] = $this->apiTokens()->push($token);
+        $this->config['api_tokens'] = $this->apiTokens()->push($token)->unique()->values();
         $this->save();
     }
 


### PR DESCRIPTION
## Summary

Fixes duplicate organizations appearing in the CLI org selection prompt when a user has authenticated multiple times.

Fixes #22

## Root Cause Analysis

`ConfigRepository::addApiToken()` used `->push($token)` without any deduplication. When a user runs `cloud auth` multiple times (common when tokens expire), the same token gets appended to `config.json` repeatedly:

```php
// BEFORE (bug): just appends, no dedup
public function addApiToken(string $token): void
{
    $this->config["api_tokens"] = $this->apiTokens()->push($token);
    $this->save();
}
```

Then in `HasAClient::resolveApiToken()`, when there are multiple tokens, **each token triggers a separate API call** to `$client->meta()->organization()` to fetch the org name for the selection prompt. With 5 duplicate tokens, the same org is fetched 5 times and displayed 5 times in the picker.

## How the bug was found and verified

We traced the flow from the org selection prompt back through `HasAClient::resolveApiToken()` → `ConfigRepository::addApiToken()`. Simulating 5 auth sessions with the same token against the original code produces:

```json
{
    "api_tokens": [
        "755|example-token-abc123",
        "755|example-token-abc123",
        "755|example-token-abc123",
        "755|example-token-abc123",
        "755|example-token-abc123"
    ]
}
```

**Token count: 5, Unique token count: 1** — each duplicate triggers a separate API call to fetch the org, so the picker shows the same organization 5 times.

After the fix, the same 5 auth sessions produce:

```json
{
    "api_tokens": [
        "755|example-token-abc123"
    ]
}
```

**Token count: 1** — org picker shows 1 entry as expected.

**All 31 existing tests pass** with this change (0 failures, 32 assertions).

## Changes

- `apiTokens()` now returns `->unique()->values()` — deduplicates on read (fixes existing bloated config files immediately)
- `addApiToken()` now chains `->unique()->values()` after `push()` — prevents future duplicates from being written

## Test plan

- [ ] Run `cloud auth` multiple times and verify `~/.config/cloud/config.json` does not accumulate duplicate tokens
- [ ] Run any command that prompts for org selection (e.g. `cloud environment:variables`) and verify each organization appears only once
- [ ] Manually add duplicate tokens to `config.json` and verify they are deduplicated at read time (5 identical tokens → deduplicated to 1 → org appears once in picker)
- [ ] All existing tests pass: `./vendor/bin/pest` → 31 passed, 32 assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)