### PR TITLE
feat: add env:pull and env:push commands for .env file sync

### DIFF
--- a/app/Commands/EnvPull.php
+++ b/app/Commands/EnvPull.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Commands;
+
+use function Laravel\Prompts\intro;
+use function Laravel\Prompts\spin;
+
+class EnvPull extends BaseCommand
+{
+    protected $signature = 'env:pull
+                            {environment? : The environment ID or name}
+                            {--output= : Output file path (default: stdout)}
+                            {--json : Output as JSON}';
+
+    protected $description = 'Pull environment variables and output as a .env file';
+
+    public function handle()
+    {
+        $this->ensureClient();
+
+        intro('Pull Environment Variables');
+
+        $environment = $this->resolvers()->environment()->from($this->argument('environment'));
+
+        $variables = $environment->environmentVariables;
+
+        if (empty($variables)) {
+            $this->outputJsonIfWanted(['message' => 'No environment variables found']);
+
+            $this->line('No environment variables found.');
+
+            return self::SUCCESS;
+        }
+
+        $content = collect($variables)
+            ->map(fn (array $var) => $var['key'].'='.$this->formatValue($var['value']))
+            ->implode(PHP_EOL).PHP_EOL;
+
+        if ($this->option('output')) {
+            file_put_contents($this->option('output'), $content);
+
+            $this->outputJsonIfWanted(['message' => 'Environment variables written to '.$this->option('output')]);
+
+            success('Environment variables written to '.$this->option('output'));
+
+            return self::SUCCESS;
+        }
+
+        $this->outputJsonIfWanted(
+            collect($variables)->mapWithKeys(fn (array $var) => [$var['key'] => $var['value']])->toArray()
+        );
+
+        // Output each line individually so test framework can capture it
+        collect($variables)
+            ->each(fn (array $var) => $this->line($var['key'].'='.$this->formatValue($var['value'])));
+
+        return self::SUCCESS;
+    }
+
+    protected function formatValue(string $value): string
+    {
+        if (str_contains($value, ' ') || str_contains($value, '"') || str_contains($value, '#') || str_contains($value, '$') || $value === '') {
+            return '"'.addcslashes($value, '"\\').'"';
+        }
+
+        return $value;
+    }
+}

--- a/app/Commands/EnvPush.php
+++ b/app/Commands/EnvPush.php
@@ -2,6 +2,7 @@
 
 namespace App\Commands;
 
+use App\Client\Requests\AddEnvironmentVariablesRequestData;
 use App\Client\Requests\ReplaceEnvironmentVariablesRequestData;
 use Dotenv\Dotenv;
 
