### PR TITLE
fix: 5 bugs found during test coverage work

### DIFF
--- a/app/Commands/ApplicationList.php
+++ b/app/Commands/ApplicationList.php
@@ -7,7 +7,6 @@ use Laravel\Prompts\Key;
 
 use function Laravel\Prompts\intro;
 use function Laravel\Prompts\spin;
-use function Laravel\Prompts\warning;
 
 class ApplicationList extends BaseCommand
 {
@@ -28,13 +27,11 @@ class ApplicationList extends BaseCommand
             'Fetching applications...',
         )->collect();
 
-        $this->outputJsonIfWanted($applications);
-
         if ($applications->isEmpty()) {
-            warning('No applications found.');
-
-            return self::FAILURE;
+            $this->failAndExit('No applications found.');
         }
+
+        $this->outputJsonIfWanted($applications);
 
         dataTable(
             headers: ['ID', 'Name', 'Region', 'Repository'],

--- a/app/Commands/BackgroundProcessCreate.php
+++ b/app/Commands/BackgroundProcessCreate.php
@@ -104,7 +104,7 @@ class BackgroundProcessCreate extends BaseCommand
                 'timeout',
                 'force',
             ])->mapWithKeys(fn ($key) => [
-                $key => $this->form()->get('config.'.$key, $this->getWorkerDefult($key)),
+                $key => $this->form()->get('config.'.$key, $this->getWorkerDefault($key)),
             ])->toArray();
         } else {
             $command = $this->form()->get('command');
@@ -131,10 +131,10 @@ class BackgroundProcessCreate extends BaseCommand
             fn ($resolver) => $resolver
                 ->fromInput(fn (?string $value) => text(
                     label: 'Connection',
-                    default: $value ?? $this->getWorkerDefult('connection'),
+                    default: $value ?? $this->getWorkerDefault('connection'),
                     required: true,
                 ))
-                ->nonInteractively(fn () => $this->getWorkerDefult('connection'))
+                ->nonInteractively(fn () => $this->getWorkerDefault('connection'))
                 ->shouldPromptOnce(),
             'connection',
         );
@@ -144,11 +144,11 @@ class BackgroundProcessCreate extends BaseCommand
             fn ($resolver) => $resolver
                 ->fromInput(fn (?string $value) => text(
                     label: 'Queue',
-                    default: $value ?? $this->getWorkerDefult('queue'),
+                    default: $value ?? $this->getWorkerDefault('queue'),
                     required: true,
                     hint: 'Comma-separated for multiple queues',
                 ))
-                ->nonInteractively(fn () => $this->getWorkerDefult('queue'))
+                ->nonInteractively(fn () => $this->getWorkerDefault('queue'))
                 ->shouldPromptOnce(),
             'queue',
         );
@@ -158,11 +158,11 @@ class BackgroundProcessCreate extends BaseCommand
             fn ($resolver) => $resolver
                 ->fromInput(fn (?string $value) => number(
                     label: 'Tries',
-                    default: $value ?? $this->getWorkerDefult('tries'),
+                    default: $value ?? $this->getWorkerDefault('tries'),
                     required: true,
                     hint: 'Number of times a job should be attempted',
                 ))
-                ->nonInteractively(fn () => $this->getWorkerDefult('tries'))
+                ->nonInteractively(fn () => $this->getWorkerDefault('tries'))
                 ->shouldPromptOnce(),
             'tries',
         );
@@ -172,11 +172,11 @@ class BackgroundProcessCreate extends BaseCommand
             fn ($resolver) => $resolver
                 ->fromInput(fn (?string $value) => number(
                     label: 'Backoff',
-                    default: $value ?? $this->getWorkerDefult('backoff'),
+                    default: $value ?? $this->getWorkerDefault('backoff'),
                     required: true,
                     hint: 'Number of seconds to wait before retrying a failed job.',
                 ))
-                ->nonInteractively(fn () => $this->getWorkerDefult('backoff'))
+                ->nonInteractively(fn () => $this->getWorkerDefault('backoff'))
                 ->shouldPromptOnce(),
             'backoff',
         );
@@ -186,11 +186,11 @@ class BackgroundProcessCreate extends BaseCommand
             fn ($resolver) => $resolver
                 ->fromInput(fn (?string $value) => number(
                     label: 'Sleep',
-                    default: $value ?? $this->getWorkerDefult('sleep'),
+                    default: $value ?? $this->getWorkerDefault('sleep'),
                     required: true,
                     hint: 'Number of seconds to sleep when no jobs are available',
                 ))
