### PR TITLE
fix: wrong RequestException import in 7 commands + ApplicationUpdate error handling

### DIFF
--- a/app/Commands/ApplicationDelete.php
+++ b/app/Commands/ApplicationDelete.php
@@ -2,7 +2,7 @@
 
 namespace App\Commands;
 
-use Illuminate\Http\Client\RequestException;
+use Saloon\Exceptions\Request\RequestException;
 
 use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\error;

--- a/app/Commands/ApplicationUpdate.php
+++ b/app/Commands/ApplicationUpdate.php
@@ -8,7 +8,9 @@ use App\Concerns\HandlesAvatars;
 use App\Dto\Application;
 use App\Exceptions\CommandExitException;
 use App\Git;
+use Saloon\Exceptions\Request\RequestException;
 
+use function Laravel\Prompts\error;
 use function Laravel\Prompts\intro;
 use function Laravel\Prompts\multiselect;
 use function Laravel\Prompts\select;
@@ -62,30 +64,40 @@ class ApplicationUpdate extends BaseCommand
 
     protected function updateApplication(Application $application): Application
     {
-        spin(
-            fn () => $this->client->applications()->update(
-                new UpdateApplicationRequestData(
-                    applicationId: $application->id,
-                    name: $this->form()->get('name'),
-                    slug: $this->form()->get('slug'),
-                    defaultEnvironmentId: $this->form()->get('default_environment_id'),
-                    repository: $this->form()->get('repository'),
-                    slackChannel: $this->form()->get('slack_channel'),
-                ),
-            ),
-            'Updating application...',
-        );
-
-        if ($this->form()->get('avatar')) {
+        try {
             spin(
-                fn () => $this->client->applications()->updateAvatar(
-                    new UpdateApplicationAvatarRequestData(
+                fn () => $this->client->applications()->update(
+                    new UpdateApplicationRequestData(
                         applicationId: $application->id,
-                        avatar: $this->getAvatarFromPath($this->form()->get('avatar')),
+                        name: $this->form()->get('name'),
+                        slug: $this->form()->get('slug'),
+                        defaultEnvironmentId: $this->form()->get('default_environment_id'),
+                        repository: $this->form()->get('repository'),
+                        slackChannel: $this->form()->get('slack_channel'),
                     ),
                 ),
-                'Updating application avatar...',
+                'Updating application...',
             );
+        } catch (RequestException $e) {
+            error('Failed to update application: '.$e->getMessage());
+
+            throw new CommandExitException(self::FAILURE);
+        }
+
+        if ($this->form()->get('avatar')) {
+            try {
+                spin(
+                    fn () => $this->client->applications()->updateAvatar(
+                        new UpdateApplicationAvatarRequestData(
+                            applicationId: $application->id,
+                            avatar: $this->getAvatarFromPath($this->form()->get('avatar')),
+                        ),
+                    ),
+                    'Updating application avatar...',
+                );
+            } catch (RequestException $e) {
+                error('Failed to update avatar: '.$e->getMessage());
+            }
         }
 
         return $this->client->applications()->get($application->id);

--- a/app/Commands/BackgroundProcessDelete.php
+++ b/app/Commands/BackgroundProcessDelete.php
@@ -2,7 +2,7 @@
 
 namespace App\Commands;
 
-use Illuminate\Http\Client\RequestException;
+use Saloon\Exceptions\Request\RequestException;
 
 use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\error;

--- a/app/Commands/DatabaseClusterDelete.php
+++ b/app/Commands/DatabaseClusterDelete.php
@@ -3,7 +3,7 @@
 namespace App\Commands;
 
 use Carbon\CarbonInterval;
-use Illuminate\Http\Client\RequestException;
+use Saloon\Exceptions\Request\RequestException;
 use Illuminate\Support\Sleep;
 
 use function Laravel\Prompts\confirm;

--- a/app/Commands/DomainDelete.php
+++ b/app/Commands/DomainDelete.php
@@ -2,7 +2,7 @@
 
 namespace App\Commands;
 
-use Illuminate\Http\Client\RequestException;
+use Saloon\Exceptions\Request\RequestException;
 
 use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\error;

--- a/app/Commands/DomainVerify.php
+++ b/app/Commands/DomainVerify.php
@@ -2,7 +2,7 @@
 
 namespace App\Commands;
 
-use Illuminate\Http\Client\RequestException;
+use Saloon\Exceptions\Request\RequestException;
 
 use function Laravel\Prompts\error;
 use function Laravel\Prompts\intro;

--- a/app/Commands/EnvironmentDelete.php
+++ b/app/Commands/EnvironmentDelete.php
@@ -2,7 +2,7 @@
 
 namespace App\Commands;
 
-use Illuminate\Http\Client\RequestException;
+use Saloon\Exceptions\Request\RequestException;
 
 use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\error;

--- a/app/Commands/InstanceDelete.php
+++ b/app/Commands/InstanceDelete.php
@@ -2,7 +2,7 @@
 
 namespace App\Commands;
 
-use Illuminate\Http\Client\RequestException;
+use Saloon\Exceptions\Request\RequestException;
 
 use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\error;


### PR DESCRIPTION
## Summary

Fixes two bugs discovered while writing comprehensive test coverage for #41.

Closes #50
Closes #51

## Bug 1: Wrong RequestException import in 7 commands

7 commands import `Illuminate\Http\Client\RequestException` (Laravel HTTP client) but the CLI uses Saloon, which throws `Saloon\Exceptions\Request\RequestException`. The catch blocks never match, so API errors during delete/verify operations crash with unhandled exceptions instead of showing user-friendly error messages.

**Affected commands:**
- `ApplicationDelete`
- `EnvironmentDelete`
- `DatabaseClusterDelete`
- `DomainDelete`
- `DomainVerify`
- `InstanceDelete`
- `BackgroundProcessDelete`

**Fix:** Replace the import in all 7 files.

## Bug 2: ApplicationUpdate has no error handling

`ApplicationCreate` uses `loopUntilValid` to catch validation errors, but `ApplicationUpdate` has no equivalent. API 422/500 responses propagate as uncaught `RequestException`, showing raw stack traces to users.

**Fix:** Added `try/catch RequestException` around both the update and avatar upload API calls.

## How these bugs were found

While writing feature tests following the Laravel Forge CLI pattern (1 test file per command), we discovered these bugs:
- Tests for `ApplicationDelete` with a mocked 500 response passed without triggering the catch block — the wrong exception class was being caught
- Tests for `ApplicationUpdate` with a mocked 422 response threw an unhandled exception instead of showing a validation error

## Test plan

- [x] `./vendor/bin/pest` — all 31 existing tests pass
- [x] `./vendor/bin/phpstan analyse` — 0 errors
- [ ] Delete an application when the API returns a 500 — should show "Failed to delete application: ..." instead of a stack trace
- [ ] Update an application with an invalid name — should show error message instead of stack trace

Generated with [Claude Code](https://claude.com/claude-code)