### PR TITLE
fix: inconsistent error handling between commands and resolvers

### DIFF
--- a/app/Commands/BaseCommand.php
+++ b/app/Commands/BaseCommand.php
@@ -2,6 +2,7 @@
 
 namespace App\Commands;
 
+use App\Concerns\FormatsErrors;
 use App\Concerns\HasAClient;
 use App\Concerns\Validates;
 use App\Exceptions\CommandExitException;
@@ -27,6 +28,7 @@ abstract class BaseCommand extends Command
 {
     use Colors;
     use DetectsNonInteractiveEnvironments;
+    use FormatsErrors;
     use HasAClient;
     use Validates;
 
@@ -74,7 +76,7 @@ abstract class BaseCommand extends Command
     protected function outputError(string $message): void
     {
         if ($this->wantsJson()) {
-            $this->line(json_encode(['message' => $message]));
+            $this->line($this->formatErrorAsJson($message));
         } else {
             error($message);
         }

--- a/app/Concerns/FormatsErrors.php
+++ b/app/Concerns/FormatsErrors.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Concerns;
+
+/**
+ * Provides consistent error output formatting across commands and resolvers.
+ *
+ * When non-interactive (or JSON requested), errors are output as JSON.
+ * When interactive, errors use Laravel Prompts' error() function.
+ */
+trait FormatsErrors
+{
+    /**
+     * Format an error message as JSON for non-interactive output.
+     */
+    protected function formatErrorAsJson(string $message): string
+    {
+        return json_encode(['message' => $message, 'error' => true]);
+    }
+}

--- a/app/Resolvers/Resolver.php
+++ b/app/Resolvers/Resolver.php
@@ -3,6 +3,7 @@
 namespace App\Resolvers;
 
 use App\Client\Connector;
+use App\Concerns\FormatsErrors;
 use App\Exceptions\CommandExitException;
 use App\LocalConfig;
 use Illuminate\Console\Command;
@@ -12,6 +13,8 @@ use function Laravel\Prompts\error;
 
 abstract class Resolver
 {
+    use FormatsErrors;
+
     protected bool $displayResolved = true;
 
     public function __construct(
@@ -55,7 +58,7 @@ abstract class Resolver
     protected function failAndExit(string $message): void
     {
         if (! $this->isInteractive) {
-            echo json_encode(['message' => $message]).PHP_EOL;
+            echo $this->formatErrorAsJson($message).PHP_EOL;
 
             throw new CommandExitException(Command::FAILURE);
         }
@@ -77,7 +80,7 @@ abstract class Resolver
     protected function ensureInteractive(string $message): void
     {
         if (! $this->isInteractive) {
-            echo json_encode(['message' => $message]).PHP_EOL;
+            echo $this->formatErrorAsJson($message).PHP_EOL;
 
             throw new CommandExitException(Command::FAILURE);
         }


### PR DESCRIPTION
## Summary

- Extracts a shared `FormatsErrors` trait (`app/Concerns/FormatsErrors.php`) that provides a single `formatErrorAsJson()` method returning `{"message":"...","error":true}`
- Updates `BaseCommand::outputError()` to use the trait instead of inline `json_encode(['message' => $message])`
- Updates `Resolver::failAndExit()` and `Resolver::ensureInteractive()` to use the trait instead of raw `echo json_encode(['message' => $message])`
- Both commands and resolvers now produce a consistent JSON error format with the `error` flag included

Closes #29

## Test plan

- [x] All 31 existing tests pass (`./vendor/bin/pest`)
- [ ] Verify non-interactive command errors output `{"message":"...","error":true}`
- [ ] Verify resolver errors in non-interactive mode output the same format
- [ ] Verify interactive mode still uses Laravel Prompts `error()` function

🤖 Generated with [Claude Code](https://claude.com/claude-code)