### PR TITLE
feat: add environment:variables delete action and metrics commands

### DIFF
--- a/app/Client/Requests/DeleteEnvironmentVariablesRequestData.php
+++ b/app/Client/Requests/DeleteEnvironmentVariablesRequestData.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Client\Requests;
+
+class DeleteEnvironmentVariablesRequestData extends RequestData
+{
+    public function __construct(
+        public readonly string $environmentId,
+        /** @var list<string> */
+        public readonly array $keys,
+    ) {
+        //
+    }
+
+    public function toRequestData(): array
+    {
+        return [
+            'keys' => $this->keys,
+        ];
+    }
+}

--- a/app/Client/Resources/Caches/GetCacheMetricsRequest.php
+++ b/app/Client/Resources/Caches/GetCacheMetricsRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Client\Resources\Caches;
+
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Http\Response;
+
+class GetCacheMetricsRequest extends Request
+{
+    protected Method $method = Method::GET;
+
+    public function __construct(
+        protected string $cacheId,
+    ) {
+        //
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return "/caches/{$this->cacheId}/metrics";
+    }
+
+    public function createDtoFromResponse(Response $response): array
+    {
+        return $response->json('data') ?? $response->json();
+    }
+}

--- a/app/Client/Resources/CachesResource.php
+++ b/app/Client/Resources/CachesResource.php
@@ -6,6 +6,7 @@ use App\Client\Requests\CreateCacheRequestData;
 use App\Client\Requests\UpdateCacheRequestData;
 use App\Client\Resources\Caches\CreateCacheRequest;
 use App\Client\Resources\Caches\DeleteCacheRequest;
+use App\Client\Resources\Caches\GetCacheMetricsRequest;
 use App\Client\Resources\Caches\GetCacheRequest;
 use App\Client\Resources\Caches\ListCachesRequest;
 use App\Client\Resources\Caches\ListCacheTypesRequest;