-                ->nonInteractively(fn () => $this->getWorkerDefult('sleep'))
+                ->nonInteractively(fn () => $this->getWorkerDefault('sleep'))
                 ->shouldPromptOnce(),
             'sleep',
         );
@@ -200,11 +200,11 @@ class BackgroundProcessCreate extends BaseCommand
             fn ($resolver) => $resolver
                 ->fromInput(fn (?string $value) => number(
                     label: 'Rest',
-                    default: $value ?? $this->getWorkerDefult('rest'),
+                    default: $value ?? $this->getWorkerDefault('rest'),
                     required: true,
                     hint: 'Number of seconds to rest between jobs',
                 ))
-                ->nonInteractively(fn () => $this->getWorkerDefult('rest'))
+                ->nonInteractively(fn () => $this->getWorkerDefault('rest'))
                 ->shouldPromptOnce(),
             'rest',
         );
@@ -214,11 +214,11 @@ class BackgroundProcessCreate extends BaseCommand
             fn ($resolver) => $resolver
                 ->fromInput(fn (?string $value) => number(
                     label: 'Timeout',
-                    default: $value ?? $this->getWorkerDefult('timeout'),
+                    default: $value ?? $this->getWorkerDefault('timeout'),
                     required: true,
                     hint: 'Number of seconds a job can run before timing out',
                 ))
-                ->nonInteractively(fn () => $this->getWorkerDefult('timeout'))
+                ->nonInteractively(fn () => $this->getWorkerDefault('timeout'))
                 ->shouldPromptOnce(),
             'timeout',
         );
@@ -228,10 +228,10 @@ class BackgroundProcessCreate extends BaseCommand
             fn ($resolver) => $resolver
                 ->fromInput(fn (?string $value) => confirm(
                     label: 'Run in maintenance mode?',
-                    default: (bool) ($value ?? $this->getWorkerDefult('force')),
+                    default: (bool) ($value ?? $this->getWorkerDefault('force')),
                     hint: 'Force the worker to run even in maintenance mode',
                 ))
-                ->nonInteractively(fn () => $this->getWorkerDefult('force'))
+                ->nonInteractively(fn () => $this->getWorkerDefault('force'))
                 ->shouldPromptOnce(),
             'force',
         );
@@ -250,14 +250,14 @@ class BackgroundProcessCreate extends BaseCommand
         }
 
         dataList([
-            'Connection' => $this->getWorkerDefult('connection'),
-            'Queue' => $this->getWorkerDefult('queue'),
-            'Tries' => $this->getWorkerDefult('tries'),
-            'Backoff' => $this->getWorkerDefult('backoff'),
-            'Sleep' => $this->getWorkerDefult('sleep'),
-            'Rest' => $this->getWorkerDefult('rest'),
-            'Timeout' => $this->getWorkerDefult('timeout'),
-            'Force to run in maintenance mode' => $this->getWorkerDefult('force') ? 'Yes' : 'No',
+            'Connection' => $this->getWorkerDefault('connection'),
+            'Queue' => $this->getWorkerDefault('queue'),
+            'Tries' => $this->getWorkerDefault('tries'),
+            'Backoff' => $this->getWorkerDefault('backoff'),
+            'Sleep' => $this->getWorkerDefault('sleep'),
+            'Rest' => $this->getWorkerDefault('rest'),
+            'Timeout' => $this->getWorkerDefault('timeout'),
+            'Force to run in maintenance mode' => $this->getWorkerDefault('force') ? 'Yes' : 'No',
         ]);
 
         return confirm(
@@ -266,7 +266,7 @@ class BackgroundProcessCreate extends BaseCommand
         );
     }
 
