### PR TITLE
feat: add deployment:logs command

### DIFF
--- a/app/Client/Resources/Deployments/GetDeploymentLogsRequest.php
+++ b/app/Client/Resources/Deployments/GetDeploymentLogsRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Client\Resources\Deployments;
+
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Http\Response;
+
+class GetDeploymentLogsRequest extends Request
+{
+    protected Method $method = Method::GET;
+
+    public function __construct(
+        protected string $deploymentId,
+    ) {
+        //
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return "/deployments/{$this->deploymentId}/logs";
+    }
+
+    public function createDtoFromResponse(Response $response): array
+    {
+        return $response->json();
+    }
+}

--- a/app/Client/Resources/DeploymentsResource.php
+++ b/app/Client/Resources/DeploymentsResource.php
@@ -3,6 +3,7 @@
 namespace App\Client\Resources;
 
 use App\Client\Requests\InitiateDeploymentRequestData;
+use App\Client\Resources\Deployments\GetDeploymentLogsRequest;
 use App\Client\Resources\Deployments\GetDeploymentRequest;
 use App\Client\Resources\Deployments\InitiateDeploymentRequest;
 use App\Client\Resources\Deployments\ListDeploymentsRequest;
@@ -21,6 +22,14 @@ class DeploymentsResource extends Resource
     public function get(string $deploymentId): Deployment
     {
         $request = new GetDeploymentRequest($deploymentId);
+        $response = $this->send($request);
+
+        return $request->createDtoFromResponse($response);
+    }
+
+    public function logs(string $deploymentId): array
+    {
+        $request = new GetDeploymentLogsRequest($deploymentId);
         $response = $this->send($request);
 
         return $request->createDtoFromResponse($response);

--- a/app/Commands/DeploymentLogs.php
+++ b/app/Commands/DeploymentLogs.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Commands;
+
+use function Laravel\Prompts\info;
+use function Laravel\Prompts\intro;
+use function Laravel\Prompts\spin;
+use function Laravel\Prompts\warning;
+
+class DeploymentLogs extends BaseCommand
+{
+    protected $signature = 'deployment:logs
+                            {deployment? : The deployment ID}
+                            {--json : Output as JSON}';
+
+    protected $description = 'View deployment build and deploy logs';
+
+    public function handle()
+    {
+        $this->ensureClient();
+
+        intro('Deployment Logs');
+
+        $deployment = $this->resolvers()->deployment()->from($this->argument('deployment'));
+
+        $logs = spin(
+            fn () => $this->client->deployments()->logs($deployment->id),
+            'Fetching deployment logs...',
+        );
+
+        $this->outputJsonIfWanted($logs);
+
+        $this->displayLogs($logs);
+    }
+
+    protected function displayLogs(array $logs): void
+    {
+        $data = $logs['data'] ?? [];
+        $meta = $logs['meta'] ?? [];
+
+        if (! empty($meta['deployment_status'])) {
+            info("Deployment status: {$meta['deployment_status']}");
+        }
+
+        $this->displayPhase('Build', $data['build'] ?? []);
+        $this->displayPhase('Deploy', $data['deploy'] ?? []);
+    }
+
+    protected function displayPhase(string $name, array $phase): void
+    {
+        if (empty($phase) || ! ($phase['available'] ?? false)) {
+            warning("{$name} logs are not available.");
+
+            return;
+        }
+
+        info($name.' Logs');
+
+        foreach ($phase['steps'] ?? [] as $step) {
+            $status = $step['status'] ?? 'unknown';
+            $description = $step['description'] ?? $step['step'] ?? 'Unknown step';
+            $duration = isset($step['duration_ms']) ? ' ('.number_format($step['duration_ms'] / 1000, 2).'s)' : '';
+
+            $this->line("  [{$status}] {$description}{$duration}");
+
+            if (! empty($step['output'])) {
+                foreach (explode("\n", $step['output']) as $outputLine) {
+                    $this->line("    {$outputLine}");
+                }
+            }
+        }
+    }
+}

--- a/tests/Feature/DeploymentLogsTest.php
+++ b/tests/Feature/DeploymentLogsTest.php
@@ -1,0 +1,199 @@
+<?php
+
+use App\Client\Resources\Applications\ListApplicationsRequest;
+use App\Client\Resources\Deployments\GetDeploymentLogsRequest;
+use App\Client\Resources\Deployments\GetDeploymentRequest;
+use App\Client\Resources\Deployments\ListDeploymentsRequest;
+use App\Client\Resources\Environments\GetEnvironmentRequest;
+use App\Client\Resources\Environments\ListEnvironmentsRequest;
+use App\Client\Resources\Meta\GetOrganizationRequest;
+use App\ConfigRepository;
+use App\Git;
+use Illuminate\Support\Sleep;
+use Laravel\Prompts\Prompt;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+
+beforeEach(function () {
+    Sleep::fake();
+    $this->mockGit = Mockery::mock(Git::class);
+    $this->mockGit->shouldReceive('isRepo')->andReturn(true)->byDefault();
+    $this->mockGit->shouldReceive('getRoot')->andReturn('/tmp/test-repo')->byDefault();
+    $this->mockGit->shouldReceive('currentBranch')->andReturn('main')->byDefault();
+    $this->mockGit->shouldReceive('remoteRepo')->andReturn('')->byDefault();
+    $this->mockGit->shouldReceive('hasGitHubRemote')->andReturn(false)->byDefault();
+    $this->app->instance(Git::class, $this->mockGit);
+    $this->mockConfig = Mockery::mock(ConfigRepository::class);
+    $this->mockConfig->shouldReceive('apiTokens')->andReturn(collect(['test-api-token']));
+    $this->app->instance(ConfigRepository::class, $this->mockConfig);
+});
+
+afterEach(fn () => MockClient::destroyGlobal());
+
+function deploymentLogsResponse(bool $buildAvailable = true, bool $deployAvailable = true): array
+{
+    return [
+        'data' => [
+            'build' => [
+                'available' => $buildAvailable,
+                'steps' => $buildAvailable ? [
+                    [
+                        'step' => 'install_dependencies',
+                        'status' => 'completed',
+                        'description' => 'Install dependencies',
+                        'output' => "Installing packages...\nDone.",
+                        'duration_ms' => 5000,
+                        'time' => '2025-01-01T00:00:05Z',
+                    ],
+                    [
+                        'step' => 'build_assets',
+                        'status' => 'completed',
+                        'description' => 'Build assets',
+                        'output' => 'Assets compiled successfully.',
+                        'duration_ms' => 3000,
+                        'time' => '2025-01-01T00:00:08Z',
+                    ],
+                ] : [],
+            ],
+            'deploy' => [
+                'available' => $deployAvailable,
+                'steps' => $deployAvailable ? [
+                    [
+                        'step' => 'activate',
+                        'status' => 'completed',
+                        'description' => 'Activate deployment',
+                        'output' => 'Deployment activated.',
+                        'duration_ms' => 2000,
+                        'time' => '2025-01-01T00:00:10Z',
+                    ],
+                ] : [],
+            ],
+        ],
+        'meta' => [
+            'deployment_status' => 'deployment.succeeded',
+        ],
+    ];
+}
+
+function logsDeploymentDataResponse(): array
+{
+    return [
+        'id' => 'depl-123',
+        'type' => 'deployments',
+        'attributes' => [
+            'status' => 'deployment.succeeded',
+            'commit' => [
+                'hash' => 'abc1234567890',
+                'message' => 'Fix bug',
+                'author' => 'Test User',
+            ],
+            'branch_name' => 'main',
+            'started_at' => '2025-01-01T00:00:00.000000Z',
+            'finished_at' => '2025-01-01T00:05:00.000000Z',
+            'failure_reason' => null,
+            'php_major_version' => '8.3',
+        ],
+        'relationships' => [
+            'environment' => ['data' => ['id' => 'env-1', 'type' => 'environments']],
+        ],
+    ];
+}
+
+it('displays deployment logs by ID', function () {
+    Prompt::fake();
+
+    MockClient::global([
+        GetDeploymentRequest::class => MockResponse::make([
+            'data' => logsDeploymentDataResponse(),
+            'included' => [createEnvironmentResponse()],
+        ], 200),
+        GetDeploymentLogsRequest::class => MockResponse::make(deploymentLogsResponse(), 200),
+    ]);
+
+    $this->artisan('deployment:logs', ['deployment' => 'depl-123'])
+        ->assertSuccessful();
+});
+
+it('resolves deployment when no ID is given', function () {
+    Prompt::fake();
+
+    MockClient::global([
+        GetOrganizationRequest::class => MockResponse::make(organizationResponse(), 200),
+        ListApplicationsRequest::class => MockResponse::make([
+            'data' => [createApplicationResponse()],
+            'included' => [
+                ['id' => 'org-1', 'type' => 'organizations', 'attributes' => ['name' => 'My Org']],
+                createEnvironmentResponse(),
+            ],
+            'links' => ['next' => null],
+        ], 200),
+        ListEnvironmentsRequest::class => MockResponse::make([
+            'data' => [createEnvironmentResponse()],
+            'links' => ['next' => null],
+        ], 200),
+        GetEnvironmentRequest::class => MockResponse::make([
+            'data' => createEnvironmentResponse(),
+            'included' => [createApplicationResponse()],
+        ], 200),
+        ListDeploymentsRequest::class => MockResponse::make([
+            'data' => [logsDeploymentDataResponse()],
+            'included' => [createEnvironmentResponse()],
+            'links' => ['next' => null],
+        ], 200),
+        GetDeploymentLogsRequest::class => MockResponse::make(deploymentLogsResponse(), 200),
+    ]);
+
+    $this->artisan('deployment:logs')
+        ->assertSuccessful();
+});
+
+it('outputs logs as JSON when --json flag is used', function () {
+    Prompt::fake();
+
+    MockClient::global([
+        GetDeploymentRequest::class => MockResponse::make([
+            'data' => logsDeploymentDataResponse(),
+            'included' => [createEnvironmentResponse()],
+        ], 200),
+        GetDeploymentLogsRequest::class => MockResponse::make(deploymentLogsResponse(), 200),
+    ]);
+
+    $this->artisan('deployment:logs', ['deployment' => 'depl-123', '--json' => true])
+        ->assertSuccessful();
+});
+
+it('handles unavailable build logs', function () {
+    Prompt::fake();
+
+    MockClient::global([
+        GetDeploymentRequest::class => MockResponse::make([
+            'data' => logsDeploymentDataResponse(),
+            'included' => [createEnvironmentResponse()],
+        ], 200),
+        GetDeploymentLogsRequest::class => MockResponse::make(
+            deploymentLogsResponse(buildAvailable: false),
+            200,
+        ),
+    ]);
+
+    $this->artisan('deployment:logs', ['deployment' => 'depl-123'])
+        ->assertSuccessful();
+});
+
+it('handles unavailable deploy logs', function () {
+    Prompt::fake();
+
+    MockClient::global([
+        GetDeploymentRequest::class => MockResponse::make([
+            'data' => logsDeploymentDataResponse(),
+            'included' => [createEnvironmentResponse()],
+        ], 200),
+        GetDeploymentLogsRequest::class => MockResponse::make(
+            deploymentLogsResponse(deployAvailable: false),
+            200,
+        ),
+    ]);
+
+    $this->artisan('deployment:logs', ['deployment' => 'depl-123'])
+        ->assertSuccessful();
+});


### PR DESCRIPTION
## Summary
- Adds a new `deployment:logs` CLI command that fetches and displays build and deploy logs for a specific deployment via the `GET /deployments/{deployment}/logs` API endpoint
- Supports deployment ID argument with automatic resolution when omitted, and `--json` flag for machine-readable output
- Includes request class, resource method, and 5 feature tests covering ID lookup, resolver fallback, JSON output, and unavailable log phases

Closes #66
Related: #69

## Test plan
- [x] `./vendor/bin/pest` -- all 36 tests pass
- [x] `./vendor/bin/phpstan analyse` -- no errors
- [ ] Manual test: `php cloud deployment:logs <deployment-id>` displays build/deploy steps with output
- [ ] Manual test: `php cloud deployment:logs <deployment-id> --json` returns full JSON response
- [ ] Manual test: `php cloud deployment:logs` (no ID) triggers interactive deployment resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)