@@ -50,6 +51,14 @@ class CachesResource extends Resource
     public function delete(string $cacheId): void
     {
         $this->send(new DeleteCacheRequest($cacheId));
+    }
+
+    public function metrics(string $cacheId): array
+    {
+        $request = new GetCacheMetricsRequest($cacheId);
+        $response = $this->send($request);
+
+        return $request->createDtoFromResponse($response);
     }
 
     /**

--- a/app/Client/Resources/DatabaseClusters/GetDatabaseClusterMetricsRequest.php
+++ b/app/Client/Resources/DatabaseClusters/GetDatabaseClusterMetricsRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Client\Resources\DatabaseClusters;
+
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Http\Response;
+
+class GetDatabaseClusterMetricsRequest extends Request
+{
+    protected Method $method = Method::GET;
+
+    public function __construct(
+        protected string $clusterId,
+    ) {
+        //
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return "/databases/clusters/{$this->clusterId}/metrics";
+    }
+
+    public function createDtoFromResponse(Response $response): array
+    {
+        return $response->json('data') ?? $response->json();
+    }
+}

--- a/app/Client/Resources/DatabaseClustersResource.php
+++ b/app/Client/Resources/DatabaseClustersResource.php
@@ -6,6 +6,7 @@ use App\Client\Requests\CreateDatabaseClusterRequestData;
 use App\Client\Requests\UpdateDatabaseClusterRequestData;
 use App\Client\Resources\DatabaseClusters\CreateDatabaseClusterRequest;
 use App\Client\Resources\DatabaseClusters\DeleteDatabaseClusterRequest;
+use App\Client\Resources\DatabaseClusters\GetDatabaseClusterMetricsRequest;
 use App\Client\Resources\DatabaseClusters\GetDatabaseClusterRequest;
 use App\Client\Resources\DatabaseClusters\ListDatabaseClustersRequest;
 use App\Client\Resources\DatabaseClusters\ListDatabaseTypesRequest;
@@ -49,6 +50,14 @@ class DatabaseClustersResource extends Resource
     public function delete(string $clusterId): void
     {
         $this->send(new DeleteDatabaseClusterRequest($clusterId));
+    }
+
+    public function metrics(string $clusterId): array
+    {
+        $request = new GetDatabaseClusterMetricsRequest($clusterId);
+        $response = $this->send($request);
+
+        return $request->createDtoFromResponse($response);
     }
 
     public function types(): array

--- a/app/Client/Resources/Environments/DeleteEnvironmentVariablesRequest.php
+++ b/app/Client/Resources/Environments/DeleteEnvironmentVariablesRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Client\Resources\Environments;
+
+use App\Client\Requests\DeleteEnvironmentVariablesRequestData;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+class DeleteEnvironmentVariablesRequest extends Request implements HasBody
+{
+    use HasJsonBody;
+
+    protected Method $method = Method::DELETE;
+
+    public function __construct(
+        protected DeleteEnvironmentVariablesRequestData $data,
+    ) {
+        //
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return "/environments/{$this->data->environmentId}/variables";
+    }
+
+    protected function defaultBody(): array
+    {
+        return $this->data->toRequestData();
+    }
+}

--- a/app/Client/Resources/Environments/DeleteEnvironmentVariablesRequest.php
+++ b/app/Client/Resources/Environments/DeleteEnvironmentVariablesRequest.php
@@ -12,7 +12,7 @@ class DeleteEnvironmentVariablesRequest extends Request implements HasBody
 {
     use HasJsonBody;
 
-    protected Method $method = Method::DELETE;
+    protected Method $method = Method::POST;
 
     public function __construct(
         protected DeleteEnvironmentVariablesRequestData $data,
@@ -22,7 +22,7 @@ class DeleteEnvironmentVariablesRequest extends Request implements HasBody
 
     public function resolveEndpoint(): string
     {
-        return "/environments/{$this->data->environmentId}/variables";
+        return "/environments/{$this->data->environmentId}/variables/delete";
     }
 
     protected function defaultBody(): array

--- a/app/Client/Resources/Environments/GetEnvironmentMetricsRequest.php
+++ b/app/Client/Resources/Environments/GetEnvironmentMetricsRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Client\Resources\Environments;
+
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Http\Response;
+
+class GetEnvironmentMetricsRequest extends Request
+{
+    protected Method $method = Method::GET;
+
+    public function __construct(
+        protected string $environmentId,
+    ) {
+        //
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return "/environments/{$this->environmentId}/metrics";
+    }
+
+    public function createDtoFromResponse(Response $response): array
+    {
+        return $response->json('data') ?? $response->json();
+    }
+}

--- a/app/Client/Resources/EnvironmentsResource.php
+++ b/app/Client/Resources/EnvironmentsResource.php
@@ -4,6 +4,7 @@ namespace App\Client\Resources;
 
 use App\Client\Requests\AddEnvironmentVariablesRequestData;
 use App\Client\Requests\CreateEnvironmentRequestData;
+use App\Client\Requests\DeleteEnvironmentVariablesRequestData;
 use App\Client\Requests\ReplaceEnvironmentVariablesRequestData;
 use App\Client\Requests\StartEnvironmentRequestData;
 use App\Client\Requests\StopEnvironmentRequestData;
@@ -11,6 +12,8 @@ use App\Client\Requests\UpdateEnvironmentRequestData;
 use App\Client\Resources\Environments\AddEnvironmentVariablesRequest;
 use App\Client\Resources\Environments\CreateEnvironmentRequest;
 use App\Client\Resources\Environments\DeleteEnvironmentRequest;
+use App\Client\Resources\Environments\DeleteEnvironmentVariablesRequest;
+use App\Client\Resources\Environments\GetEnvironmentMetricsRequest;
 use App\Client\Resources\Environments\GetEnvironmentRequest;
 use App\Client\Resources\Environments\ListEnvironmentLogsRequest;
 use App\Client\Resources\Environments\ListEnvironmentsRequest;
@@ -83,6 +86,19 @@ class EnvironmentsResource extends Resource
     public function replaceVariables(ReplaceEnvironmentVariablesRequestData $data): void
     {
         $this->send(new ReplaceEnvironmentVariablesRequest($data));
+    }
+
+    public function deleteVariables(DeleteEnvironmentVariablesRequestData $data): void
+    {
+        $this->send(new DeleteEnvironmentVariablesRequest($data));
+    }
+
+    public function metrics(string $environmentId): array
+    {
+        $request = new GetEnvironmentMetricsRequest($environmentId);
+        $response = $this->send($request);
+
+        return $request->createDtoFromResponse($response);
     }
 
     public function start(string $environmentId): void

--- a/app/Client/Resources/WebSocketApplications/GetWebSocketApplicationMetricsRequest.php
+++ b/app/Client/Resources/WebSocketApplications/GetWebSocketApplicationMetricsRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Client\Resources\WebSocketApplications;
+
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Http\Response;
+
+class GetWebSocketApplicationMetricsRequest extends Request
+{
+    protected Method $method = Method::GET;
+
+    public function __construct(
+        protected string $applicationId,
+    ) {
+        //
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return "/websocket-applications/{$this->applicationId}/metrics";
+    }
+
+    public function createDtoFromResponse(Response $response): array
+    {
+        return $response->json('data') ?? $response->json();
+    }
+}

--- a/app/Client/Resources/WebSocketApplicationsResource.php
+++ b/app/Client/Resources/WebSocketApplicationsResource.php
@@ -6,6 +6,7 @@ use App\Client\Requests\CreateWebSocketApplicationRequestData;
 use App\Client\Requests\UpdateWebSocketApplicationRequestData;
 use App\Client\Resources\WebSocketApplications\CreateWebSocketApplicationRequest;
 use App\Client\Resources\WebSocketApplications\DeleteWebSocketApplicationRequest;
+use App\Client\Resources\WebSocketApplications\GetWebSocketApplicationMetricsRequest;
 use App\Client\Resources\WebSocketApplications\GetWebSocketApplicationRequest;
 use App\Client\Resources\WebSocketApplications\ListWebSocketApplicationsRequest;
 use App\Client\Resources\WebSocketApplications\UpdateWebSocketApplicationRequest;
@@ -52,5 +53,13 @@ class WebSocketApplicationsResource extends Resource
         $this->send(new DeleteWebSocketApplicationRequest(
             applicationId: $applicationId,
         ));
+    }
+
+    public function metrics(string $applicationId): array
+    {
+        $request = new GetWebSocketApplicationMetricsRequest($applicationId);
+        $response = $this->send($request);
+
+        return $request->createDtoFromResponse($response);
     }
 }

--- a/app/Client/Resources/WebSocketClusters/GetWebSocketClusterMetricsRequest.php
+++ b/app/Client/Resources/WebSocketClusters/GetWebSocketClusterMetricsRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Client\Resources\WebSocketClusters;
+
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Http\Response;
+
+class GetWebSocketClusterMetricsRequest extends Request
+{
+    protected Method $method = Method::GET;
+
+    public function __construct(
+        protected string $clusterId,
+    ) {
+        //
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return "/websocket-servers/{$this->clusterId}/metrics";
+    }
+
+    public function createDtoFromResponse(Response $response): array
+    {
+        return $response->json('data') ?? $response->json();
+    }
+}

--- a/app/Client/Resources/WebSocketClustersResource.php
+++ b/app/Client/Resources/WebSocketClustersResource.php
@@ -6,6 +6,7 @@ use App\Client\Requests\CreateWebSocketClusterRequestData;
 use App\Client\Requests\UpdateWebSocketClusterRequestData;
 use App\Client\Resources\WebSocketClusters\CreateWebSocketClusterRequest;
 use App\Client\Resources\WebSocketClusters\DeleteWebSocketClusterRequest;
+use App\Client\Resources\WebSocketClusters\GetWebSocketClusterMetricsRequest;
 use App\Client\Resources\WebSocketClusters\GetWebSocketClusterRequest;
 use App\Client\Resources\WebSocketClusters\ListWebSocketClustersRequest;
 use App\Client\Resources\WebSocketClusters\UpdateWebSocketClusterRequest;
@@ -48,5 +49,13 @@ class WebSocketClustersResource extends Resource
     public function delete(string $clusterId): void
     {
         $this->send(new DeleteWebSocketClusterRequest($clusterId));
+    }
+
+    public function metrics(string $clusterId): array
+    {
+        $request = new GetWebSocketClusterMetricsRequest($clusterId);
+        $response = $this->send($request);
+
+        return $request->createDtoFromResponse($response);
     }
 }

--- a/app/Commands/CacheMetrics.php
+++ b/app/Commands/CacheMetrics.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Commands;
+
+use function Laravel\Prompts\intro;
+use function Laravel\Prompts\spin;
+
+class CacheMetrics extends BaseCommand
+{
+    protected $signature = 'cache:metrics {cache? : The cache ID or name} {--json : Output as JSON}';
+
+    protected $description = 'Get cache metrics';
+
+    public function handle()
+    {
+        $this->ensureClient();
+
+        intro('Cache Metrics');
+
+        $cache = $this->resolvers()->cache()->from($this->argument('cache'));
+
+        $metrics = spin(
+            fn () => $this->client->caches()->metrics($cache->id),
+            'Fetching cache metrics...',
+        );
+
+        $this->outputJsonIfWanted($metrics);
+
+        $this->displayMetrics($metrics);
+    }
+
+    protected function displayMetrics(array $metrics): void
+    {
+        if (empty($metrics)) {
+            $this->line('No metrics available.');
+
+            return;
+        }
+
+        $rows = collect($metrics)->map(function ($value, $key) {
+            return [$key, is_array($value) ? json_encode($value) : $value];
+        })->values()->toArray();
+
+        $this->table(['Metric', 'Value'], $rows);
+    }
+}

--- a/app/Commands/DatabaseClusterMetrics.php
+++ b/app/Commands/DatabaseClusterMetrics.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Commands;
+
+use function Laravel\Prompts\intro;
+use function Laravel\Prompts\spin;
+
+class DatabaseClusterMetrics extends BaseCommand
+{
+    protected $signature = 'database-cluster:metrics {cluster? : The cluster ID or name} {--json : Output as JSON}';
+
+    protected $description = 'Get database cluster metrics';
+
+    public function handle()
+    {
+        $this->ensureClient();
+
+        intro('Database Cluster Metrics');
+
+        $cluster = $this->resolvers()->databaseCluster()->from($this->argument('cluster'));
+
+        $metrics = spin(
+            fn () => $this->client->databaseClusters()->metrics($cluster->id),
+            'Fetching database cluster metrics...',
+        );
+
+        $this->outputJsonIfWanted($metrics);
+
+        $this->displayMetrics($metrics);
+    }
+
+    protected function displayMetrics(array $metrics): void
+    {
+        if (empty($metrics)) {
+            $this->line('No metrics available.');
+
+            return;
+        }
+
+        $rows = collect($metrics)->map(function ($value, $key) {
+            return [$key, is_array($value) ? json_encode($value) : $value];
+        })->values()->toArray();
+
+        $this->table(['Metric', 'Value'], $rows);
+    }
+}

--- a/app/Commands/EnvironmentMetrics.php
+++ b/app/Commands/EnvironmentMetrics.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Commands;
+
+use function Laravel\Prompts\intro;
+use function Laravel\Prompts\spin;
+
+class EnvironmentMetrics extends BaseCommand
+{
+    protected $signature = 'environment:metrics {environment? : The environment ID or name} {--json : Output as JSON}';
+
+    protected $description = 'Get environment metrics';
+
+    public function handle()
+    {
+        $this->ensureClient();
+
+        intro('Environment Metrics');
+
+        $environment = $this->resolvers()->environment()->from($this->argument('environment'));
+
+        $metrics = spin(
+            fn () => $this->client->environments()->metrics($environment->id),
+            'Fetching environment metrics...',
+        );
+
+        $this->outputJsonIfWanted($metrics);
+
+        $this->displayMetrics($metrics);
+    }
+
+    protected function displayMetrics(array $metrics): void
+    {
+        if (empty($metrics)) {
+            $this->line('No metrics available.');
+
+            return;
+        }
+
+        $rows = collect($metrics)->map(function ($value, $key) {
+            return [$key, is_array($value) ? json_encode($value) : $value];
+        })->values()->toArray();
+
+        $this->table(['Metric', 'Value'], $rows);
+    }
+}

--- a/app/Commands/EnvironmentVariables.php
+++ b/app/Commands/EnvironmentVariables.php
@@ -3,6 +3,7 @@
 namespace App\Commands;
 
 use App\Client\Requests\AddEnvironmentVariablesRequestData;
+use App\Client\Requests\DeleteEnvironmentVariablesRequestData;
 use App\Client\Requests\ReplaceEnvironmentVariablesRequestData;
 use App\Dto\Environment;
 
@@ -15,8 +16,8 @@ class EnvironmentVariables extends BaseCommand
 {
     protected $signature = 'environment:variables
                             {environment? : The environment ID or name}
-                            {--action= : append, set, or replace}
-                            {--key= : Variable key}
+                            {--action= : append, set, replace, or delete}
+                            {--key=* : Variable key(s)}
                             {--value= : Variable value}
                             {--force : Force update without confirmation}
                             {--json : Output as JSON}';
@@ -48,13 +49,20 @@ class EnvironmentVariables extends BaseCommand
                     'append' => ['Append', 'Add without checking for duplicates'],
                     'set' => ['Set', 'Check for duplicates and update existing variables'],
                     'replace' => ['Replace', 'Replace all existing variable'],
+                    'delete' => ['Delete', 'Remove variables by key'],
                 ],
                 default: $value ?? 'add',
             )),
         );
 
-        if (! in_array($this->form()->get('action'), ['append', 'set', 'replace'])) {
-            $this->failAndExit('Invalid action, must be either `append`, `set` or `replace`');
+        if (! in_array($this->form()->get('action'), ['append', 'set', 'replace', 'delete'])) {
+            $this->failAndExit('Invalid action, must be either `append`, `set`, `replace` or `delete`');
+        }
+
+        if ($this->form()->get('action') === 'delete') {
+            $this->deleteVariables($environment);
+
+            return;
         }
 
         if ($this->form()->get('action') === 'replace' && ! $this->option('force')) {
@@ -99,11 +107,67 @@ class EnvironmentVariables extends BaseCommand
         }
     }
 
+    protected function deleteVariables(Environment $environment): void
+    {
+        $keys = $this->option('key');
+
+        if (empty($keys)) {
+            if (! $this->isInteractive()) {
+                $this->failAndExit('You must provide at least one --key to delete.');
+            }
+
+            $keys = [];
+            $adding = true;
+
+            while ($adding) {
+                $key = text(
+                    label: 'Key to delete',
+                    required: true,
+                );
+
+                $keys[] = $key;
+
+                $adding = confirm(
+                    'Delete another variable?',
+                    no: 'No, done',
+                    yes: 'Yes, delete another',
+                    default: false,
+                );
+            }
+        }
+
+        if (! $this->option('force')) {
+            if (! $this->isInteractive()) {
+                $this->failAndExit('Cancelled. Use --force to force deletion.');
+            }
+
+            if (! confirm(
+                label: 'Are you sure you want to delete '.count($keys).' variable(s)?',
+                yes: 'Yes, delete',
+                no: 'No, cancel',
+            )) {
+                $this->failAndExit('Cancelled');
+            }
+        }
+
+        spin(
+            fn () => $this->client->environments()->deleteVariables(
+                new DeleteEnvironmentVariablesRequestData(
+                    environmentId: $environment->id,
+                    keys: $keys,
+                ),
+            ),
+            'Deleting variables...',
+        );
+    }
+
     protected function collectVariablesFromOptions(): array
     {
+        $keys = $this->option('key');
+
         return [
             [
-                'key' => $this->option('key'),
+                'key' => $keys[0] ?? null,
                 'value' => $this->option('value'),
             ],
         ];

--- a/app/Commands/WebsocketApplicationMetrics.php
+++ b/app/Commands/WebsocketApplicationMetrics.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Commands;
+
+use function Laravel\Prompts\intro;
+use function Laravel\Prompts\spin;
+
+class WebsocketApplicationMetrics extends BaseCommand
+{
+    protected $signature = 'websocket-application:metrics
+                            {application? : The application ID or name}
+                            {--json : Output as JSON}';
+
+    protected $description = 'Get WebSocket application metrics';
+
+    public function handle()
+    {
+        $this->ensureClient();
+
+        intro('WebSocket Application Metrics');
+
+        $app = $this->resolvers()->websocketApplication()->from($this->argument('application'));
+
+        $metrics = spin(
+            fn () => $this->client->websocketApplications()->metrics($app->id),
+            'Fetching WebSocket application metrics...',
+        );
+
+        $this->outputJsonIfWanted($metrics);
+
+        $this->displayMetrics($metrics);
+    }
+
+    protected function displayMetrics(array $metrics): void
+    {
+        if (empty($metrics)) {
+            $this->line('No metrics available.');
+
+            return;
+        }
+
+        $rows = collect($metrics)->map(function ($value, $key) {
+            return [$key, is_array($value) ? json_encode($value) : $value];
+        })->values()->toArray();
+
+        $this->table(['Metric', 'Value'], $rows);
+    }
+}

--- a/app/Commands/WebsocketClusterMetrics.php
+++ b/app/Commands/WebsocketClusterMetrics.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Commands;
+
+use function Laravel\Prompts\intro;
+use function Laravel\Prompts\spin;
+
+class WebsocketClusterMetrics extends BaseCommand
+{
+    protected $signature = 'websocket-cluster:metrics {cluster? : The cluster ID or name} {--json : Output as JSON}';
+
+    protected $description = 'Get WebSocket cluster metrics';
+
+    public function handle()
+    {
+        $this->ensureClient();
+
+        intro('WebSocket Cluster Metrics');
+
+        $cluster = $this->resolvers()->websocketCluster()->from($this->argument('cluster'));
+
+        $metrics = spin(
+            fn () => $this->client->websocketClusters()->metrics($cluster->id),
+            'Fetching WebSocket cluster metrics...',
+        );
+
+        $this->outputJsonIfWanted($metrics);
+
+        $this->displayMetrics($metrics);
+    }
+
+    protected function displayMetrics(array $metrics): void
+    {
+        if (empty($metrics)) {
+            $this->line('No metrics available.');
+
+            return;
+        }
+
+        $rows = collect($metrics)->map(function ($value, $key) {
+            return [$key, is_array($value) ? json_encode($value) : $value];
+        })->values()->toArray();
+
+        $this->table(['Metric', 'Value'], $rows);
+    }
+}

--- a/tests/Feature/EnvironmentVariablesDeleteTest.php
+++ b/tests/Feature/EnvironmentVariablesDeleteTest.php
@@ -1,0 +1,84 @@
+<?php
+
+use App\Client\Resources\Environments\DeleteEnvironmentVariablesRequest;
+use App\Client\Resources\Environments\GetEnvironmentRequest;
+use App\Client\Resources\Environments\ListEnvironmentsRequest;
+use App\Client\Resources\Meta\GetOrganizationRequest;
+use App\ConfigRepository;
+use App\Git;
+use Illuminate\Support\Sleep;
+use Laravel\Prompts\Prompt;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+
+beforeEach(function () {
+    Sleep::fake();
+
+    $this->mockGit = Mockery::mock(Git::class);
+    $this->mockGit->shouldReceive('isRepo')->andReturn(true)->byDefault();
+    $this->mockGit->shouldReceive('getRoot')->andReturn('/tmp/test-repo')->byDefault();
+    $this->app->instance(Git::class, $this->mockGit);
+
+    $this->mockConfig = Mockery::mock(ConfigRepository::class);
+    $this->mockConfig->shouldReceive('apiTokens')->andReturn(collect(['test-api-token']));
+    $this->app->instance(ConfigRepository::class, $this->mockConfig);
+});
+
+afterEach(function () {
+    MockClient::destroyGlobal();
+});
+
+it('deletes environment variables successfully in non-interactive mode', function () {
+    Prompt::fake();
+
+    MockClient::global([
+        GetOrganizationRequest::class => MockResponse::make(organizationResponse(), 200),
+        GetEnvironmentRequest::class => MockResponse::make([
+            'data' => createEnvironmentResponse(),
+        ], 200),
+        DeleteEnvironmentVariablesRequest::class => MockResponse::make([], 200),
+    ]);
+
+    $this->artisan('environment:variables', [
+        'environment' => 'env-1',
+        '--action' => 'delete',
+        '--key' => ['MY_VAR'],
+        '--force' => true,
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+});
+
+it('fails when no keys are provided in non-interactive mode', function () {
+    Prompt::fake();
+
+    MockClient::global([
+        GetOrganizationRequest::class => MockResponse::make(organizationResponse(), 200),
+        GetEnvironmentRequest::class => MockResponse::make([
+            'data' => createEnvironmentResponse(),
+        ], 200),
+    ]);
+
+    $this->artisan('environment:variables', [
+        'environment' => 'env-1',
+        '--action' => 'delete',
+        '--no-interaction' => true,
+    ])->assertFailed();
+});
+
+it('fails without force flag in non-interactive mode', function () {
+    Prompt::fake();
+
+    MockClient::global([
+        GetOrganizationRequest::class => MockResponse::make(organizationResponse(), 200),
+        GetEnvironmentRequest::class => MockResponse::make([
+            'data' => createEnvironmentResponse(),
+        ], 200),
+    ]);
+
+    $this->artisan('environment:variables', [
+        'environment' => 'env-1',
+        '--action' => 'delete',
+        '--key' => ['MY_VAR'],
+        '--no-interaction' => true,
+    ])->assertFailed();
+});

--- a/tests/Feature/MetricsCommandsTest.php
+++ b/tests/Feature/MetricsCommandsTest.php
@@ -1,0 +1,193 @@
+<?php
+
+use App\Client\Resources\Caches\GetCacheMetricsRequest;
+use App\Client\Resources\Caches\GetCacheRequest;
+use App\Client\Resources\Caches\ListCachesRequest;
+use App\Client\Resources\DatabaseClusters\GetDatabaseClusterMetricsRequest;
+use App\Client\Resources\DatabaseClusters\GetDatabaseClusterRequest;
+use App\Client\Resources\DatabaseClusters\ListDatabaseClustersRequest;
+use App\Client\Resources\Environments\GetEnvironmentMetricsRequest;
+use App\Client\Resources\Environments\GetEnvironmentRequest;
+use App\Client\Resources\Meta\GetOrganizationRequest;
+use App\Client\Resources\WebSocketApplications\GetWebSocketApplicationMetricsRequest;
+use App\Client\Resources\WebSocketApplications\GetWebSocketApplicationRequest;
+use App\Client\Resources\WebSocketClusters\GetWebSocketClusterMetricsRequest;
+use App\Client\Resources\WebSocketClusters\GetWebSocketClusterRequest;
+use App\Client\Resources\WebSocketClusters\ListWebSocketClustersRequest;
+use App\ConfigRepository;
+use App\Git;
+use Illuminate\Support\Sleep;
+use Laravel\Prompts\Prompt;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+
+beforeEach(function () {
+    Sleep::fake();
+
+    $this->mockGit = Mockery::mock(Git::class);
+    $this->mockGit->shouldReceive('isRepo')->andReturn(true)->byDefault();
+    $this->mockGit->shouldReceive('getRoot')->andReturn('/tmp/test-repo')->byDefault();
+    $this->app->instance(Git::class, $this->mockGit);
+
+    $this->mockConfig = Mockery::mock(ConfigRepository::class);
+    $this->mockConfig->shouldReceive('apiTokens')->andReturn(collect(['test-api-token']));
+    $this->app->instance(ConfigRepository::class, $this->mockConfig);
+});
+
+afterEach(function () {
+    MockClient::destroyGlobal();
+});
+
+it('fetches cache metrics successfully', function () {
+    Prompt::fake();
+
+    MockClient::global([
+        GetOrganizationRequest::class => MockResponse::make(organizationResponse(), 200),
+        ListCachesRequest::class => MockResponse::make([
+            'data' => [
+                [
+                    'id' => 'cache-1',
+                    'type' => 'caches',
+                    'attributes' => [
+                        'name' => 'My Cache',
+                        'type' => 'redis',
+                        'status' => 'running',
+                        'region' => 'us-east-1',
+                        'size' => '1GB',
+                        'auto_upgrade_enabled' => true,
+                        'is_public' => false,
+                    ],
+                ],
+            ],
+            'links' => ['next' => null],
+        ], 200),
+        GetCacheMetricsRequest::class => MockResponse::make([
+            'data' => ['cpu' => '10%', 'memory' => '256MB'],
+        ], 200),
+    ]);
+
+    $this->artisan('cache:metrics', [
+        'cache' => 'My Cache',
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+});
+
+it('fetches database cluster metrics successfully', function () {
+    Prompt::fake();
+
+    MockClient::global([
+        GetOrganizationRequest::class => MockResponse::make(organizationResponse(), 200),
+        ListDatabaseClustersRequest::class => MockResponse::make([
+            'data' => [
+                [
+                    'id' => 'db-1',
+                    'type' => 'database_clusters',
+                    'attributes' => [
+                        'name' => 'My DB',
+                        'type' => 'mysql',
+                        'status' => 'running',
+                        'region' => 'us-east-1',
+                    ],
+                ],
+            ],
+            'links' => ['next' => null],
+        ], 200),
+        GetDatabaseClusterMetricsRequest::class => MockResponse::make([
+            'data' => ['cpu' => '15%', 'memory' => '512MB'],
+        ], 200),
+    ]);
+
+    $this->artisan('database-cluster:metrics', [
+        'cluster' => 'My DB',
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+});
+
+it('fetches environment metrics successfully', function () {
+    Prompt::fake();
+
+    MockClient::global([
+        GetOrganizationRequest::class => MockResponse::make(organizationResponse(), 200),
+        GetEnvironmentRequest::class => MockResponse::make([
+            'data' => createEnvironmentResponse(),
+        ], 200),
+        GetEnvironmentMetricsRequest::class => MockResponse::make([
+            'data' => ['cpu' => '20%', 'memory' => '1GB'],
+        ], 200),
+    ]);
+
+    $this->artisan('environment:metrics', [
+        'environment' => 'env-1',
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+});
+
+it('fetches websocket application metrics successfully', function () {
+    Prompt::fake();
+
+    MockClient::global([
+        GetOrganizationRequest::class => MockResponse::make(organizationResponse(), 200),
+        GetWebSocketApplicationRequest::class => MockResponse::make([
+            'data' => [
+                'id' => 'wsa-app-1',
+                'type' => 'websocket_applications',
+                'attributes' => [
+                    'name' => 'My WS App',
+                    'app_id' => 'app-123',
+                    'key' => 'key-123',
+                    'secret' => 'secret-123',
+                    'allowed_origins' => [],
+                    'max_connections' => 1000,
+                    'ping_interval' => 30,
+                    'activity_timeout' => 120,
+                    'max_message_size' => 65536,
+                ],
+                'relationships' => [],
+            ],
+        ], 200),
+        GetWebSocketApplicationMetricsRequest::class => MockResponse::make([
+            'data' => ['connections' => 42, 'messages_per_second' => 100],
+        ], 200),
+    ]);
+
+    $this->artisan('websocket-application:metrics', [
+        'application' => 'wsa-app-1',
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+});
+
+it('fetches websocket cluster metrics successfully', function () {
+    Prompt::fake();
+
+    $clusterData = [
+        'id' => 'ws-cluster-1',
+        'type' => 'websocket_clusters',
+        'attributes' => [
+            'name' => 'My WS Cluster',
+            'region' => 'us-east-1',
+            'status' => 'available',
+            'type' => 'reverb',
+            'hostname' => 'ws.example.com',
+            'max_connections' => 10000,
+            'connection_distribution_strategy' => 'evenly',
+        ],
+        'relationships' => [],
+    ];
+
+    MockClient::global([
+        GetOrganizationRequest::class => MockResponse::make(organizationResponse(), 200),
+        GetWebSocketClusterRequest::class => MockResponse::make(['data' => $clusterData], 200),
+        ListWebSocketClustersRequest::class => MockResponse::make([
+            'data' => [$clusterData],
+            'links' => ['next' => null],
+        ], 200),
+        GetWebSocketClusterMetricsRequest::class => MockResponse::make([
+            'data' => ['connections' => 100, 'bandwidth' => '5MB/s'],
+        ], 200),
+    ]);
+
+    $this->artisan('websocket-cluster:metrics', [
+        'cluster' => 'ws-cluster-1',
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+});


### PR DESCRIPTION
## Summary

- Adds `delete` action to the `environment:variables` command, allowing users to remove environment variables by key via `--action=delete --key=VAR_NAME --force` (fixes #67)
- Adds metrics commands for all resources that support them: `cache:metrics`, `database-cluster:metrics`, `environment:metrics`, `websocket-application:metrics`, `websocket-cluster:metrics` (fixes #68, fixes #69)
- Creates corresponding API request classes (`DeleteEnvironmentVariablesRequest`, `Get*MetricsRequest`) and `metrics()` methods on each resource class
- Adds tests for all new commands

## Details

### Part 1: `environment:variables --delete`
- New `delete` action in the interactive action selector
- In non-interactive mode: `--action=delete --key=VAR_NAME --force`
- Supports multiple `--key` flags to delete several variables at once
- Requires `--force` in non-interactive mode for safety
- Interactive mode prompts for key names and confirmation

### Part 2: Metrics commands
- Each command resolves the resource, fetches metrics from the API, and displays as a table (interactive) or JSON (non-interactive/`--json`)
- Follows the same pattern as existing `*:get` commands

## Test plan
- [x] `./vendor/bin/pest` passes (39 tests, 40 assertions)
- [x] `./vendor/bin/phpstan analyse` passes (0 errors)
- [ ] Manual testing against the Laravel Cloud API

🤖 Generated with [Claude Code](https://claude.com/claude-code)