### PR TITLE
feat: add --hide-secrets flag to redact connection credentials

### DIFF
--- a/app/Commands/BaseCommand.php
+++ b/app/Commands/BaseCommand.php
@@ -18,6 +18,7 @@ use LaravelZero\Framework\Commands\Command;
 use RuntimeException;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 use function Laravel\Prompts\confirm;
@@ -30,9 +31,39 @@ abstract class BaseCommand extends Command
     use HasAClient;
     use Validates;
 
+    /**
+     * Sensitive field names that should be redacted when --hide-secrets is used.
+     */
+    protected const SENSITIVE_FIELD_NAMES = [
+        'password',
+        'secret',
+        'api_key',
+        'apiKey',
+        'access_key',
+        'accessKey',
+        'secret_key',
+        'secretKey',
+        'secret_access_key',
+        'secretAccessKey',
+        'token',
+        'private_key',
+        'privateKey',
+    ];
+
+    protected const REDACTED_VALUE = '********';
+
     protected Form $form;
 
     protected ?Resolvers $resolvers;
+
+    protected function configure(): void
+    {
+        parent::configure();
+
+        $this->getDefinition()->addOption(
+            new InputOption('hide-secrets', null, InputOption::VALUE_NONE, 'Redact sensitive values in output')
+        );
+    }
 
     protected function form(): Form
     {
@@ -161,15 +192,94 @@ abstract class BaseCommand extends Command
             return;
         }
 
+        if ($this->shouldHideSecrets()) {
+            $data = $this->redactSecrets($data);
+        }
+
         if (is_string($data)) {
             $this->line(json_encode(['message' => $data]));
         } elseif ($data instanceof Jsonable) {
-            $this->line($data->toJson());
+            $jsonData = json_decode($data->toJson(), true);
+            if ($this->shouldHideSecrets() && is_array($jsonData)) {
+                $jsonData = $this->redactSecrets($jsonData);
+            }
+            $this->line(json_encode($jsonData));
         } else {
             $this->line(json_encode($data));
         }
 
         throw new CommandExitException(self::SUCCESS);
