### PR TITLE
fix: add missing CLI options for non-interactive create commands

### DIFF
--- a/app/Commands/InstanceCreate.php
+++ b/app/Commands/InstanceCreate.php
@@ -18,8 +18,12 @@ class InstanceCreate extends BaseCommand
                             {--name= : Instance name}
                             {--type=service : Instance type (app|worker)}
                             {--size= : Instance size}
+                            {--scaling-type= : Scaling type (custom|none)}
                             {--min-replicas= : Minimum replicas}
                             {--max-replicas= : Maximum replicas}
+                            {--scaling-cpu-threshold-percentage= : Scaling CPU threshold percentage (50-95)}
+                            {--scaling-memory-threshold-percentage= : Scaling memory threshold percentage (50-95)}
+                            {--uses-scheduler= : Use scheduler (true|false)}
                             {--json : Output as JSON}';
 
     protected $description = 'Create a new instance';
@@ -56,74 +60,86 @@ class InstanceCreate extends BaseCommand
 
         $this->form()->prompt(
             'size',
-            fn ($resolver) => $resolver->fromInput(
-                fn ($value) => search(
-                    label: 'Size',
-                    options: fn ($query) => collect($sizes->all())
-                        ->filter(
-                            fn ($size) => $query === ''
-                                || str_contains(strtolower($size->name), strtolower($query))
-                                || str_contains(strtolower($size->description), strtolower($query)),
-                        )
-                        ->mapWithKeys(fn ($size) => [$size->name => $size->description])
-                        ->toArray(),
-                    required: true,
-                ),
-            ),
+            fn ($resolver) => $resolver
+                ->fromInput(
+                    fn ($value) => search(
+                        label: 'Size',
+                        options: fn ($query) => collect($sizes->all())
+                            ->filter(
+                                fn ($size) => $query === ''
+                                    || str_contains(strtolower($size->name), strtolower($query))
+                                    || str_contains(strtolower($size->description), strtolower($query)),
+                            )
+                            ->mapWithKeys(fn ($size) => [$size->name => $size->description])
+                            ->toArray(),
+                        required: true,
+                    ),
+                )
+                ->nonInteractively(fn () => null),
         );
 
         $this->form()->prompt(
             'scaling_type',
-            fn ($resolver) => $resolver->fromInput(
-                fn ($value) => $value ?? (confirm('Enable autoscaling?', default: true) ? 'custom' : 'none'),
-            ),
+            fn ($resolver) => $resolver
+                ->fromInput(
+                    fn ($value) => $value ?? (confirm('Enable autoscaling?', default: true) ? 'custom' : 'none'),
+                )
+                ->nonInteractively(fn () => 'custom'),
         );
 
         $isCustom = $this->form()->get('scaling_type') === 'custom';
 
         $this->form()->prompt(
             'min_replicas',
-            fn ($resolver) => $resolver->fromInput(
-                fn ($value) => $isCustom ? number(
-                    label: 'Minimum replicas',
-                    default: $value ?? '1',
-                    min: 1,
-                    max: 10,
-                ) : 1,
-            ),
+            fn ($resolver) => $resolver
+                ->fromInput(
+                    fn ($value) => $isCustom ? number(
+                        label: 'Minimum replicas',
+                        default: $value ?? '1',
+                        min: 1,
+                        max: 10,
+                    ) : 1,
+                )
+                ->nonInteractively(fn () => 1),
         );
 
         $this->form()->prompt(
             'max_replicas',
-            fn ($resolver) => $resolver->fromInput(
-                fn ($value) => $isCustom ? number(
-                    label: 'Maximum replicas',
-                    default: $value ?? $this->form()->get('min_replicas'),
-                    min: $this->form()->integer('min_replicas'),
-                    max: 10,
-                ) : $this->form()->integer('min_replicas'),
-            ),
+            fn ($resolver) => $resolver
+                ->fromInput(
+                    fn ($value) => $isCustom ? number(
+                        label: 'Maximum replicas',
+                        default: $value ?? $this->form()->get('min_replicas'),
+                        min: $this->form()->integer('min_replicas'),
+                        max: 10,
+                    ) : $this->form()->integer('min_replicas'),
+                )
+                ->nonInteractively(fn () => $this->form()->integer('min_replicas')),
         );
 
         if ($isCustom) {
             $this->form()->prompt(
                 'scaling_cpu_threshold_percentage',
-                fn ($resolver) => $resolver->fromInput(fn ($value) => number(
-                    label: 'Scaling CPU threshold percentage',
-                    default: $value ?? '50',
-                    min: 50,
-                    max: 95,
-                )),
+                fn ($resolver) => $resolver
+                    ->fromInput(fn ($value) => number(
+                        label: 'Scaling CPU threshold percentage',
+                        default: $value ?? '50',
+                        min: 50,
+                        max: 95,
+                    ))
+                    ->nonInteractively(fn () => 50),
             );
 
             $this->form()->prompt(
                 'scaling_memory_threshold_percentage',
-                fn ($resolver) => $resolver->fromInput(fn ($value) => number(
-                    label: 'Scaling memory threshold percentage',
-                    default: $value ?? '50',
-                    min: 50,
-                    max: 95,
-                )),
+                fn ($resolver) => $resolver
+                    ->fromInput(fn ($value) => number(
+                        label: 'Scaling memory threshold percentage',
+                        default: $value ?? '50',
+                        min: 50,
+                        max: 95,
+                    ))
+                    ->nonInteractively(fn () => 50),
             );
         }
 
