### PR TITLE
feat: auto-show deployment logs on failure

### DIFF
--- a/app/Client/Resources/Deployments/GetDeploymentLogsRequest.php
+++ b/app/Client/Resources/Deployments/GetDeploymentLogsRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Client\Resources\Deployments;
+
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Http\Response;
+
+class GetDeploymentLogsRequest extends Request
+{
+    protected Method $method = Method::GET;
+
+    public function __construct(
+        protected string $deploymentId,
+    ) {
+        //
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return "/deployments/{$this->deploymentId}/logs";
+    }
+
+    /**
+     * @return array<int, array{type: string, timestamp: string|null, output: string}>
+     */
+    public function createDtoFromResponse(Response $response): array
+    {
+        return $response->json('data', []);
+    }
+}

--- a/app/Client/Resources/DeploymentsResource.php
+++ b/app/Client/Resources/DeploymentsResource.php
@@ -3,6 +3,7 @@
 namespace App\Client\Resources;
 
 use App\Client\Requests\InitiateDeploymentRequestData;
+use App\Client\Resources\Deployments\GetDeploymentLogsRequest;
 use App\Client\Resources\Deployments\GetDeploymentRequest;
 use App\Client\Resources\Deployments\InitiateDeploymentRequest;
 use App\Client\Resources\Deployments\ListDeploymentsRequest;