+    }
+
+    /**
+     * Determine whether secrets should be hidden in output.
+     */
+    protected function shouldHideSecrets(): bool
+    {
+        return $this->hasOption('hide-secrets') && $this->option('hide-secrets');
+    }
+
+    /**
+     * Recursively redact sensitive values from the given data.
+     *
+     * Redacts:
+     * - Arrays with 'key' + 'value' structure (environment variables) where key looks sensitive
+     * - Any field whose name matches a known sensitive field name (password, secret, etc.)
+     */
+    protected function redactSecrets(mixed $data): mixed
+    {
+        if ($data instanceof Jsonable) {
+            $decoded = json_decode($data->toJson(), true);
+
+            return is_array($decoded) ? $this->redactSecrets($decoded) : $data;
+        }
+
+        if (! is_array($data)) {
+            return $data;
+        }
+
+        // Handle environment variable style arrays: [{key: "DB_PASSWORD", value: "secret"}]
+        if (isset($data['key'], $data['value']) && is_string($data['key'])) {
+            if ($this->isSensitiveKeyName($data['key'])) {
+                $data['value'] = self::REDACTED_VALUE;
+            }
+
+            return $data;
+        }
+
+        foreach ($data as $key => $value) {
+            if (is_string($key) && $this->isSensitiveFieldName($key) && is_string($value)) {
+                $data[$key] = self::REDACTED_VALUE;
+            } elseif (is_array($value) || $value instanceof Jsonable) {
+                $data[$key] = $this->redactSecrets($value);
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * Check if a field name is a known sensitive credential field.
+     */
+    protected function isSensitiveFieldName(string $name): bool
+    {
+        return in_array($name, self::SENSITIVE_FIELD_NAMES, true);
+    }
+
+    /**
+     * Check if an environment variable key name looks sensitive.
+     */
+    protected function isSensitiveKeyName(string $key): bool
+    {
+        $normalized = strtolower($key);
+
+        foreach (['password', 'secret', 'api_key', 'token', 'private_key', 'access_key'] as $sensitive) {
+            if (str_contains($normalized, $sensitive)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     protected function resolve(string $argument): ValueResolver

--- a/tests/Unit/RedactSecretsTest.php
+++ b/tests/Unit/RedactSecretsTest.php
@@ -1,0 +1,253 @@
+<?php
+
+use App\Commands\BaseCommand;
+
+/**
+ * Create a testable instance of BaseCommand that exposes the redactSecrets method.
+ */
+function createTestCommand(): object
+{
+    return new class extends BaseCommand
+    {
+        protected $signature = 'test:redact {--hide-secrets}';
+
+        protected $description = 'Test command';
+
+        public function handle()
+        {
+            //
+        }
+
+        public function testRedactSecrets(mixed $data): mixed
+        {
+            return $this->redactSecrets($data);
+        }
+
+        public function testIsSensitiveFieldName(string $name): bool
+        {
+            return $this->isSensitiveFieldName($name);
+        }
+
+        public function testIsSensitiveKeyName(string $key): bool
+        {
+            return $this->isSensitiveKeyName($key);
+        }
+    };
+}
+
+// --- isSensitiveFieldName ---
+
+it('identifies password as a sensitive field name', function () {
+    $command = createTestCommand();
+    expect($command->testIsSensitiveFieldName('password'))->toBeTrue();
+});
+
+it('identifies secret as a sensitive field name', function () {
+    $command = createTestCommand();
+    expect($command->testIsSensitiveFieldName('secret'))->toBeTrue();
+});
+
+it('identifies secret_access_key as a sensitive field name', function () {
+    $command = createTestCommand();
+    expect($command->testIsSensitiveFieldName('secret_access_key'))->toBeTrue();
+});
+
+it('identifies secretAccessKey as a sensitive field name', function () {
+    $command = createTestCommand();
+    expect($command->testIsSensitiveFieldName('secretAccessKey'))->toBeTrue();
+});
+
+it('does not flag hostname as a sensitive field name', function () {
+    $command = createTestCommand();
+    expect($command->testIsSensitiveFieldName('hostname'))->toBeFalse();
+});
+
+it('does not flag name as a sensitive field name', function () {
+    $command = createTestCommand();
+    expect($command->testIsSensitiveFieldName('name'))->toBeFalse();
+});
+
+// --- isSensitiveKeyName ---
+
+it('identifies DB_PASSWORD as a sensitive key name', function () {
+    $command = createTestCommand();
+    expect($command->testIsSensitiveKeyName('DB_PASSWORD'))->toBeTrue();
+});
+
+it('identifies APP_SECRET as a sensitive key name', function () {
+    $command = createTestCommand();
+    expect($command->testIsSensitiveKeyName('APP_SECRET'))->toBeTrue();
+});
+
+it('identifies AWS_ACCESS_KEY as a sensitive key name', function () {
+    $command = createTestCommand();
+    expect($command->testIsSensitiveKeyName('AWS_ACCESS_KEY'))->toBeTrue();
+});
+
+it('does not flag APP_NAME as a sensitive key name', function () {
+    $command = createTestCommand();
+    expect($command->testIsSensitiveKeyName('APP_NAME'))->toBeFalse();
+});
+
+// --- redactSecrets ---
+
+it('redacts password fields in connection arrays', function () {
+    $command = createTestCommand();
+
+    $data = [
+        'connection' => [
+            'hostname' => 'redis.example.com',
+            'port' => 6379,
+            'password' => 'super-secret-password',
+        ],
+    ];
+
+    $result = $command->testRedactSecrets($data);
+
+    expect($result['connection']['hostname'])->toBe('redis.example.com');
+    expect($result['connection']['port'])->toBe(6379);
+    expect($result['connection']['password'])->toBe('********');
+});
+
+it('redacts secret_access_key fields in nested objects', function () {
+    $command = createTestCommand();
+
+    $data = [
+        'id' => 'key-1',
+        'name' => 'my-key',
+        'accessKeyId' => 'AKIA12345',
+        'secretAccessKey' => 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+    ];
+
+    $result = $command->testRedactSecrets($data);
+
+    expect($result['id'])->toBe('key-1');
+    expect($result['name'])->toBe('my-key');
+    expect($result['accessKeyId'])->toBe('AKIA12345');
+    expect($result['secretAccessKey'])->toBe('********');
+});
+
+it('redacts environment variable style arrays when key is sensitive', function () {
+    $command = createTestCommand();
+
+    $data = [
+        ['key' => 'APP_NAME', 'value' => 'My App'],
+        ['key' => 'DB_PASSWORD', 'value' => 'secret123'],
+        ['key' => 'API_TOKEN', 'value' => 'tok_abc'],
+    ];
+
+    $result = $command->testRedactSecrets($data);
+
+    expect($result[0]['value'])->toBe('My App');
+    expect($result[1]['value'])->toBe('********');
+    expect($result[2]['value'])->toBe('********');
+});
+
+it('handles deeply nested structures', function () {
+    $command = createTestCommand();
+
+    $data = [
+        'caches' => [
+            [
+                'id' => 'cache-1',
+                'name' => 'redis',
+                'connection' => [
+                    'hostname' => 'redis.example.com',
+                    'password' => 'my-redis-password',
+                ],
+            ],
+            [
+                'id' => 'cache-2',
+                'name' => 'memcached',
+                'connection' => [
+                    'hostname' => 'memcached.example.com',
+                    'password' => 'my-memcached-password',
+                ],
+            ],
+        ],
+    ];
+
+    $result = $command->testRedactSecrets($data);
+
+    expect($result['caches'][0]['connection']['hostname'])->toBe('redis.example.com');
+    expect($result['caches'][0]['connection']['password'])->toBe('********');
+    expect($result['caches'][1]['connection']['password'])->toBe('********');
+});
+
+it('leaves non-sensitive fields untouched', function () {
+    $command = createTestCommand();
+
+    $data = [
+        'id' => 'cache-1',
+        'name' => 'redis',
+        'type' => 'redis',
+        'status' => 'running',
+        'region' => 'us-east-1',
+    ];
+
+    $result = $command->testRedactSecrets($data);
+
+    expect($result)->toBe($data);
+});
+
+it('handles empty arrays', function () {
+    $command = createTestCommand();
+    expect($command->testRedactSecrets([]))->toBe([]);
+});
+
+it('handles non-array data', function () {
+    $command = createTestCommand();
+    expect($command->testRedactSecrets('hello'))->toBe('hello');
+    expect($command->testRedactSecrets(42))->toBe(42);
+    expect($command->testRedactSecrets(null))->toBeNull();
+});
+
+it('redacts database cluster connection passwords', function () {
+    $command = createTestCommand();
+
+    $data = [
+        'id' => 'cluster-1',
+        'name' => 'my-db',
+        'type' => 'mysql',
+        'connection' => [
+            'hostname' => 'db.example.com',
+            'port' => 3306,
+            'username' => 'admin',
+            'password' => 'db-password-123',
+        ],
+    ];
+
+    $result = $command->testRedactSecrets($data);
+
+    expect($result['connection']['hostname'])->toBe('db.example.com');
+    expect($result['connection']['username'])->toBe('admin');
+    expect($result['connection']['password'])->toBe('********');
+});
+
+it('redacts token fields', function () {
+    $command = createTestCommand();
+
+    $data = [
+        'name' => 'webhook',
+        'token' => 'whsec_12345abcde',
+    ];
+
+    $result = $command->testRedactSecrets($data);
+
+    expect($result['name'])->toBe('webhook');
+    expect($result['token'])->toBe('********');
+});
+
+it('redacts api_key fields', function () {
+    $command = createTestCommand();
+
+    $data = [
+        'service' => 'stripe',
+        'api_key' => 'sk_live_12345',
+    ];
+
+    $result = $command->testRedactSecrets($data);
+
+    expect($result['service'])->toBe('stripe');
+    expect($result['api_key'])->toBe('********');
+});


### PR DESCRIPTION
## Summary
- Adds a `--hide-secrets` option to `BaseCommand` that all commands inherit
- Extends `outputJsonIfWanted()` to recursively redact sensitive values when the flag is set
- Redacts named credential fields (`password`, `secret`, `api_key`, `access_key`, `secret_key`, `secretAccessKey`, `token`, `private_key`, etc.) in any nested structure
- Redacts environment variable key/value pairs where the key contains sensitive terms (e.g. `DB_PASSWORD`, `APP_SECRET`)
- All redacted values are replaced with `********`

This addresses the issue where `cache:list`, `cache:get`, `database-cluster:get`, `bucket-key:get`, and similar commands expose connection passwords and secrets in their JSON output. For example:

```json
{"connection": {"hostname": "...", "password": "plaintext"}}
```

With `--hide-secrets`:

```json
{"connection": {"hostname": "...", "password": "********"}}
```

Closes #60

## Test plan
- [x] Added 20 unit tests covering field name detection, key name detection, recursive redaction, nested structures, edge cases
- [x] All 51 tests pass (`vendor/bin/pest`)
- [x] PHPStan passes with no errors (`vendor/bin/phpstan analyse`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)