@@ -134,12 +150,14 @@ class InstanceCreate extends BaseCommand
 
         $this->form()->prompt(
             'uses_scheduler',
-            fn ($resolver) => $resolver->fromInput(
-                fn ($value) => confirm(
-                    label: 'Use scheduler?',
-                    default: false,
-                ),
-            ),
+            fn ($resolver) => $resolver
+                ->fromInput(
+                    fn ($value) => confirm(
+                        label: 'Use scheduler?',
+                        default: $value ?? false,
+                    ),
+                )
+                ->nonInteractively(fn () => false),
         );
 
         return spin(

--- a/app/Commands/WebsocketApplicationCreate.php
+++ b/app/Commands/WebsocketApplicationCreate.php
@@ -13,6 +13,9 @@ class WebsocketApplicationCreate extends BaseCommand
     protected $signature = 'websocket-application:create
                             {cluster? : The WebSocket cluster ID or name}
                             {--name= : Application name}
+                            {--allowed-origins= : Allowed origins (comma-separated, prefixed with protocol e.g. https://)}
+                            {--ping-interval= : Ping interval in seconds (1-60)}
+                            {--activity-timeout= : Activity timeout in seconds (1-60)}
                             {--json : Output as JSON}';
 
     protected $description = 'Create a WebSocket application';
@@ -27,6 +30,9 @@ class WebsocketApplicationCreate extends BaseCommand
 
         $defaults = array_filter([
             'name' => $this->option('name'),
+            'allowed_origins' => $this->option('allowed-origins'),
+            'ping_interval' => $this->option('ping-interval'),
+            'activity_timeout' => $this->option('activity-timeout'),
         ]);
 
         $app = $this->loopUntilValid(

--- a/app/Commands/WebsocketClusterCreate.php
+++ b/app/Commands/WebsocketClusterCreate.php
@@ -15,6 +15,7 @@ class WebsocketClusterCreate extends BaseCommand
     protected $signature = 'websocket-cluster:create
                             {--name= : Cluster name}
                             {--region= : Region}
+                            {--max-connections= : Max connections (100, 200, 500, 2000, 5000, 10000)}
                             {--json : Output as JSON}';
 
     protected $description = 'Create a WebSocket cluster';
@@ -28,6 +29,7 @@ class WebsocketClusterCreate extends BaseCommand
         $defaults = array_filter([
             'name' => $this->option('name'),
             'region' => $this->option('region') ?: $this->getDefaultRegion(),
+            'max_connections' => $this->option('max-connections'),
         ]);
 
         $cluster = $this->loopUntilValid(

--- a/app/Concerns/CreatesWebSocketApplication.php
+++ b/app/Concerns/CreatesWebSocketApplication.php
@@ -28,45 +28,52 @@ trait CreatesWebSocketApplication
 
         $this->form()->prompt(
             'allowed_origins',
-            fn ($resolver) => $resolver->fromInput(
-                fn (?string $value) => textarea(
-                    label: 'Allowed origins',
-                    default: $value ?? $defaults['allowed_origins'] ?? '',
-                    hint: 'Origins that are allowed to connect to the application, separated by new lines, prefixed with the protocol (https://)',
-                ),
-            ),
+            fn ($resolver) => $resolver
+                ->fromInput(
+                    fn (?string $value) => textarea(
+                        label: 'Allowed origins',
+                        default: $value ?? $defaults['allowed_origins'] ?? '',
+                        hint: 'Origins that are allowed to connect to the application, separated by new lines, prefixed with the protocol (https://)',
+                    ),
+                )
+                ->nonInteractively(fn () => $defaults['allowed_origins'] ?? null),
         );
 
         $this->form()->prompt(
             'ping_interval',
-            fn ($resolver) => $resolver->fromInput(
-                fn ($value) => number(
-                    label: 'Ping interval',
-                    default: $value ?? $defaults['ping_interval'] ?? 60,
-                    min: 1,
-                    max: 60,
-                    required: true,
-                ),
-            ),
+            fn ($resolver) => $resolver
+                ->fromInput(
+                    fn ($value) => number(
+                        label: 'Ping interval',
+                        default: $value ?? $defaults['ping_interval'] ?? 60,
+                        min: 1,
+                        max: 60,
+                        required: true,
+                    ),
+                )
+                ->nonInteractively(fn () => $defaults['ping_interval'] ?? 60),
         );
 
         $this->form()->prompt(
             'activity_timeout',
-            fn ($resolver) => $resolver->fromInput(
-                fn ($value) => number(
-                    label: 'Activity timeout',
-                    default: $value ?? $defaults['activity_timeout'] ?? 30,
-                    min: 1,
-                    max: 60,
-                    required: true,
-                ),
-            ),
+            fn ($resolver) => $resolver
+                ->fromInput(
+                    fn ($value) => number(
+                        label: 'Activity timeout',
+                        default: $value ?? $defaults['activity_timeout'] ?? 30,
+                        min: 1,
+                        max: 60,
+                        required: true,
+                    ),
+                )
+                ->nonInteractively(fn () => $defaults['activity_timeout'] ?? 30),
         );
 
         $allowedOrigins = $this->form()->get('allowed_origins');
 
         if ($allowedOrigins !== null && $allowedOrigins !== '') {
-            $allowedOrigins = collect(explode(PHP_EOL, $allowedOrigins))->filter(fn ($origin) => $origin !== '')->values()->toArray();
+            $separator = str_contains($allowedOrigins, PHP_EOL) ? PHP_EOL : ',';
+            $allowedOrigins = collect(explode($separator, $allowedOrigins))->map(fn ($origin) => trim($origin))->filter(fn ($origin) => $origin !== '')->values()->toArray();
         } else {
             $allowedOrigins = null;
         }

--- a/app/Concerns/CreatesWebSocketCluster.php
+++ b/app/Concerns/CreatesWebSocketCluster.php
@@ -33,26 +33,30 @@ trait CreatesWebSocketCluster
 
         $this->form()->prompt(
             'region',
-            fn ($resolver) => $resolver->fromInput(
-                fn (?string $value) => select(
-                    label: 'Region',
-                    options: collect($regions)->mapWithKeys(fn (Region $r) => [$r->value => $r->label])->toArray(),
-                    default: $value ?? $defaults['region'] ?? null,
-                    required: true,
-                ),
-            ),
+            fn ($resolver) => $resolver
+                ->fromInput(
+                    fn (?string $value) => select(
+                        label: 'Region',
+                        options: collect($regions)->mapWithKeys(fn (Region $r) => [$r->value => $r->label])->toArray(),
+                        default: $value ?? $defaults['region'] ?? null,
+                        required: true,
+                    ),
+                )
+                ->nonInteractively(fn () => $defaults['region'] ?? null),
         );
 
         $this->form()->prompt(
             'max_connections',
-            fn ($resolver) => $resolver->fromInput(
-                fn ($value) => select(
-                    label: 'Max connections',
-                    options: collect(WebsocketServerMaxConnection::cases())->mapWithKeys(fn ($case) => [$case->value => $case->value])->toArray(),
-                    default: $value ?? $defaults['max_connections'] ?? WebsocketServerMaxConnection::ONE_HUNDRED->value,
-                    required: true,
-                ),
-            ),
+            fn ($resolver) => $resolver
+                ->fromInput(
+                    fn ($value) => select(
+                        label: 'Max connections',
+                        options: collect(WebsocketServerMaxConnection::cases())->mapWithKeys(fn ($case) => [$case->value => $case->value])->toArray(),
+                        default: $value ?? $defaults['max_connections'] ?? WebsocketServerMaxConnection::ONE_HUNDRED->value,
+                        required: true,
+                    ),
+                )
+                ->nonInteractively(fn () => $defaults['max_connections'] ?? WebsocketServerMaxConnection::ONE_HUNDRED->value),
         );
 
         return spin(


### PR DESCRIPTION
## Summary

Closes #47

This PR adds the missing CLI options and `nonInteractively()` fallbacks to three create commands so they can be used in scripts and CI pipelines without interactive prompts.

**This PR requires design decisions from maintainers** — see questions below.

## Changes

### `instance:create` — 4 new options added

| Option | Default (non-interactive) | Notes |
|--------|--------------------------|-------|
| `--scaling-type=` | `custom` | **Is `custom` the right default?** Interactively, the confirm prompt defaults to `true` (autoscaling enabled = `custom`). Should the non-interactive default match, or should it be `none`? |
| `--scaling-cpu-threshold-percentage=` | `50` | Matches the interactive default |
| `--scaling-memory-threshold-percentage=` | `50` | Matches the interactive default |
| `--uses-scheduler=` | `false` | Matches the interactive default |

Also added `nonInteractively()` fallbacks to existing fields that were missing them:
- `size` — no default (remains required via `--size`)
- `min_replicas` — defaults to `1`
- `max_replicas` — defaults to `min_replicas` value
- `scaling_type` — defaults to `custom`

### `websocket-cluster:create` — 1 new option added

| Option | Default (non-interactive) | Notes |
|--------|--------------------------|-------|
| `--max-connections=` | `100` | Matches `WebsocketServerMaxConnection::ONE_HUNDRED`. **Is 100 the right default for non-interactive use?** |

Also added `nonInteractively()` fallback to `region` (falls back to the `--region` value or `$defaults['region']`).

### `websocket-application:create` — 3 new options added

| Option | Default (non-interactive) | Notes |
|--------|--------------------------|-------|
| `--allowed-origins=` | `null` (none) | Accepts comma-separated values. **Should the default be empty (allow all), or should origins be required?** |
| `--ping-interval=` | `60` | Matches the interactive default |
| `--activity-timeout=` | `30` | Matches the interactive default |

Also updated allowed origins parsing in `CreatesWebSocketApplication` to support comma-separated input (in addition to newline-separated from the interactive textarea).

## Questions for maintainers

1. **Should these commands support full non-interactive mode, or is interactive-only intentional for these resource types?**
2. For `instance:create --scaling-type`: is `custom` (autoscaling enabled) the correct non-interactive default?
3. For `websocket-cluster:create --max-connections`: is `100` the correct non-interactive default?
4. For `websocket-application:create --allowed-origins`: should the default be `null` (no restriction), or should origins be required in non-interactive mode?

## Test plan

- [x] `phpstan analyse` passes with no errors
- [x] All existing tests pass (31/31)
- [ ] Manual test: `cloud instance:create <env-id> --name=test --size=compute-optimized-256 --no-interaction`
- [ ] Manual test: `cloud websocket-cluster:create --name=test --region=us-east-1 --max-connections=100 --no-interaction`
- [ ] Manual test: `cloud websocket-application:create <cluster-id> --name=test --no-interaction`

🤖 Generated with [Claude Code](https://claude.com/claude-code)