### PR TITLE
feat: add --token flag and LARAVEL_CLOUD_API_TOKEN env var support

### DIFF
--- a/app/Commands/BaseCommand.php
+++ b/app/Commands/BaseCommand.php
@@ -18,6 +18,7 @@ use LaravelZero\Framework\Commands\Command;
 use RuntimeException;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 use function Laravel\Prompts\confirm;
@@ -29,6 +30,18 @@ abstract class BaseCommand extends Command
     use DetectsNonInteractiveEnvironments;
     use HasAClient;
     use Validates;
+
+    protected function configure(): void
+    {
+        parent::configure();
+
+        $this->addOption(
+            'token',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'Laravel Cloud API token (overrides stored tokens and LARAVEL_CLOUD_API_TOKEN env var)',
+        );
+    }
 
     protected Form $form;
 

--- a/app/Concerns/HasAClient.php
+++ b/app/Concerns/HasAClient.php
@@ -23,6 +23,12 @@ trait HasAClient
 
     protected function ensureApiTokenExists(): void
     {
+        // If a token is available via env var, no need to check config
+        $envToken = getenv('LARAVEL_CLOUD_API_TOKEN');
+        if ($envToken !== false && $envToken !== '') {
+            return;
+        }
+
         $config = app(ConfigRepository::class);
         $apiTokens = $config->apiTokens();
 
@@ -35,6 +41,20 @@ trait HasAClient
 
     protected function resolveApiToken(bool $ignoreLocalConfig = false): string
     {
+        // --token flag takes highest priority
+        if ($this instanceof \Symfony\Component\Console\Command\Command
+            && $this->getDefinition()->hasOption('token')
+            && ($flagToken = $this->option('token'))
+        ) {
+            return $flagToken;
+        }
+
+        // LARAVEL_CLOUD_API_TOKEN env var takes second priority
+        $envToken = getenv('LARAVEL_CLOUD_API_TOKEN');
+        if ($envToken !== false && $envToken !== '') {
+            return $envToken;
+        }
+
         $config = app(ConfigRepository::class);
         $apiTokens = $config->apiTokens();
 

--- a/app/Concerns/HasAClient.php
+++ b/app/Concerns/HasAClient.php
@@ -5,6 +5,7 @@ namespace App\Concerns;
 use App\Client\Connector;
 use App\ConfigRepository;
 use App\LocalConfig;
+use Symfony\Component\Console\Command\Command;
 
 use function Laravel\Prompts\password;
 use function Laravel\Prompts\select;
@@ -23,8 +24,16 @@ trait HasAClient
 
     protected function ensureApiTokenExists(): void
     {
+        // --token flag takes highest priority (check argv since middleware doesn't have command context)
+        foreach ($_SERVER['argv'] ?? [] as $arg) {
+            if (str_starts_with($arg, '--token=') || $arg === '--token') {
+                return;
+            }
+        }
+
         // If a token is available via env var, no need to check config
         $envToken = getenv('LARAVEL_CLOUD_API_TOKEN');
+
         if ($envToken !== false && $envToken !== '') {
             return;
         }
@@ -42,7 +51,7 @@ trait HasAClient
     protected function resolveApiToken(bool $ignoreLocalConfig = false): string
     {
         // --token flag takes highest priority
-        if ($this instanceof \Symfony\Component\Console\Command\Command
+        if ($this instanceof Command
             && $this->getDefinition()->hasOption('token')
             && ($flagToken = $this->option('token'))
         ) {
@@ -51,6 +60,7 @@ trait HasAClient
 
         // LARAVEL_CLOUD_API_TOKEN env var takes second priority
         $envToken = getenv('LARAVEL_CLOUD_API_TOKEN');
+
         if ($envToken !== false && $envToken !== '') {
             return $envToken;
         }


### PR DESCRIPTION
## Summary

- Adds a global `--token` option to `BaseCommand` so all commands accept an explicit API token
- Adds `LARAVEL_CLOUD_API_TOKEN` environment variable support in `HasAClient::resolveApiToken()`
- Token resolution priority: `--token` flag > `LARAVEL_CLOUD_API_TOKEN` env var > stored config token > interactive prompt
- Tokens passed via flag or env var are used directly without validation and are **not** persisted to `config.json`
- Updates `ensureApiTokenExists()` to skip config checks when env var token is available

Closes #27

## Test plan

- [x] All 40 existing tests pass (`./vendor/bin/pest`)
- [ ] Verify `cloud app:list --token=<valid-token>` authenticates without stored config
- [ ] Verify `LARAVEL_CLOUD_API_TOKEN=<token> cloud app:list` works in non-interactive mode
- [ ] Verify `--token` flag takes precedence over env var
- [ ] Verify commands with `NoAuthRequired` interface still work without a token
- [ ] Verify tokens passed via flag/env are not written to `~/.config/cloud/config.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)