@@ -13,19 +14,22 @@ class EnvPush extends BaseCommand
 {
     protected $signature = 'env:push
                             {environment? : The environment ID or name}
-                            {--file= : Path to .env file (default: .env)}
+                            {--file=.env : Path to .env file}
+                            {--replace : Replace ALL variables (destructive — removes vars not in file)}
                             {--force : Skip confirmation}
                             {--json : Output as JSON}';
 
-    protected $description = 'Push local .env file contents to an environment';
+    protected $description = 'Push local .env file contents to an environment (merge by default)';
 
     public function handle()
     {
         $this->ensureClient();
 
-        intro('Push Environment Variables');
+        $replaceMode = $this->option('replace');
 
-        $filePath = $this->option('file') ?? '.env';
+        intro($replaceMode ? 'Replace Environment Variables' : 'Merge Environment Variables');
+
+        $filePath = $this->option('file');
 
         if (! file_exists($filePath)) {
             $this->failAndExit("File not found: {$filePath}");
@@ -46,14 +50,24 @@ class EnvPush extends BaseCommand
             ->toArray();
 
         if ($this->isInteractive() && ! $this->option('force')) {
-            $this->displayDiff($environment->environmentVariables, $variables);
+            $this->displayDiff($environment->environmentVariables, $variables, $replaceMode);
 
-            if (! confirm(
-                label: 'This will replace ALL environment variables. Continue?',
-                yes: 'Yes, replace all variables',
-                no: 'No, cancel',
-            )) {
-                $this->failAndExit('Cancelled');
+            if ($replaceMode) {
+                if (! confirm(
+                    label: 'This will replace ALL environment variables. Variables not in the file will be removed. Continue?',
+                    yes: 'Yes, replace all variables',
+                    no: 'No, cancel',
+                )) {
+                    $this->failAndExit('Cancelled');
+                }
+            } else {
+                if (! confirm(
+                    label: 'Merge these variables into the environment? (existing vars not in file will be kept)',
+                    yes: 'Yes, merge variables',
+                    no: 'No, cancel',
+                )) {
+                    $this->failAndExit('Cancelled');
+                }
             }
         }
 
@@ -61,24 +75,41 @@ class EnvPush extends BaseCommand
             $this->failAndExit('Use --force to skip confirmation in non-interactive mode.');
         }
 
-        spin(
-            fn () => $this->client->environments()->replaceVariables(
-                new ReplaceEnvironmentVariablesRequestData(
-                    environmentId: $environment->id,
-                    variables: $variables,
+        if ($replaceMode) {
+            spin(
+                fn () => $this->client->environments()->replaceVariables(
+                    new ReplaceEnvironmentVariablesRequestData(
+                        environmentId: $environment->id,
+                        variables: $variables,
+                    ),
                 ),
-            ),
-            'Pushing environment variables...',
-        );
+                'Replacing environment variables...',
+            );
 
-        $this->outputJsonIfWanted('Environment variables replaced');
+            $this->outputJsonIfWanted('Environment variables replaced');
 
-        success('Environment variables replaced ('.count($variables).' variables pushed)');
+            success('Environment variables replaced ('.count($variables).' variables pushed)');
+        } else {
+            spin(
+                fn () => $this->client->environments()->addVariables(
+                    new AddEnvironmentVariablesRequestData(
+                        environmentId: $environment->id,
+                        variables: $variables,
+                        method: 'set',
+                    ),
+                ),
+                'Merging environment variables...',
+            );
+
+            $this->outputJsonIfWanted('Environment variables merged');
+
+            success('Environment variables merged ('.count($variables).' variables pushed)');
+        }
 
         return self::SUCCESS;
     }
 
-    protected function displayDiff(array $currentVars, array $newVars): void
+    protected function displayDiff(array $currentVars, array $newVars, bool $replaceMode = false): void
     {
         $current = collect($currentVars)->keyBy('key');
         $new = collect($newVars)->keyBy('key');
@@ -90,14 +121,25 @@ class EnvPush extends BaseCommand
 
         $this->newLine();
 
+        if ($replaceMode) {
+            $this->line('<fg=yellow>Mode: REPLACE (destructive — vars not in file will be removed)</>');
+        } else {
+            $this->line('<fg=cyan>Mode: MERGE (existing vars not in file will be kept)</>');
+        }
+
+        $this->newLine();
+
         if ($added->isNotEmpty()) {
             $this->line('<info>Added ('.count($added).'):</info>');
             $added->each(fn (array $var) => $this->line("  + {$var['key']}"));
         }
 
-        if ($removed->isNotEmpty()) {
+        if ($replaceMode && $removed->isNotEmpty()) {
             $this->line('<error>Removed ('.count($removed).'):</error>');
             $removed->each(fn (array $var) => $this->line("  - {$var['key']}"));
+        } elseif (! $replaceMode && $removed->isNotEmpty()) {
+            $this->line('<fg=gray>Kept ('.count($removed).'): (not in file, will remain unchanged)</>');
+            $removed->each(fn (array $var) => $this->line("  = {$var['key']}"));
         }
 
         if ($changed->isNotEmpty()) {

--- a/app/Commands/EnvPush.php
+++ b/app/Commands/EnvPush.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\Commands;
+
+use App\Client\Requests\ReplaceEnvironmentVariablesRequestData;
+use Dotenv\Dotenv;
+
+use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\intro;
+use function Laravel\Prompts\spin;
+
+class EnvPush extends BaseCommand
+{
+    protected $signature = 'env:push
+                            {environment? : The environment ID or name}
+                            {--file= : Path to .env file (default: .env)}
+                            {--force : Skip confirmation}
+                            {--json : Output as JSON}';
+
+    protected $description = 'Push local .env file contents to an environment';
+
+    public function handle()
+    {
+        $this->ensureClient();
+
+        intro('Push Environment Variables');
+
+        $filePath = $this->option('file') ?? '.env';
+
+        if (! file_exists($filePath)) {
+            $this->failAndExit("File not found: {$filePath}");
+        }
+
+        $content = file_get_contents($filePath);
+        $parsed = Dotenv::parse($content);
+
+        if (empty($parsed)) {
+            $this->failAndExit('No variables found in '.$filePath);
+        }
+
+        $environment = $this->resolvers()->environment()->from($this->argument('environment'));
+
+        $variables = collect($parsed)
+            ->map(fn (string $value, string $key) => ['key' => $key, 'value' => $value])
+            ->values()
+            ->toArray();
+
+        if ($this->isInteractive() && ! $this->option('force')) {
+            $this->displayDiff($environment->environmentVariables, $variables);
+
+            if (! confirm(
+                label: 'This will replace ALL environment variables. Continue?',
+                yes: 'Yes, replace all variables',
+                no: 'No, cancel',
+            )) {
+                $this->failAndExit('Cancelled');
+            }
+        }
+
+        if (! $this->isInteractive() && ! $this->option('force')) {
+            $this->failAndExit('Use --force to skip confirmation in non-interactive mode.');
+        }
+
+        spin(
+            fn () => $this->client->environments()->replaceVariables(
+                new ReplaceEnvironmentVariablesRequestData(
+                    environmentId: $environment->id,
+                    variables: $variables,
+                ),
+            ),
+            'Pushing environment variables...',
+        );
+
+        $this->outputJsonIfWanted('Environment variables replaced');
+
+        success('Environment variables replaced ('.count($variables).' variables pushed)');
+
+        return self::SUCCESS;
+    }
+
+    protected function displayDiff(array $currentVars, array $newVars): void
+    {
+        $current = collect($currentVars)->keyBy('key');
+        $new = collect($newVars)->keyBy('key');
+
+        $added = $new->diffKeys($current);
+        $removed = $current->diffKeys($new);
+        $changed = $new->filter(fn (array $var) => $current->has($var['key']) && $current->get($var['key'])['value'] !== $var['value']);
+        $unchanged = $new->filter(fn (array $var) => $current->has($var['key']) && $current->get($var['key'])['value'] === $var['value']);
+
+        $this->newLine();
+
+        if ($added->isNotEmpty()) {
+            $this->line('<info>Added ('.count($added).'):</info>');
+            $added->each(fn (array $var) => $this->line("  + {$var['key']}"));
+        }
+
+        if ($removed->isNotEmpty()) {
+            $this->line('<error>Removed ('.count($removed).'):</error>');
+            $removed->each(fn (array $var) => $this->line("  - {$var['key']}"));
+        }
+
+        if ($changed->isNotEmpty()) {
+            $this->line('<comment>Changed ('.count($changed).'):</comment>');
+            $changed->each(fn (array $var) => $this->line("  ~ {$var['key']}"));
+        }
+
+        if ($unchanged->isNotEmpty()) {
+            $this->line('<fg=gray>Unchanged ('.count($unchanged).')</>');
+        }
+
+        $this->newLine();
+    }
+}

--- a/tests/Feature/EnvPullTest.php
+++ b/tests/Feature/EnvPullTest.php
@@ -1,0 +1,128 @@
+<?php
+
+use App\Client\Resources\Applications\ListApplicationsRequest;
+use App\Client\Resources\Environments\GetEnvironmentRequest;
+use App\Client\Resources\Environments\ListEnvironmentsRequest;
+use App\ConfigRepository;
+use App\Git;
+use Laravel\Prompts\Prompt;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+
+beforeEach(function () {
+    $this->mockGit = Mockery::mock(Git::class);
+    $this->mockGit->shouldReceive('isRepo')->andReturn(true)->byDefault();
+    $this->mockGit->shouldReceive('getRoot')->andReturn('/tmp/test-repo')->byDefault();
+    $this->mockGit->shouldReceive('currentBranch')->andReturn('main')->byDefault();
+    $this->app->instance(Git::class, $this->mockGit);
+
+    $this->mockConfig = Mockery::mock(ConfigRepository::class);
+    $this->mockConfig->shouldReceive('apiTokens')->andReturn(collect(['test-api-token']));
+    $this->app->instance(ConfigRepository::class, $this->mockConfig);
+});
+
+afterEach(function () {
+    MockClient::destroyGlobal();
+});
+
+function setupEnvPullMocks(array $envVars = []): void
+{
+    MockClient::global([
+        ListApplicationsRequest::class => MockResponse::make([
+            'data' => [createApplicationResponse()],
+            'included' => [
+                ['id' => 'org-1', 'type' => 'organizations', 'attributes' => ['name' => 'My Org']],
+                createEnvironmentResponse(['attributes' => ['environment_variables' => $envVars]]),
+            ],
+            'links' => ['next' => null],
+        ], 200),
+
+        ListEnvironmentsRequest::class => MockResponse::make([
+            'data' => [createEnvironmentResponse(['attributes' => ['environment_variables' => $envVars]])],
+            'links' => ['next' => null],
+        ], 200),
+
+        GetEnvironmentRequest::class => MockResponse::make([
+            'data' => createEnvironmentResponse(['attributes' => ['environment_variables' => $envVars]]),
+        ], 200),
+    ]);
+}
+
+it('pulls environment variables to a file', function () {
+    Prompt::fake();
+
+    $this->mockGit->shouldReceive('hasGitHubRemote')->andReturn(true);
+    $this->mockGit->shouldReceive('remoteRepo')->andReturn('user/my-app');
+
+    $outputFile = tempnam(sys_get_temp_dir(), 'env_pull_test_');
+
+    setupEnvPullMocks([
+        ['key' => 'APP_NAME', 'value' => 'MyApp'],
+        ['key' => 'APP_KEY', 'value' => 'base64:abc123'],
+    ]);
+
+    $this->artisan('env:pull', [
+        'environment' => 'production',
+        '--output' => $outputFile,
+    ])->assertSuccessful();
+
+    $content = file_get_contents($outputFile);
+    expect($content)->toContain('APP_NAME=MyApp');
+    expect($content)->toContain('APP_KEY=base64:abc123');
+
+    unlink($outputFile);
+});
+
+it('outputs json with --json flag', function () {
+    Prompt::fake();
+
+    $this->mockGit->shouldReceive('hasGitHubRemote')->andReturn(true);
+    $this->mockGit->shouldReceive('remoteRepo')->andReturn('user/my-app');
+
+    setupEnvPullMocks([
+        ['key' => 'APP_NAME', 'value' => 'MyApp'],
+        ['key' => 'DB_HOST', 'value' => 'localhost'],
+    ]);
+
+    $this->artisan('env:pull', [
+        'environment' => 'production',
+        '--json' => true,
+    ])
+        ->expectsOutputToContain('"APP_NAME":"MyApp"')
+        ->assertSuccessful();
+});
+
+it('handles empty environment variables', function () {
+    Prompt::fake();
+
+    $this->mockGit->shouldReceive('hasGitHubRemote')->andReturn(true);
+    $this->mockGit->shouldReceive('remoteRepo')->andReturn('user/my-app');
+
+    setupEnvPullMocks([]);
+
+    $this->artisan('env:pull', ['environment' => 'production'])
+        ->assertSuccessful();
+});
+
+it('quotes values with spaces in output file', function () {
+    Prompt::fake();
+
+    $this->mockGit->shouldReceive('hasGitHubRemote')->andReturn(true);
+    $this->mockGit->shouldReceive('remoteRepo')->andReturn('user/my-app');
+
+    $outputFile = tempnam(sys_get_temp_dir(), 'env_pull_test_');
+
+    setupEnvPullMocks([
+        ['key' => 'APP_NAME', 'value' => 'My Application'],
+    ]);
+
+    $this->artisan('env:pull', [
+        'environment' => 'production',
+        '--output' => $outputFile,
+    ])->assertSuccessful();
+
+    $content = file_get_contents($outputFile);
+    expect($content)->toContain('APP_NAME="My Application"');
+
+    unlink($outputFile);
+});

--- a/tests/Feature/EnvPushTest.php
+++ b/tests/Feature/EnvPushTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Client\Resources\Applications\ListApplicationsRequest;
+use App\Client\Resources\Environments\AddEnvironmentVariablesRequest;
 use App\Client\Resources\Environments\GetEnvironmentRequest;
 use App\Client\Resources\Environments\ListEnvironmentsRequest;
 use App\Client\Resources\Environments\ReplaceEnvironmentVariablesRequest;
@@ -26,7 +27,7 @@ afterEach(function () {
     MockClient::destroyGlobal();
 });
 
-function setupEnvPushMocks(array $existingVars = []): void
+function setupEnvPushMocks(array $existingVars = [], string $requestClass = AddEnvironmentVariablesRequest::class): void
 {
     MockClient::global([
         ListApplicationsRequest::class => MockResponse::make([
@@ -47,11 +48,14 @@ function setupEnvPushMocks(array $existingVars = []): void
             'data' => createEnvironmentResponse(['attributes' => ['environment_variables' => $existingVars]]),
         ], 200),
 
+        AddEnvironmentVariablesRequest::class => MockResponse::make([], 200),
         ReplaceEnvironmentVariablesRequest::class => MockResponse::make([], 200),
     ]);
 }
 
-it('pushes env file with --force flag', function () {
+// --- Merge mode (default) ---
+
+it('merges env variables by default with --force flag', function () {
     Prompt::fake();
 
     $this->mockGit->shouldReceive('hasGitHubRemote')->andReturn(true);
@@ -71,6 +75,55 @@ it('pushes env file with --force flag', function () {
     unlink($envFile);
 });
 
+it('uses addVariables with set method in merge mode', function () {
+    Prompt::fake();
+
+    $this->mockGit->shouldReceive('hasGitHubRemote')->andReturn(true);
+    $this->mockGit->shouldReceive('remoteRepo')->andReturn('user/my-app');
+
+    $envFile = tempnam(sys_get_temp_dir(), 'env_push_test_');
+    file_put_contents($envFile, "APP_NAME=MyApp\n");
+
+    setupEnvPushMocks([
+        ['key' => 'EXISTING_VAR', 'value' => 'keep-me'],
+    ]);
+
+    $this->artisan('env:push', [
+        'environment' => 'production',
+        '--file' => $envFile,
+        '--force' => true,
+    ])->assertSuccessful()
+        ->expectsOutputToContain('merged');
+
+    unlink($envFile);
+});
+
+// --- Replace mode ---
+
+it('replaces env variables when --replace flag is used', function () {
+    Prompt::fake();
+
+    $this->mockGit->shouldReceive('hasGitHubRemote')->andReturn(true);
+    $this->mockGit->shouldReceive('remoteRepo')->andReturn('user/my-app');
+
+    $envFile = tempnam(sys_get_temp_dir(), 'env_push_test_');
+    file_put_contents($envFile, "APP_NAME=MyApp\nAPP_KEY=base64:abc123\n");
+
+    setupEnvPushMocks();
+
+    $this->artisan('env:push', [
+        'environment' => 'production',
+        '--file' => $envFile,
+        '--replace' => true,
+        '--force' => true,
+    ])->assertSuccessful()
+        ->expectsOutputToContain('replaced');
+
+    unlink($envFile);
+});
+
+// --- Common behavior ---
+
 it('fails when env file does not exist', function () {
     Prompt::fake();
 
@@ -81,7 +134,7 @@ it('fails when env file does not exist', function () {
 
     $this->artisan('env:push', [
         'environment' => 'production',
-        '--file' => '/tmp/nonexistent-env-file-' . uniqid(),
+        '--file' => '/tmp/nonexistent-env-file-'.uniqid(),
         '--force' => true,
     ])->assertFailed();
 });
@@ -122,6 +175,42 @@ it('parses env file with quoted values', function () {
         '--file' => $envFile,
         '--force' => true,
     ])->assertSuccessful();
+
+    unlink($envFile);
+});
+
+it('uses default .env file path when --file is not specified', function () {
+    Prompt::fake();
+
+    $this->mockGit->shouldReceive('hasGitHubRemote')->andReturn(true);
+    $this->mockGit->shouldReceive('remoteRepo')->andReturn('user/my-app');
+
+    // The default file is .env which won't exist in test context
+    setupEnvPushMocks();
+
+    $this->artisan('env:push', [
+        'environment' => 'production',
+        '--force' => true,
+    ])->assertFailed(); // .env won't exist
+});
+
+it('fails without --force in non-interactive mode even with --replace', function () {
+    Prompt::fake();
+
+    $this->mockGit->shouldReceive('hasGitHubRemote')->andReturn(true);
+    $this->mockGit->shouldReceive('remoteRepo')->andReturn('user/my-app');
+
+    $envFile = tempnam(sys_get_temp_dir(), 'env_push_test_');
+    file_put_contents($envFile, "APP_NAME=MyApp\n");
+
+    setupEnvPushMocks();
+
+    $this->artisan('env:push', [
+        'environment' => 'production',
+        '--file' => $envFile,
+        '--replace' => true,
+        '--no-interaction' => true,
+    ])->assertFailed();
 
     unlink($envFile);
 });

--- a/tests/Feature/EnvPushTest.php
+++ b/tests/Feature/EnvPushTest.php
@@ -1,0 +1,127 @@
+<?php
+
+use App\Client\Resources\Applications\ListApplicationsRequest;
+use App\Client\Resources\Environments\GetEnvironmentRequest;
+use App\Client\Resources\Environments\ListEnvironmentsRequest;
+use App\Client\Resources\Environments\ReplaceEnvironmentVariablesRequest;
+use App\ConfigRepository;
+use App\Git;
+use Laravel\Prompts\Prompt;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+
+beforeEach(function () {
+    $this->mockGit = Mockery::mock(Git::class);
+    $this->mockGit->shouldReceive('isRepo')->andReturn(true)->byDefault();
+    $this->mockGit->shouldReceive('getRoot')->andReturn('/tmp/test-repo')->byDefault();
+    $this->mockGit->shouldReceive('currentBranch')->andReturn('main')->byDefault();
+    $this->app->instance(Git::class, $this->mockGit);
+
+    $this->mockConfig = Mockery::mock(ConfigRepository::class);
+    $this->mockConfig->shouldReceive('apiTokens')->andReturn(collect(['test-api-token']));
+    $this->app->instance(ConfigRepository::class, $this->mockConfig);
+});
+
+afterEach(function () {
+    MockClient::destroyGlobal();
+});
+
+function setupEnvPushMocks(array $existingVars = []): void
+{
+    MockClient::global([
+        ListApplicationsRequest::class => MockResponse::make([
+            'data' => [createApplicationResponse()],
+            'included' => [
+                ['id' => 'org-1', 'type' => 'organizations', 'attributes' => ['name' => 'My Org']],
+                createEnvironmentResponse(['attributes' => ['environment_variables' => $existingVars]]),
+            ],
+            'links' => ['next' => null],
+        ], 200),
+
+        ListEnvironmentsRequest::class => MockResponse::make([
+            'data' => [createEnvironmentResponse(['attributes' => ['environment_variables' => $existingVars]])],
+            'links' => ['next' => null],
+        ], 200),
+
+        GetEnvironmentRequest::class => MockResponse::make([
+            'data' => createEnvironmentResponse(['attributes' => ['environment_variables' => $existingVars]]),
+        ], 200),
+
+        ReplaceEnvironmentVariablesRequest::class => MockResponse::make([], 200),
+    ]);
+}
+
+it('pushes env file with --force flag', function () {
+    Prompt::fake();
+
+    $this->mockGit->shouldReceive('hasGitHubRemote')->andReturn(true);
+    $this->mockGit->shouldReceive('remoteRepo')->andReturn('user/my-app');
+
+    $envFile = tempnam(sys_get_temp_dir(), 'env_push_test_');
+    file_put_contents($envFile, "APP_NAME=MyApp\nAPP_KEY=base64:abc123\n");
+
+    setupEnvPushMocks();
+
+    $this->artisan('env:push', [
+        'environment' => 'production',
+        '--file' => $envFile,
+        '--force' => true,
+    ])->assertSuccessful();
+
+    unlink($envFile);
+});
+
+it('fails when env file does not exist', function () {
+    Prompt::fake();
+
+    $this->mockGit->shouldReceive('hasGitHubRemote')->andReturn(true);
+    $this->mockGit->shouldReceive('remoteRepo')->andReturn('user/my-app');
+
+    setupEnvPushMocks();
+
+    $this->artisan('env:push', [
+        'environment' => 'production',
+        '--file' => '/tmp/nonexistent-env-file-' . uniqid(),
+        '--force' => true,
+    ])->assertFailed();
+});
+
+it('fails without --force in non-interactive mode', function () {
+    Prompt::fake();
+
+    $this->mockGit->shouldReceive('hasGitHubRemote')->andReturn(true);
+    $this->mockGit->shouldReceive('remoteRepo')->andReturn('user/my-app');
+
+    $envFile = tempnam(sys_get_temp_dir(), 'env_push_test_');
+    file_put_contents($envFile, "APP_NAME=MyApp\n");
+
+    setupEnvPushMocks();
+
+    $this->artisan('env:push', [
+        'environment' => 'production',
+        '--file' => $envFile,
+        '--no-interaction' => true,
+    ])->assertFailed();
+
+    unlink($envFile);
+});
+
+it('parses env file with quoted values', function () {
+    Prompt::fake();
+
+    $this->mockGit->shouldReceive('hasGitHubRemote')->andReturn(true);
+    $this->mockGit->shouldReceive('remoteRepo')->andReturn('user/my-app');
+
+    $envFile = tempnam(sys_get_temp_dir(), 'env_push_test_');
+    file_put_contents($envFile, "APP_NAME=\"My Application\"\nDB_PASSWORD='secret password'\n");
+
+    setupEnvPushMocks();
+
+    $this->artisan('env:push', [
+        'environment' => 'production',
+        '--file' => $envFile,
+        '--force' => true,
+    ])->assertSuccessful();
+
+    unlink($envFile);
+});


### PR DESCRIPTION
## Summary

Adds `env:pull` and `env:push` commands for syncing entire `.env` files between local and remote environments, inspired by the [Forge CLI](https://github.com/laravel/forge-cli).

Refs #76

## Commands

### `env:pull`
```bash
cloud env:pull production > .env.production
cloud env:pull staging --output=.env.staging
cloud env:pull production --json
```
Fetches all environment variables and outputs them in `.env` format. Properly quotes values containing spaces, `#`, `$`, or quotes.

### `env:push`
```bash
cloud env:push staging --file=.env.staging --force
cloud env:push production --file=.env.production --force
```
Parses a local `.env` file and replaces all remote environment variables. Shows an interactive diff of added/removed/changed variables before applying. Requires `--force` in non-interactive mode.

## Important: Design decision needed before merging

### Platform-injected variables risk

Laravel Cloud automatically injects environment variables when you attach resources (databases, caches). For example: `DB_HOST`, `DB_PASSWORD`, `DB_DATABASE`, `CACHE_STORE`.

**Current implementation uses `replaceVariables`** which overwrites ALL variables. This means:

- If your local `.env` uses sqlite but production has a Cloud database attached, pushing would **silently remove** `DB_HOST` and `DB_PASSWORD`
- The app crashes on the next request with no warning about what changed
- There is no undo

### Recommended changes before merging

- [ ] **Default to `addVariables` (merge)** instead of `replaceVariables` — only add/update vars, never remove existing ones
- [ ] **Add `--replace` flag** for the destructive "overwrite all" behaviour as an explicit opt-in
- [ ] **Warn about platform-managed vars** — if the API distinguishes injected from custom vars, show a warning before replacing them
- [ ] **Annotate injected vars on pull** — `env:pull` should mark which vars are platform-managed so users know not to remove them:
  ```env
  # Managed by Laravel Cloud (attached database)
  DB_HOST=ep-xxx.pg.laravel.cloud
  DB_PASSWORD=npg_xxx
  
  # Custom variables  
  APP_NAME=MyApp
  STRIPE_KEY=sk_test_xxx
  ```

### Question for maintainers

Does the API response distinguish between injected (platform-managed) and custom environment variables? If so, both pull and push should respect that distinction to prevent accidental removal of platform config.

## Tests

- `EnvPullTest` — 4 tests: file output, JSON output, empty variables, value quoting
- `EnvPushTest` — 4 tests: force push, missing file error, non-interactive without force, quoted value parsing

## Test plan

- [x] `./vendor/bin/pest` — all tests pass
- [x] `./vendor/bin/phpstan analyse` — 0 errors
- [ ] **Manual test:** Pull vars from a real environment, verify injected vars are included
- [ ] **Manual test:** Push a `.env` that is missing injected vars — verify whether the platform re-injects them or if they are permanently removed
- [ ] **Decision:** Should default be merge (`addVariables`) or replace (`replaceVariables`)?

Generated with [Claude Code](https://claude.com/claude-code)