@@ -29,6 +30,17 @@ class DeploymentsResource extends Resource
     public function initiate(InitiateDeploymentRequestData $data): Deployment
     {
         $request = new InitiateDeploymentRequest($data);
+        $response = $this->send($request);
+
+        return $request->createDtoFromResponse($response);
+    }
+
+    /**
+     * @return array<int, array{type: string, timestamp: string|null, output: string}>
+     */
+    public function logs(string $deploymentId): array
+    {
+        $request = new GetDeploymentLogsRequest($deploymentId);
         $response = $this->send($request);
 
         return $request->createDtoFromResponse($response);

--- a/app/Commands/Deploy.php
+++ b/app/Commands/Deploy.php
@@ -5,6 +5,7 @@ namespace App\Commands;
 use App\Client\Requests\InitiateDeploymentRequestData;
 use App\Concerns\RequiresRemoteGitRepo;
 use App\Concerns\UpdatesBuildDeployCommands;
+use App\Enums\DeploymentStatus;
 use App\Dto\Deployment;
 use App\Exceptions\CommandExitException;
 use Carbon\CarbonImmutable;
@@ -72,7 +73,10 @@ class Deploy extends BaseCommand
         $deployment = $this->client->deployments()->get($deployment->id);
 
         if ($deployment->failed()) {
-            error('Deployment failed: '.$deployment->failureReason);
+            $phase = $deployment->status === DeploymentStatus::BUILD_FAILED ? 'Build' : 'Deploy';
+            error('Deployment failed: '.($deployment->failureReason ?: $phase.' failed'));
+
+            $this->displayDeploymentLogs($deployment, $phase);
 
             if ($this->isInteractive()) {
                 if (confirm('Do you want to edit the build and deploy commands and try again?')) {
@@ -142,6 +146,32 @@ class Deploy extends BaseCommand
             $count++;
             $checkApi = $count % $checkInterval === 0;
         } while ($deploymentStatus->isInProgress());
+    }
+
+    protected function displayDeploymentLogs(Deployment $deployment, string $phase): void
+    {
+        try {
+            $logs = $this->client->deployments()->logs($deployment->id);
+        } catch (\Throwable) {
+            return;
+        }
+
+        if (empty($logs)) {
+            return;
+        }
+
+        $this->newLine();
+        $this->line("  <comment>{$phase} output:</comment>");
+
+        foreach ($logs as $log) {
+            $output = $log['output'];
+
+            foreach (explode("\n", rtrim($output)) as $line) {
+                $this->line('  <fg=gray>|</> '.$line);
+            }
+        }
+
+        $this->newLine();
     }
 
     protected function getDeploymentMessage(Deployment $deployment): string

--- a/tests/Feature/DeployTest.php
+++ b/tests/Feature/DeployTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Client\Resources\Applications\ListApplicationsRequest;
+use App\Client\Resources\Deployments\GetDeploymentLogsRequest;
 use App\Client\Resources\Deployments\GetDeploymentRequest;
 use App\Client\Resources\Deployments\InitiateDeploymentRequest;
 use App\Client\Resources\Environments\GetEnvironmentRequest;
@@ -39,7 +40,7 @@ function createDeploymentResponse(string $status = 'pending', array $overrides =
             'attributes' => [
                 'status' => $status,
                 'started_at' => now()->toISOString(),
-                'finished_at' => $status === 'deployment.succeeded' || $status === 'deployment.failed'
+                'finished_at' => in_array($status, ['deployment.succeeded', 'deployment.failed', 'build.failed'])
                     ? now()->toISOString()
                     : null,
             ],
@@ -315,4 +316,92 @@ it('deploys to specific application by ID', function () {
         'application' => 'app-123',
         'environment' => 'production',
     ])->assertSuccessful();
+});
+
+function setupFailedDeployMocks(string $failureStatus = 'build.failed', string $failureReason = 'Build failed', array $logs = []): void
+{
+    MockClient::global([
+        ListApplicationsRequest::class => MockResponse::make([
+            'data' => [createApplicationResponse()],
+            'included' => [
+                ['id' => 'org-1', 'type' => 'organizations', 'attributes' => ['name' => 'My Org']],
+                createEnvironmentResponse(),
+            ],
+            'links' => ['next' => null],
+        ], 200),
+
+        ListEnvironmentsRequest::class => MockResponse::make([
+            'data' => [createEnvironmentResponse()],
+            'links' => ['next' => null],
+        ], 200),
+
+        GetEnvironmentRequest::class => MockResponse::make([
+            'data' => createEnvironmentResponse(),
+        ], 200),
+
+        InitiateDeploymentRequest::class => MockResponse::make(
+            createDeploymentResponse('pending'),
+            200,
+        ),
+
+        GetDeploymentRequest::class => MockResponse::make(
+            createDeploymentResponse($failureStatus, [
+                'attributes' => [
+                    'status' => $failureStatus,
+                    'failure_reason' => $failureReason,
+                    'started_at' => now()->toISOString(),
+                    'finished_at' => now()->toISOString(),
+                ],
+            ]),
+            200,
+        ),
+
+        GetDeploymentLogsRequest::class => MockResponse::make([
+            'data' => $logs,
+        ], 200),
+    ]);
+}
+
+it('displays build logs when deployment fails with build error', function () {
+    Prompt::fake();
+
+    $this->mockGit->shouldReceive('hasGitHubRemote')->andReturn(true);
+    $this->mockGit->shouldReceive('remoteRepo')->andReturn('user/my-app');
+
+    setupFailedDeployMocks('build.failed', 'Build failed', [
+        ['type' => 'build', 'timestamp' => now()->toISOString(), 'output' => "Installing dependencies...\nnpm ERR! Could not resolve dependency"],
+    ]);
+
+    $this->artisan('deploy', ['--no-interaction' => true])
+        ->expectsOutputToContain('Build output:')
+        ->expectsOutputToContain('npm ERR! Could not resolve dependency')
+        ->assertFailed();
+});
+
+it('displays deploy logs when deployment fails with deploy error', function () {
+    Prompt::fake();
+
+    $this->mockGit->shouldReceive('hasGitHubRemote')->andReturn(true);
+    $this->mockGit->shouldReceive('remoteRepo')->andReturn('user/my-app');
+
+    setupFailedDeployMocks('deployment.failed', 'Deploy failed', [
+        ['type' => 'deploy', 'timestamp' => now()->toISOString(), 'output' => "Running migrations...\nSQLSTATE[42S02]: Table not found"],
+    ]);
+
+    $this->artisan('deploy', ['--no-interaction' => true])
+        ->expectsOutputToContain('Deploy output:')
+        ->expectsOutputToContain('SQLSTATE[42S02]: Table not found')
+        ->assertFailed();
+});
+
+it('handles failed deployment when logs endpoint returns empty', function () {
+    Prompt::fake();
+
+    $this->mockGit->shouldReceive('hasGitHubRemote')->andReturn(true);
+    $this->mockGit->shouldReceive('remoteRepo')->andReturn('user/my-app');
+
+    setupFailedDeployMocks('build.failed', 'Build failed', []);
+
+    $this->artisan('deploy', ['--no-interaction' => true])
+        ->assertFailed();
 });


### PR DESCRIPTION
## Summary
- Automatically fetches and displays deployment logs when `cloud deploy` or `cloud ship` fails
- Shows which phase failed (Build vs Deploy) with the actual error output
- Adds `GetDeploymentLogsRequest` for `GET /deployments/{id}/logs` and a `logs()` method on `DeploymentsResource`
- Gracefully handles cases where the logs endpoint is unavailable or returns empty

Closes #73

## Example output
```
✗ Deployment failed: Build failed

  Build output:
  | Installing composer dependencies...
  | npm ci --audit false
  | npm ERR! Could not resolve dependency: @inertiajs/vue3@^2.0
  | npm ERR! peer dep missing: vue@^3.0

  Do you want to edit the build and deploy commands and try again?
```

## Test plan
- [x] Added test: displays build logs when deployment fails with build error
- [x] Added test: displays deploy logs when deployment fails with deploy error
- [x] Added test: handles failed deployment when logs endpoint returns empty
- [x] All existing tests pass
- [x] PHPStan passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)