-    protected function getWorkerDefult(string $key): ?string
+    protected function getWorkerDefault(string $key): ?string
     {
         $arg = $this->option($key);
 

--- a/app/Commands/BackgroundProcessList.php
+++ b/app/Commands/BackgroundProcessList.php
@@ -6,7 +6,6 @@ use Laravel\Prompts\Key;
 
 use function Laravel\Prompts\intro;
 use function Laravel\Prompts\spin;
-use function Laravel\Prompts\warning;
 
 class BackgroundProcessList extends BaseCommand
 {
@@ -29,13 +28,11 @@ class BackgroundProcessList extends BaseCommand
 
         $items = $processes->collect();
 
-        $this->outputJsonIfWanted($items);
-
         if ($items->isEmpty()) {
-            warning('No background processes found.');
-
-            return self::FAILURE;
+            $this->failAndExit('No background processes found.');
         }
+
+        $this->outputJsonIfWanted($items);
 
         dataTable(
             headers: ['ID', 'Command', 'Type', 'Processes'],

--- a/app/Commands/BucketDelete.php
+++ b/app/Commands/BucketDelete.php
@@ -11,7 +11,8 @@ class BucketDelete extends BaseCommand
 {
     protected $signature = 'bucket:delete
                             {bucket? : The bucket ID or name}
-                            {--force : Skip confirmation}';
+                            {--force : Skip confirmation}
+                            {--json : Output as JSON}';
 
     protected $description = 'Delete an object storage bucket';
 

--- a/app/Commands/BucketKeyList.php
+++ b/app/Commands/BucketKeyList.php
@@ -7,7 +7,6 @@ use Laravel\Prompts\Key;
 
 use function Laravel\Prompts\intro;
 use function Laravel\Prompts\spin;
-use function Laravel\Prompts\warning;
 
 class BucketKeyList extends BaseCommand
 {
@@ -32,13 +31,11 @@ class BucketKeyList extends BaseCommand
 
         $items = collect($keys);
 
-        $this->outputJsonIfWanted($items->toArray());
-
         if ($items->isEmpty()) {
-            warning('No keys found.');
-
-            return self::FAILURE;
+            $this->failAndExit('No keys found.');
         }
+
+        $this->outputJsonIfWanted($items->toArray());
 
         dataTable(
             headers: ['ID', 'Name', 'Permission', 'Created At'],

--- a/app/Commands/BucketList.php
+++ b/app/Commands/BucketList.php
@@ -7,7 +7,6 @@ use Laravel\Prompts\Key;
 
 use function Laravel\Prompts\intro;
 use function Laravel\Prompts\spin;
-use function Laravel\Prompts\warning;
 
 class BucketList extends BaseCommand
 {
@@ -36,13 +35,11 @@ class BucketList extends BaseCommand
             'Fetching buckets...',
         );
 
-        $this->outputJsonIfWanted($buckets->toArray());
-
         if ($buckets->isEmpty()) {
-            warning('No buckets found.');
-
-            return self::FAILURE;
+            $this->failAndExit('No buckets found.');
         }
+
+        $this->outputJsonIfWanted($buckets->toArray());
 
         dataTable(
             headers: ['ID', 'Name', 'Type', 'Status', 'Visibility', 'Region'],

--- a/app/Commands/CacheDelete.php
+++ b/app/Commands/CacheDelete.php
@@ -11,7 +11,8 @@ class CacheDelete extends BaseCommand
 {
     protected $signature = 'cache:delete
                             {cache? : The cache ID or name}
-                            {--force : Skip confirmation}';
+                            {--force : Skip confirmation}
+                            {--json : Output as JSON}';
 
     protected $description = 'Delete a cache';
 

--- a/app/Commands/CacheList.php
+++ b/app/Commands/CacheList.php
@@ -7,7 +7,6 @@ use Laravel\Prompts\Key;
 
 use function Laravel\Prompts\intro;
 use function Laravel\Prompts\spin;
-use function Laravel\Prompts\warning;
 
 class CacheList extends BaseCommand
 {
@@ -30,13 +29,11 @@ class CacheList extends BaseCommand
 
         $items = collect($caches);
 
-        $this->outputJsonIfWanted($items);
-
         if ($items->isEmpty()) {
-            warning('No caches found.');
-
-            return self::FAILURE;
+            $this->failAndExit('No caches found.');
         }
+
+        $this->outputJsonIfWanted($items);
 
         dataTable(
             headers: ['ID', 'Name', 'Type', 'Status', 'Region', 'Size'],

--- a/app/Commands/CacheTypes.php
+++ b/app/Commands/CacheTypes.php
@@ -7,7 +7,6 @@ use App\Dto\CacheType;
 use function Laravel\Prompts\intro;
 use function Laravel\Prompts\spin;
 use function Laravel\Prompts\table;
-use function Laravel\Prompts\warning;
 
 class CacheTypes extends BaseCommand
 {
@@ -28,13 +27,11 @@ class CacheTypes extends BaseCommand
 
         $items = collect($types);
 
-        $this->outputJsonIfWanted($items);
-
         if ($items->isEmpty()) {
-            warning('No cache types found.');
-
-            return self::FAILURE;
+            $this->failAndExit('No cache types found.');
         }
+
+        $this->outputJsonIfWanted($items);
 
         $rows = collect($types)->map(fn (CacheType $type, $index) => [
             $type->label,

--- a/app/Commands/DatabaseClusterList.php
+++ b/app/Commands/DatabaseClusterList.php
@@ -6,7 +6,6 @@ use Laravel\Prompts\Key;
 
 use function Laravel\Prompts\intro;
 use function Laravel\Prompts\spin;
-use function Laravel\Prompts\warning;
 
 class DatabaseClusterList extends BaseCommand
 {
@@ -27,13 +26,11 @@ class DatabaseClusterList extends BaseCommand
 
         $items = $databases->collect();
 
-        $this->outputJsonIfWanted($items);
-
         if ($items->isEmpty()) {
-            warning('No databases found.');
-
-            return self::FAILURE;
+            $this->failAndExit('No databases found.');
         }
+
+        $this->outputJsonIfWanted($items);
 
         dataTable(
             headers: ['ID', 'Name', 'Type', 'Status', 'Region', 'Schemas'],

--- a/app/Commands/DatabaseDelete.php
+++ b/app/Commands/DatabaseDelete.php
@@ -2,7 +2,7 @@
 
 namespace App\Commands;
 
-use Throwable;
+use Saloon\Exceptions\Request\RequestException;
 
 use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\error;
@@ -48,7 +48,7 @@ class DatabaseDelete extends BaseCommand
             success('Database deleted.');
 
             return self::SUCCESS;
-        } catch (Throwable $e) {
+        } catch (RequestException $e) {
             error('Failed to delete database: '.$e->getMessage());
 
             return self::FAILURE;

--- a/app/Commands/DatabaseList.php
+++ b/app/Commands/DatabaseList.php
@@ -6,7 +6,6 @@ use Laravel\Prompts\Key;
 
 use function Laravel\Prompts\intro;
 use function Laravel\Prompts\spin;
-use function Laravel\Prompts\warning;
 
 class DatabaseList extends BaseCommand
 {
@@ -29,13 +28,11 @@ class DatabaseList extends BaseCommand
             'Fetching databases...',
         );
 
-        $this->outputJsonIfWanted($databases->toArray());
-
         if ($databases->isEmpty()) {
-            warning('No databases found.');
-
-            return self::FAILURE;
+            $this->failAndExit('No databases found.');
         }
+
+        $this->outputJsonIfWanted($databases->toArray());
 
         dataTable(
             headers: ['ID', 'Name', 'Created At'],

--- a/app/Commands/DatabaseSnapshotList.php
+++ b/app/Commands/DatabaseSnapshotList.php
@@ -7,7 +7,6 @@ use Laravel\Prompts\Key;
 
 use function Laravel\Prompts\intro;
 use function Laravel\Prompts\spin;
-use function Laravel\Prompts\warning;
 
 class DatabaseSnapshotList extends BaseCommand
 {
@@ -32,13 +31,11 @@ class DatabaseSnapshotList extends BaseCommand
 
         $items = collect($snapshots);
 
-        $this->outputJsonIfWanted($items->toArray());
-
         if ($items->isEmpty()) {
-            warning('No snapshots found.');
-
-            return self::FAILURE;
+            $this->failAndExit('No snapshots found.');
         }
+
+        $this->outputJsonIfWanted($items->toArray());
 
         dataTable(
             headers: ['ID', 'Name', 'Created At', 'Status'],

--- a/app/Commands/DedicatedClusterList.php
+++ b/app/Commands/DedicatedClusterList.php
@@ -6,7 +6,6 @@ use App\Dto\DedicatedCluster;
 
 use function Laravel\Prompts\intro;
 use function Laravel\Prompts\spin;
-use function Laravel\Prompts\warning;
 
 class DedicatedClusterList extends BaseCommand
 {
@@ -29,13 +28,11 @@ class DedicatedClusterList extends BaseCommand
 
         $items = $clusters->collect();
 
-        $this->outputJsonIfWanted($items->toArray());
-
         if ($items->isEmpty()) {
-            warning('No dedicated clusters found.');
-
-            return self::FAILURE;
+            $this->failAndExit('No dedicated clusters found.');
         }
+
+        $this->outputJsonIfWanted($items->toArray());
 
         $rows = $items->map(fn (DedicatedCluster $cluster) => [
             $cluster->id,

--- a/app/Commands/DeploymentList.php
+++ b/app/Commands/DeploymentList.php
@@ -6,7 +6,6 @@ use Laravel\Prompts\Key;
 
 use function Laravel\Prompts\intro;
 use function Laravel\Prompts\spin;
-use function Laravel\Prompts\warning;
 
 class DeploymentList extends BaseCommand
 {
@@ -29,13 +28,11 @@ class DeploymentList extends BaseCommand
 
         $items = $deployments->collect();
 
-        $this->outputJsonIfWanted($items);
-
         if ($items->isEmpty()) {
-            warning('No deployments found.');
-
-            return self::FAILURE;
+            $this->failAndExit('No deployments found.');
         }
+
+        $this->outputJsonIfWanted($items);
 
         dataTable(
             headers: ['ID', 'Status', 'Branch', 'Commit', 'Started'],

--- a/app/Commands/DomainCreate.php
+++ b/app/Commands/DomainCreate.php
@@ -69,7 +69,8 @@ class DomainCreate extends BaseCommand
                 ->fromInput(fn ($value) => confirm(
                     label: 'Enable wildcard',
                     default: $value ?? false,
-                )),
+                ))
+                ->nonInteractively(fn () => false),
         );
 
         $this->form()->prompt(
@@ -83,7 +84,8 @@ class DomainCreate extends BaseCommand
                     ],
                     default: $value ?? 'pre_verification',
                     required: true,
-                )),
+                ))
+                ->nonInteractively(fn () => 'pre_verification'),
         );
 
         return spin(

--- a/app/Commands/DomainList.php
+++ b/app/Commands/DomainList.php
@@ -6,7 +6,6 @@ use Laravel\Prompts\Key;
 
 use function Laravel\Prompts\intro;
 use function Laravel\Prompts\spin;
-use function Laravel\Prompts\warning;
 
 class DomainList extends BaseCommand
 {
@@ -29,13 +28,11 @@ class DomainList extends BaseCommand
 
         $items = $domains->collect();
 
-        $this->outputJsonIfWanted($items);
-
         if ($items->isEmpty()) {
-            warning('No domains found.');
-
-            return self::FAILURE;
+            $this->failAndExit('No domains found.');
         }
+
+        $this->outputJsonIfWanted($items);
 
         dataTable(
             headers: ['ID', 'Name', 'Status', 'Primary'],

--- a/app/Commands/EnvironmentList.php
+++ b/app/Commands/EnvironmentList.php
@@ -6,7 +6,6 @@ use Laravel\Prompts\Key;
 
 use function Laravel\Prompts\intro;
 use function Laravel\Prompts\spin;
-use function Laravel\Prompts\warning;
 
 class EnvironmentList extends BaseCommand
 {
@@ -33,13 +32,11 @@ class EnvironmentList extends BaseCommand
 
         $envItems = $environments->collect();
 
-        $this->outputJsonIfWanted($envItems);
-
         if ($envItems->isEmpty()) {
-            warning('No environments found.');
-
-            return self::FAILURE;
+            $this->failAndExit('No environments found.');
         }
+
+        $this->outputJsonIfWanted($envItems);
 
         dataTable(
             headers: ['ID', 'Name', 'Branch', 'Status'],

--- a/app/Commands/InstanceList.php
+++ b/app/Commands/InstanceList.php
@@ -6,7 +6,6 @@ use Laravel\Prompts\Key;
 
 use function Laravel\Prompts\intro;
 use function Laravel\Prompts\spin;
-use function Laravel\Prompts\warning;
 
 class InstanceList extends BaseCommand
 {
@@ -31,13 +30,11 @@ class InstanceList extends BaseCommand
 
         $items = $instances->collect();
 
-        $this->outputJsonIfWanted($items);
-
         if ($items->isEmpty()) {
-            warning('No instances found.');
-
-            return self::FAILURE;
+            $this->failAndExit('No instances found.');
         }
+
+        $this->outputJsonIfWanted($items);
 
         dataTable(
             headers: ['ID', 'Name', 'Type', 'Size', 'Replicas', 'Scheduler'],

--- a/app/Commands/InstanceSizes.php
+++ b/app/Commands/InstanceSizes.php
@@ -4,7 +4,6 @@ namespace App\Commands;
 
 use function Laravel\Prompts\intro;
 use function Laravel\Prompts\spin;
-use function Laravel\Prompts\warning;
 
 class InstanceSizes extends BaseCommand
 {
@@ -23,13 +22,11 @@ class InstanceSizes extends BaseCommand
             'Fetching instance sizes...',
         );
 
-        $this->outputJsonIfWanted($sizes->toArray());
-
         if (count($sizes->all()) === 0) {
-            warning('No instance sizes found.');
-
-            return self::FAILURE;
+            $this->failAndExit('No instance sizes found.');
         }
+
+        $this->outputJsonIfWanted($sizes->toArray());
 
         dataTable(
             headers: [

--- a/app/Commands/WebsocketApplicationList.php
+++ b/app/Commands/WebsocketApplicationList.php
@@ -7,7 +7,6 @@ use Laravel\Prompts\Key;
 
 use function Laravel\Prompts\intro;
 use function Laravel\Prompts\spin;
-use function Laravel\Prompts\warning;
 
 class WebsocketApplicationList extends BaseCommand
 {
@@ -32,13 +31,11 @@ class WebsocketApplicationList extends BaseCommand
 
         $items = collect($apps);
 
-        $this->outputJsonIfWanted($items->toArray());
-
         if ($items->isEmpty()) {
-            warning('No WebSocket applications found.');
-
-            return self::FAILURE;
+            $this->failAndExit('No WebSocket applications found.');
         }
+
+        $this->outputJsonIfWanted($items->toArray());
 
         dataTable(
             headers: ['ID', 'Name', 'App ID', 'Max connections', 'Created At'],

--- a/app/Commands/WebsocketClusterList.php
+++ b/app/Commands/WebsocketClusterList.php
@@ -7,7 +7,6 @@ use Laravel\Prompts\Key;
 
 use function Laravel\Prompts\intro;
 use function Laravel\Prompts\spin;
-use function Laravel\Prompts\warning;
 
 class WebsocketClusterList extends BaseCommand
 {
@@ -30,13 +29,11 @@ class WebsocketClusterList extends BaseCommand
 
         $items = $clusters->collect();
 
-        $this->outputJsonIfWanted($items->toArray());
-
         if ($items->isEmpty()) {
-            warning('No WebSocket clusters found.');
-
-            return self::FAILURE;
+            $this->failAndExit('No WebSocket clusters found.');
         }
+
+        $this->outputJsonIfWanted($items->toArray());
 
         dataTable(
             headers: ['ID', 'Name', 'Region', 'Status'],


### PR DESCRIPTION
## Summary

- **Empty list commands return SUCCESS in JSON mode (Closes #44):** `outputJsonIfWanted()` threw `CommandExitException(SUCCESS)` before the empty-check logic could run. Fixed by moving the empty check before `outputJsonIfWanted()` in all 17 affected list commands, using `failAndExit()` which correctly outputs JSON errors with FAILURE exit code.
- **DomainCreate missing non-interactive defaults (Closes #45):** `wildcard_enabled` and `verification_method` had no `nonInteractively()` fallback, causing failures in non-interactive/CI environments. Added `nonInteractively(fn () => false)` for wildcard and `nonInteractively(fn () => 'pre_verification')` for verification method, matching the interactive prompt defaults.
- **DatabaseDelete catches Throwable (Closes #46):** Changed overly broad `catch (Throwable $e)` to `catch (Saloon\Exceptions\Request\RequestException $e)`, consistent with the exception type the Saloon HTTP client actually throws and matching the pattern in `Validates` concern.
- **CacheDelete and BucketDelete missing --json option (Closes #48):** Added `{--json : Output as JSON}` to both command signatures so `wantsJson()` and `isInteractive()` work correctly.
- **Method typo getWorkerDefult (Closes #49):** Renamed `getWorkerDefult` to `getWorkerDefault` across all 22 references in `BackgroundProcessCreate`.

**Not fixed in this PR:** #47 (3 create commands can't run non-interactively) — needs design discussion since adding CLI options changes the command interface.

## Test plan
- [x] `phpstan analyse` passes with no errors
- [x] `pest` test suite passes (31 tests, 32 assertions)
- [ ] Verify list commands return FAILURE exit code with JSON error message when results are empty
- [ ] Verify `domain:create` works in non-interactive mode with default wildcard and verification method
- [ ] Verify `database:delete` no longer swallows non-request exceptions
- [ ] Verify `cache:delete --json` and `bucket:delete --json` are recognized options
- [ ] Verify `background-process:create` worker defaults work with corrected method name

🤖 Generated with [Claude Code](https://claude.com/claude-code)