### PR TITLE
Add cloud status command

### DIFF
--- a/app/Commands/Status.php
+++ b/app/Commands/Status.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace App\Commands;
+
+use App\Dto\Cache;
+use App\Dto\DatabaseCluster;
+use App\Dto\Deployment;
+use Carbon\CarbonImmutable;
+
+use function Laravel\Prompts\intro;
+use function Laravel\Prompts\spin;
+use function Laravel\Prompts\warning;
+
+class Status extends BaseCommand
+{
+    protected $signature = 'status {application? : The application ID or name} {--json : Output as JSON}';
+
+    protected $description = 'Show application health and status overview';
+
+    public function handle()
+    {
+        $this->ensureClient();
+
+        intro('Application Status');
+
+        $application = $this->resolvers()->application()->from($this->argument('application'));
+
+        $environments = collect($application->environments);
+
+        $latestDeployments = spin(function () use ($environments) {
+            return $environments->mapWithKeys(function ($env) {
+                $deployments = $this->client->deployments()->list($env->id)->collect();
+
+                return [$env->id => $deployments->first()];
+            });
+        }, 'Fetching deployments...');
+
+        $databases = spin(
+            fn () => $this->client->databaseClusters()->list()->collect(),
+            'Fetching databases...',
+        );
+
+        $caches = spin(
+            fn () => $this->client->caches()->list()->collect(),
+            'Fetching caches...',
+        );
+
+        if ($this->wantsJson()) {
+            $this->outputJsonIfWanted([
+                'application' => $application->toArray(),
+                'environments' => $environments->map(function ($env) use ($latestDeployments) {
+                    $deployment = $latestDeployments->get($env->id);
+
+                    return [
+                        'id' => $env->id,
+                        'name' => $env->name,
+                        'status' => $env->status,
+                        'latest_deployment' => $deployment ? [
+                            'id' => $deployment->id,
+                            'status' => $deployment->status->value,
+                            'started_at' => $deployment->startedAt?->toISOString(),
+                        ] : null,
+                    ];
+                })->values()->toArray(),
+                'databases' => $databases->map(fn (DatabaseCluster $db) => [
+                    'id' => $db->id,
+                    'name' => $db->name,
+                    'status' => $db->status,
+                ])->values()->toArray(),
+                'caches' => $caches->map(fn (Cache $cache) => [
+                    'id' => $cache->id,
+                    'name' => $cache->name,
+                    'status' => $cache->status,
+                ])->values()->toArray(),
+            ]);
+
+            return;
+        }
+
+        $this->newLine();
+        $this->line("  <options=bold>{$application->name}</>");
+
+        foreach ($environments as $env) {
+            /** @var Deployment|null $deployment */
+            $deployment = $latestDeployments->get($env->id);
+            $deployInfo = $this->formatDeploymentInfo($deployment);
+            $this->line("    {$env->name}: {$env->status}{$deployInfo}");
+        }
+
+        if ($databases->isNotEmpty()) {
+            $this->newLine();
+            foreach ($databases as $db) {
+                $this->line("  Database: {$db->name} ({$db->status})");
+            }
+        }
+
+        if ($caches->isNotEmpty()) {
+            $this->newLine();
+            foreach ($caches as $cache) {
+                $this->line("  Cache: {$cache->name} ({$cache->status})");
+            }
+        }
+
+        if ($databases->isEmpty() && $caches->isEmpty()) {
+            $this->newLine();
+            $this->line('  No databases or caches found.');
+        }
+
+        $this->newLine();
+    }
+
+    protected function formatDeploymentInfo(?Deployment $deployment): string
+    {
+        if (! $deployment) {
+            return '';
+        }
+
+        $parts = [];
+
+        if ($deployment->startedAt) {
+            $parts[] = 'last deploy: '.$deployment->startedAt->diffForHumans(CarbonImmutable::now(), CarbonImmutable::DIFF_ABSOLUTE).' ago';
+        }
+
+        $parts[] = $deployment->status->label();
+
+        return ' ('.implode(', ', $parts).')';
+    }
+}

