### PR TITLE
Fixed Safari auth flow

### DIFF
--- a/app/Commands/Auth.php
+++ b/app/Commands/Auth.php
@@ -172,7 +172,9 @@ class Auth extends BaseCommand implements NoAuthRequired
             if ($clientSocket !== false) {
                 $this->handleRequest($clientSocket);
 
-                break;
+                if ($this->exchangeCode !== null) {
+                    break;
+                }
             }
 
             if (time() - $startTime > $timeout) {


### PR DESCRIPTION
Fixed an issue in Safari with `auth`, CLI now waits for the code to be present before breaking.