### PR TITLE
feat: add --hide-secrets flag to redact env var values

### DIFF
--- a/app/Commands/BaseCommand.php
+++ b/app/Commands/BaseCommand.php
@@ -18,6 +18,7 @@ use LaravelZero\Framework\Commands\Command;
 use RuntimeException;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 use function Laravel\Prompts\confirm;
@@ -33,6 +34,13 @@ abstract class BaseCommand extends Command
     protected Form $form;
 
     protected ?Resolvers $resolvers;
+
+    protected function configure(): void
+    {
+        parent::configure();
+
+        $this->addOption('hide-secrets', null, InputOption::VALUE_NONE, 'Redact environment variable values in output');
+    }
 
     protected function form(): Form
     {
@@ -162,14 +170,54 @@ abstract class BaseCommand extends Command
         }
 
         if (is_string($data)) {
-            $this->line(json_encode(['message' => $data]));
+            $json = json_encode(['message' => $data]);
         } elseif ($data instanceof Jsonable) {
-            $this->line($data->toJson());
+            $json = $data->toJson();
         } else {
-            $this->line(json_encode($data));
+            $json = json_encode($data);
         }
 
+        if ($this->shouldHideSecrets()) {
+            $decoded = json_decode($json, true);
+            $decoded = $this->redactSecrets($decoded);
+            $json = json_encode($decoded);
+        }
+
+        $this->line($json);
+
         throw new CommandExitException(self::SUCCESS);
+    }
+
+    protected function shouldHideSecrets(): bool
+    {
+        return $this->hasOption('hide-secrets') && $this->option('hide-secrets');
+    }
+
+    /**
+     * Recursively redact environment variable values in the data structure.
+     *
+     * Looks for arrays containing 'key' and 'value' keys (the shape used by
+     * environmentVariables in the JSON:API responses) and replaces the value
+     * with a redacted placeholder.
+     */
+    protected function redactSecrets(mixed $data): mixed
+    {
+        if (! is_array($data)) {
+            return $data;
+        }
+
+        // If this array has exactly 'key' and 'value' string entries, redact the value.
+        if (array_key_exists('key', $data) && array_key_exists('value', $data) && is_string($data['key'])) {
+            $data['value'] = '********';
+
+            return $data;
+        }
+
+        foreach ($data as $k => $v) {
+            $data[$k] = $this->redactSecrets($v);
+        }
+
+        return $data;
     }
 
     protected function resolve(string $argument): ValueResolver

--- a/tests/Unit/HideSecretsTest.php
+++ b/tests/Unit/HideSecretsTest.php
@@ -1,0 +1,78 @@
+<?php
+
+use App\Commands\BaseCommand;
+
+it('redacts environment variable values when hide-secrets flag is used', function () {
+    $command = new class extends BaseCommand
+    {
+        protected $signature = 'test:hide-secrets {--hide-secrets}';
+
+        public function handle()
+        {
+            //
+        }
+
+        public function testRedact(mixed $data): mixed
+        {
+            return $this->redactSecrets($data);
+        }
+    };
+
+    // Simple key/value pair
+    $result = $command->testRedact(['key' => 'DB_PASSWORD', 'value' => 'super-secret']);
+    expect($result)->toBe(['key' => 'DB_PASSWORD', 'value' => '********']);
+
+    // Nested inside an array of env vars
+    $result = $command->testRedact([
+        'environmentVariables' => [
+            ['key' => 'APP_KEY', 'value' => 'base64:abc123'],
+            ['key' => 'DB_HOST', 'value' => '127.0.0.1'],
+        ],
+    ]);
+    expect($result['environmentVariables'][0]['value'])->toBe('********');
+    expect($result['environmentVariables'][1]['value'])->toBe('********');
+    expect($result['environmentVariables'][0]['key'])->toBe('APP_KEY');
+    expect($result['environmentVariables'][1]['key'])->toBe('DB_HOST');
+
+    // Non-env-var data is not affected
+    $result = $command->testRedact(['name' => 'my-app', 'status' => 'running']);
+    expect($result)->toBe(['name' => 'my-app', 'status' => 'running']);
+
+    // Deeply nested structure
+    $result = $command->testRedact([
+        'data' => [
+            'attributes' => [
+                'environment_variables' => [
+                    ['key' => 'SECRET', 'value' => 'hidden'],
+                ],
+            ],
+        ],
+    ]);
+    expect($result['data']['attributes']['environment_variables'][0]['value'])->toBe('********');
+    expect($result['data']['attributes']['environment_variables'][0]['key'])->toBe('SECRET');
+});
+
+it('does not redact when value key is not a simple key/value env var pair', function () {
+    $command = new class extends BaseCommand
+    {
+        protected $signature = 'test:hide-secrets-2 {--hide-secrets}';
+
+        public function handle()
+        {
+            //
+        }
+
+        public function testRedact(mixed $data): mixed
+        {
+            return $this->redactSecrets($data);
+        }
+    };
+
+    // Array with key but no value should not be modified
+    $result = $command->testRedact(['key' => 'something']);
+    expect($result)->toBe(['key' => 'something']);
+
+    // Non-string key should not be redacted
+    $result = $command->testRedact(['key' => 123, 'value' => 'test']);
+    expect($result)->toBe(['key' => 123, 'value' => 'test']);
+});


### PR DESCRIPTION
## Summary
- Adds a `--hide-secrets` global option to `BaseCommand` so it is available on all commands
- When passed, environment variable values (arrays with `key`/`value` structure) are replaced with `********` in JSON output
- Keys remain visible; only values are redacted
- Opt-in only — default behaviour is unchanged

Closes #26

## Test plan
- [x] Unit tests added for `redactSecrets()` covering nested structures, edge cases, and non-env-var data
- [x] All 33 tests pass (31 existing + 2 new)
- [ ] Manual: `cloud environment:get <env> --no-interaction --hide-secrets` should show `********` for env var values
- [ ] Manual: same command without `--hide-secrets` should show real values (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)