--- a/tests/Feature/StatusTest.php
+++ b/tests/Feature/StatusTest.php
@@ -1,0 +1,165 @@
+<?php
+
+use App\Client\Resources\Applications\GetApplicationRequest;
+use App\Client\Resources\Applications\ListApplicationsRequest;
+use App\Client\Resources\Caches\ListCachesRequest;
+use App\Client\Resources\DatabaseClusters\ListDatabaseClustersRequest;
+use App\Client\Resources\Deployments\ListDeploymentsRequest;
+use App\ConfigRepository;
+use App\Git;
+use Laravel\Prompts\Prompt;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+
+beforeEach(function () {
+    $this->mockGit = Mockery::mock(Git::class);
+    $this->mockGit->shouldReceive('isRepo')->andReturn(true)->byDefault();
+    $this->mockGit->shouldReceive('getRoot')->andReturn('/tmp/test-repo')->byDefault();
+    $this->mockGit->shouldReceive('currentBranch')->andReturn('main')->byDefault();
+    $this->app->instance(Git::class, $this->mockGit);
+
+    $this->mockConfig = Mockery::mock(ConfigRepository::class);
+    $this->mockConfig->shouldReceive('apiTokens')->andReturn(collect(['test-api-token']));
+    $this->app->instance(ConfigRepository::class, $this->mockConfig);
+});
+
+afterEach(function () {
+    MockClient::destroyGlobal();
+});
+
+function setupStatusMocks(array $overrides = []): void
+{
+    $defaults = [
+        'deployments' => [
+            [
+                'id' => 'deploy-1',
+                'type' => 'deployments',
+                'attributes' => [
+                    'status' => 'deployment.succeeded',
+                    'started_at' => now()->subHours(2)->toISOString(),
+                    'finished_at' => now()->subHours(2)->addMinutes(3)->toISOString(),
+                    'branch_name' => 'main',
+                    'commit' => ['hash' => 'abc1234', 'message' => 'fix bug', 'author' => 'dev'],
+                ],
+            ],
+        ],
+        'databases' => [
+            [
+                'id' => 'db-1',
+                'type' => 'databaseClusters',
+                'attributes' => [
+                    'name' => 'my-app-db',
+                    'type' => 'mysql',
+                    'status' => 'available',
+                    'region' => 'us-east-1',
+                    'config' => [],
+                    'connection' => [],
+                ],
+            ],
+        ],
+        'caches' => [
+            [
+                'id' => 'cache-1',
+                'type' => 'caches',
+                'attributes' => [
+                    'name' => 'my-app-cache',
+                    'type' => 'redis',
+                    'status' => 'available',
+                    'region' => 'us-east-1',
+                    'size' => '256MB',
+                    'auto_upgrade_enabled' => false,
+                    'is_public' => false,
+                ],
+            ],
+        ],
+    ];
+
+    $data = array_merge($defaults, $overrides);
+
+    MockClient::global([
+        GetApplicationRequest::class => MockResponse::make([
+            'data' => createApplicationResponse(),
+            'included' => [
+                ['id' => 'org-1', 'type' => 'organizations', 'attributes' => ['name' => 'My Org', 'slug' => 'my-org']],
+                createEnvironmentResponse(),
+            ],
+        ], 200),
+
+        ListApplicationsRequest::class => MockResponse::make([
+            'data' => [createApplicationResponse()],
+            'included' => [
+                ['id' => 'org-1', 'type' => 'organizations', 'attributes' => ['name' => 'My Org', 'slug' => 'my-org']],
+                createEnvironmentResponse(),
+            ],
+            'links' => ['next' => null],
+        ], 200),
+
+        ListDeploymentsRequest::class => MockResponse::make([
+            'data' => $data['deployments'],
+            'links' => ['next' => null],
+        ], 200),
+
+        ListDatabaseClustersRequest::class => MockResponse::make([
+            'data' => $data['databases'],
+            'links' => ['next' => null],
+        ], 200),
+
+        ListCachesRequest::class => MockResponse::make([
+            'data' => $data['caches'],
+            'links' => ['next' => null],
+        ], 200),
+    ]);
+}
+
+it('displays application status overview', function () {
+    Prompt::fake();
+
+    $this->mockGit->shouldReceive('hasGitHubRemote')->andReturn(true);
+    $this->mockGit->shouldReceive('remoteRepo')->andReturn('user/my-app');
+
+    setupStatusMocks();
+
+    $this->artisan('status', ['application' => 'app-123'])
+        ->assertSuccessful();
+});
+
+it('displays status with no databases or caches', function () {
+    Prompt::fake();
+
+    $this->mockGit->shouldReceive('hasGitHubRemote')->andReturn(true);
+    $this->mockGit->shouldReceive('remoteRepo')->andReturn('user/my-app');
+
+    setupStatusMocks([
+        'databases' => [],
+        'caches' => [],
+    ]);
+
+    $this->artisan('status', ['application' => 'app-123'])
+        ->assertSuccessful();
+});
+
+it('displays status with no deployments', function () {
+    Prompt::fake();
+
+    $this->mockGit->shouldReceive('hasGitHubRemote')->andReturn(true);
+    $this->mockGit->shouldReceive('remoteRepo')->andReturn('user/my-app');
+
+    setupStatusMocks([
+        'deployments' => [],
+    ]);
+
+    $this->artisan('status', ['application' => 'app-123'])
+        ->assertSuccessful();
+});
+
+it('outputs json when json flag is provided', function () {
+    Prompt::fake();
+
+    $this->mockGit->shouldReceive('hasGitHubRemote')->andReturn(true);
+    $this->mockGit->shouldReceive('remoteRepo')->andReturn('user/my-app');
+
+    setupStatusMocks();
+
+    $this->artisan('status', ['application' => 'app-123', '--json' => true])
+        ->assertSuccessful();
+});


### PR DESCRIPTION
## Summary
- Adds a new `status` command that shows application health at a glance: environment statuses, latest deployment per environment (with time ago and result), database clusters, and caches
- Supports `--json` flag for structured output, suitable for scripting and CI
- Resolves #96 — previously users had to run `environment:get`, `deployment:list`, `database-cluster:list`, and `cache:list` separately

## Test plan
- [ ] Run `cloud status` with a single application and verify environment, deployment, database, and cache info renders correctly
- [ ] Run `cloud status my-app` with an explicit application name/ID
- [ ] Run `cloud status --json` and verify valid JSON output with all expected fields
- [ ] Run `cloud status` with no databases/caches and verify graceful "No databases or caches found" message
- [ ] Run `./vendor/bin/pest tests/Feature/StatusTest.php` — 4 tests pass
- [ ] Run `./vendor/bin/phpstan analyse` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)