### PR TITLE
Add debug, health check, and ci:setup commands

### DIFF
--- a/app/Commands/CiSetup.php
+++ b/app/Commands/CiSetup.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Commands;
+
+use App\Contracts\NoAuthRequired;
+
+use function Laravel\Prompts\error;
+use function Laravel\Prompts\info;
+use function Laravel\Prompts\intro;
+use function Laravel\Prompts\warning;
+
+class CiSetup extends BaseCommand implements NoAuthRequired
+{
+    protected $signature = 'ci:setup
+                            {--provider=github-actions : CI provider}
+                            {--branch=main : Branch to deploy from}
+                            {--force : Overwrite existing workflow file}';
+
+    protected $description = 'Generate CI/CD workflow configuration for deploying to Laravel Cloud';
+
+    public function handle()
+    {
+        intro('CI/CD Setup');
+
+        $provider = $this->option('provider');
+        $branch = $this->option('branch');
+
+        if ($provider !== 'github-actions') {
+            error("Unsupported CI provider: {$provider}. Currently only 'github-actions' is supported.");
+
+            return self::FAILURE;
+        }
+
+        return $this->setupGitHubActions($branch);
+    }
+
+    protected function setupGitHubActions(string $branch): int
+    {
+        $workflowDir = getcwd().'/.github/workflows';
+        $workflowFile = $workflowDir.'/cloud-deploy.yml';
+
+        if (file_exists($workflowFile) && ! $this->option('force')) {
+            warning('Workflow file already exists: .github/workflows/cloud-deploy.yml');
+            info('Use --force to overwrite the existing file.');
+
+            return self::FAILURE;
+        }
+
+        if (! is_dir($workflowDir)) {
+            mkdir($workflowDir, 0755, true);
+        }
+
+        $template = $this->getGitHubActionsTemplate($branch);
+
+        file_put_contents($workflowFile, $template);
+
+        info('Created .github/workflows/cloud-deploy.yml');
+
+        $this->line('');
+        intro('Next Steps');
+        $this->line('  1. Add your <comment>LARAVEL_CLOUD_API_TOKEN</comment> as a GitHub repository secret');
+        $this->line('     Go to: Settings > Secrets and variables > Actions > New repository secret');
+        $this->line('');
+        $this->line('  2. Commit and push the workflow file:');
+        $this->line('     <comment>git add .github/workflows/cloud-deploy.yml</comment>');
+        $this->line('     <comment>git commit -m "Add Laravel Cloud deploy workflow"</comment>');
+        $this->line('     <comment>git push</comment>');
+        $this->line('');
+        $this->line("  3. Push to <comment>{$branch}</comment> to trigger a deployment");
+
+        return self::SUCCESS;
+    }
+
+    protected function getGitHubActionsTemplate(string $branch): string
+    {
+        return <<<YAML
+name: Deploy to Laravel Cloud
+
+on:
+  push:
+    branches:
+      - {$branch}
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+
+      - name: Install Laravel Cloud CLI
+        run: composer global require laravel/cloud-cli
+
+      - name: Deploy to Laravel Cloud
+        env:
+          LARAVEL_CLOUD_API_TOKEN: \${{ secrets.LARAVEL_CLOUD_API_TOKEN }}
+        run: cloud deploy --no-interaction
+
+YAML;
+    }
+}

--- a/app/Commands/Debug.php
+++ b/app/Commands/Debug.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace App\Commands;
+
+use Carbon\CarbonImmutable;
+
+use function Laravel\Prompts\intro;
+use function Laravel\Prompts\spin;
+use function Laravel\Prompts\warning;
+
+class Debug extends BaseCommand
+{
+    protected $signature = 'debug
+                            {application? : Application ID or name}
+                            {environment? : Environment ID or name}
+                            {--json : Output as JSON}';
+
+    protected $description = 'Show diagnostic information for an environment';
+
+    public function handle()
+    {
+        $this->ensureClient();
+
+        intro('Environment Diagnostics');
+
+        $app = $this->resolvers()->application()->from($this->argument('application'));
+        $environment = $this->resolvers()->environment()->withApplication($app)->from($this->argument('environment'));
+
+        $diagnostics = spin(function () use ($environment) {
+            return $this->gatherDiagnostics($environment);
+        }, 'Gathering diagnostics...');
+
+        $this->outputJsonIfWanted($diagnostics);
+
+        $this->displayDiagnostics($diagnostics, $environment);
+    }
+
+    protected function gatherDiagnostics(mixed $environment): array
+    {
+        $diagnostics = [
+            'environment' => [
+                'id' => $environment->id,
+                'name' => $environment->name,
+                'status' => $environment->status,
+                'url' => $environment->url,
+                'php_version' => $environment->phpMajorVersion,
+                'instance_count' => count($environment->instances ?? []),
+                'env_var_count' => count($environment->environmentVariables ?? []),
+            ],
+            'deployments' => [],
+            'recent_errors' => [],
+            'databases' => [],
+            'caches' => [],
+        ];
+
+        // Fetch last 3 deployments
+        try {
+            $deployments = $this->client->deployments()->list($environment->id);
+            $items = $deployments->collect()->take(3);
+
+            $diagnostics['deployments'] = $items->map(fn ($d) => [
+                'id' => $d->id,
+                'status' => $d->status->value,
+                'commit' => $d->commitHash ? substr($d->commitHash, 0, 7) : null,
+                'started_at' => $d->startedAt?->toDateTimeString(),
+                'finished_at' => $d->finishedAt?->toDateTimeString(),
+            ])->values()->toArray();
+        } catch (\Throwable) {
+            // Continue gathering other diagnostics
+        }
+
+        // Fetch recent logs (last 5 minutes), filter for errors
+        try {
+            $from = CarbonImmutable::now()->subMinutes(5);
+            $to = CarbonImmutable::now();
+            $logs = $this->client->environments()->logs($environment->id, $from, $to);
+
+            $diagnostics['recent_errors'] = collect($logs)
+                ->filter(fn ($log) => isset($log['level']) && in_array($log['level'], ['error', 'warning']))
+                ->take(10)
+                ->map(fn ($log) => [
+                    'level' => $log['level'] ?? 'unknown',
+                    'message' => $log['message'] ?? '',
+                    'logged_at' => $log['logged_at'] ?? null,
+                ])
+                ->values()
+                ->toArray();
+        } catch (\Throwable) {
+            // Continue gathering other diagnostics
+        }
+
+        // Fetch database clusters
+        try {
+            $databases = $this->client->databaseClusters()->list();
+            $diagnostics['databases'] = $databases->collect()->map(fn ($db) => [
+                'id' => $db->id,
+                'name' => $db->name,
+                'type' => $db->type,
+                'status' => $db->status,
+                'region' => $db->region,
+            ])->values()->toArray();
+        } catch (\Throwable) {
+            // Continue gathering other diagnostics
+        }
+
+        // Fetch caches
+        try {
+            $caches = $this->client->caches()->list();
+            $diagnostics['caches'] = $caches->collect()->map(fn ($cache) => [
+                'id' => $cache->id,
+                'name' => $cache->name,
+                'type' => $cache->type,
+                'status' => $cache->status,
+                'region' => $cache->region,
+            ])->values()->toArray();
+        } catch (\Throwable) {
+            // Continue gathering other diagnostics
+        }
+
+        return $diagnostics;
+    }
+
+    protected function displayDiagnostics(array $diagnostics, mixed $environment): void
+    {
+        // Environment overview
+        intro('Environment');
+
+        dataList([
+            'ID' => $diagnostics['environment']['id'],
+            'Name' => $diagnostics['environment']['name'],
+            'Status' => $diagnostics['environment']['status'] ?? 'N/A',
+            'URL' => $diagnostics['environment']['url'] ?: 'N/A',
+            'PHP Version' => $diagnostics['environment']['php_version'],
+            'Instances' => (string) $diagnostics['environment']['instance_count'],
+            'Environment Variables' => (string) $diagnostics['environment']['env_var_count'],
+        ]);
+
+        // Recent deployments
+        intro('Recent Deployments');
+
+        if (empty($diagnostics['deployments'])) {
+            warning('No deployments found.');
+        } else {
+            dataTable(
+                headers: ['ID', 'Status', 'Commit', 'Started', 'Finished'],
+                rows: collect($diagnostics['deployments'])->map(fn ($d) => [
+                    $d['id'],
+                    $d['status'],
+                    $d['commit'] ?? 'N/A',
+                    $d['started_at'] ?? 'N/A',
+                    $d['finished_at'] ?? 'N/A',
+                ])->toArray(),
+            );
+        }
+
+        // Recent errors
+        intro('Recent Errors (last 5 min)');
+
+        if (empty($diagnostics['recent_errors'])) {
+            $this->line('  <info>No recent errors found.</info>');
+        } else {
+            foreach ($diagnostics['recent_errors'] as $error) {
+                $level = strtoupper($error['level']);
+                $this->line("  [{$level}] {$error['message']}");
+            }
+        }
+
+        // Resources
+        intro('Resources');
+
+        if (empty($diagnostics['databases'])) {
+            $this->line('  <comment>Databases:</comment> None');
+        } else {
+            foreach ($diagnostics['databases'] as $db) {
+                $this->line("  <comment>Database:</comment> {$db['name']} ({$db['type']}) — {$db['status']}");
+            }
+        }
+
+        if (empty($diagnostics['caches'])) {
+            $this->line('  <comment>Caches:</comment> None');
+        } else {
+            foreach ($diagnostics['caches'] as $cache) {
+                $this->line("  <comment>Cache:</comment> {$cache['name']} ({$cache['type']}) — {$cache['status']}");
+            }
+        }
+    }
+}

--- a/app/Commands/Deploy.php
+++ b/app/Commands/Deploy.php
@@ -6,10 +6,12 @@ use App\Client\Requests\InitiateDeploymentRequestData;
 use App\Concerns\RequiresRemoteGitRepo;
 use App\Concerns\UpdatesBuildDeployCommands;
 use App\Dto\Deployment;
+use App\Dto\Environment;
 use App\Exceptions\CommandExitException;
 use Carbon\CarbonImmutable;
 use Carbon\CarbonInterval;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Process;
 use Illuminate\Support\Sleep;
 
@@ -95,6 +97,8 @@ class Deploy extends BaseCommand
 
         success('Deployment completed in <comment>'.$deployment->totalTime()->format('%I:%S').'</comment>');
 
+        $this->runHealthCheck($environment);
+
         if ($this->option('open')) {
             Process::run('open '.$environment->url);
         }
@@ -108,6 +112,38 @@ class Deploy extends BaseCommand
         ]);
 
         outro($environment->url);
+    }
+
+    protected function runHealthCheck(Environment $environment): void
+    {
+        if (empty($environment->url)) {
+            return;
+        }
+
+        try {
+            $response = Http::timeout(10)->get($environment->url.'/up');
+
+            if ($response->status() === 200) {
+                success('Health check: /up returned 200');
+            } else {
+                warning('Health check: /up returned '.$response->status());
+
+                try {
+                    $from = CarbonImmutable::now()->subMinutes(2);
+                    $to = CarbonImmutable::now();
+                    $logs = $this->client->environments()->logs($environment->id, $from, $to);
+                    $recentLogs = array_slice($logs, -3);
+
+                    foreach ($recentLogs as $log) {
+                        $this->line('  '.($log['message'] ?? ''));
+                    }
+                } catch (\Throwable) {
+                    // Don't fail on log fetch errors
+                }
+            }
+        } catch (\Throwable) {
+            warning('Health check: Could not reach '.$environment->url.'/up');
+        }
     }
 
     protected function updateDeploymentStatus(Deployment $deployment, callable $updateMessage): void

--- a/tests/Feature/CiSetupTest.php
+++ b/tests/Feature/CiSetupTest.php
@@ -1,0 +1,78 @@
+<?php
+
+use Illuminate\Support\Facades\File;
+
+beforeEach(function () {
+    $this->testDir = sys_get_temp_dir().'/cloud-cli-test-'.uniqid();
+    mkdir($this->testDir, 0755, true);
+    chdir($this->testDir);
+});
+
+afterEach(function () {
+    if (is_dir($this->testDir)) {
+        // Clean up
+        $files = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($this->testDir, RecursiveDirectoryIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($files as $file) {
+            if ($file->isDir()) {
+                rmdir($file->getRealPath());
+            } else {
+                unlink($file->getRealPath());
+            }
+        }
+
+        rmdir($this->testDir);
+    }
+});
+
+it('creates a github actions workflow file', function () {
+    $this->artisan('ci:setup')
+        ->assertSuccessful();
+
+    $workflowFile = $this->testDir.'/.github/workflows/cloud-deploy.yml';
+    expect(file_exists($workflowFile))->toBeTrue();
+
+    $content = file_get_contents($workflowFile);
+    expect($content)->toContain('Deploy to Laravel Cloud');
+    expect($content)->toContain('LARAVEL_CLOUD_API_TOKEN');
+    expect($content)->toContain('cloud deploy --no-interaction');
+    expect($content)->toContain('- main');
+});
+
+it('creates workflow with custom branch', function () {
+    $this->artisan('ci:setup', ['--branch' => 'develop'])
+        ->assertSuccessful();
+
+    $workflowFile = $this->testDir.'/.github/workflows/cloud-deploy.yml';
+    $content = file_get_contents($workflowFile);
+    expect($content)->toContain('- develop');
+});
+
+it('fails if workflow file already exists without force flag', function () {
+    // Create the file first
+    mkdir($this->testDir.'/.github/workflows', 0755, true);
+    file_put_contents($this->testDir.'/.github/workflows/cloud-deploy.yml', 'existing');
+
+    $this->artisan('ci:setup')
+        ->assertFailed();
+});
+
+it('overwrites existing file with force flag', function () {
+    // Create the file first
+    mkdir($this->testDir.'/.github/workflows', 0755, true);
+    file_put_contents($this->testDir.'/.github/workflows/cloud-deploy.yml', 'existing');
+
+    $this->artisan('ci:setup', ['--force' => true])
+        ->assertSuccessful();
+
+    $content = file_get_contents($this->testDir.'/.github/workflows/cloud-deploy.yml');
+    expect($content)->toContain('Deploy to Laravel Cloud');
+});
+
+it('rejects unsupported providers', function () {
+    $this->artisan('ci:setup', ['--provider' => 'gitlab'])
+        ->assertFailed();
+});

--- a/tests/Feature/DebugTest.php
+++ b/tests/Feature/DebugTest.php
@@ -1,0 +1,125 @@
+<?php
+
+use App\Client\Resources\Applications\ListApplicationsRequest;
+use App\Client\Resources\Caches\ListCachesRequest;
+use App\Client\Resources\DatabaseClusters\ListDatabaseClustersRequest;
+use App\Client\Resources\Deployments\ListDeploymentsRequest;
+use App\Client\Resources\Environments\GetEnvironmentRequest;
+use App\Client\Resources\Environments\ListEnvironmentLogsRequest;
+use App\Client\Resources\Environments\ListEnvironmentsRequest;
+use App\ConfigRepository;
+use App\Git;
+use Laravel\Prompts\Prompt;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+
+beforeEach(function () {
+    $this->mockConfig = Mockery::mock(ConfigRepository::class);
+    $this->mockConfig->shouldReceive('apiTokens')->andReturn(collect(['test-api-token']));
+    $this->app->instance(ConfigRepository::class, $this->mockConfig);
+});
+
+afterEach(function () {
+    MockClient::destroyGlobal();
+});
+
+function setupDebugMocks(): void
+{
+    MockClient::global([
+        ListApplicationsRequest::class => MockResponse::make([
+            'data' => [createApplicationResponse()],
+            'included' => [
+                ['id' => 'org-1', 'type' => 'organizations', 'attributes' => ['name' => 'My Org']],
+                createEnvironmentResponse(),
+            ],
+            'links' => ['next' => null],
+        ], 200),
+
+        ListEnvironmentsRequest::class => MockResponse::make([
+            'data' => [createEnvironmentResponse()],
+            'links' => ['next' => null],
+        ], 200),
+
+        GetEnvironmentRequest::class => MockResponse::make([
+            'data' => createEnvironmentResponse(),
+        ], 200),
+
+        ListDeploymentsRequest::class => MockResponse::make([
+            'data' => [
+                [
+                    'id' => 'deploy-1',
+                    'type' => 'deployments',
+                    'attributes' => [
+                        'status' => 'deployment.succeeded',
+                        'commit' => ['hash' => 'abc1234567890'],
+                        'started_at' => now()->subMinutes(10)->toISOString(),
+                        'finished_at' => now()->subMinutes(8)->toISOString(),
+                        'branch_name' => 'main',
+                        'php_major_version' => '8.3',
+                    ],
+                ],
+            ],
+            'links' => ['next' => null],
+        ], 200),
+
+        ListEnvironmentLogsRequest::class => MockResponse::make([], 200),
+
+        ListDatabaseClustersRequest::class => MockResponse::make([
+            'data' => [
+                [
+                    'id' => 'db-1',
+                    'type' => 'databaseClusters',
+                    'attributes' => [
+                        'name' => 'my-db',
+                        'type' => 'mysql',
+                        'status' => 'running',
+                        'region' => 'us-east-1',
+                        'config' => [],
+                        'connection' => [],
+                    ],
+                ],
+            ],
+            'links' => ['next' => null],
+        ], 200),
+
+        ListCachesRequest::class => MockResponse::make([
+            'data' => [
+                [
+                    'id' => 'cache-1',
+                    'type' => 'caches',
+                    'attributes' => [
+                        'name' => 'my-cache',
+                        'type' => 'redis',
+                        'status' => 'running',
+                        'region' => 'us-east-1',
+                        'size' => '256mb',
+                        'auto_upgrade_enabled' => false,
+                        'is_public' => false,
+                    ],
+                ],
+            ],
+            'links' => ['next' => null],
+        ], 200),
+    ]);
+}
+
+it('displays diagnostic information for an environment', function () {
+    Prompt::fake();
+    setupDebugMocks();
+
+    $this->artisan('debug', [
+        'application' => 'My App',
+        'environment' => 'production',
+    ])->assertSuccessful();
+});
+
+it('outputs json when --json flag is provided', function () {
+    Prompt::fake();
+    setupDebugMocks();
+
+    $this->artisan('debug', [
+        'application' => 'My App',
+        'environment' => 'production',
+        '--json' => true,
+    ])->assertSuccessful();
+});

--- a/tests/Feature/DeployHealthCheckTest.php
+++ b/tests/Feature/DeployHealthCheckTest.php
@@ -1,0 +1,123 @@
+<?php
+
+use App\Client\Resources\Applications\ListApplicationsRequest;
+use App\Client\Resources\Deployments\GetDeploymentRequest;
+use App\Client\Resources\Deployments\InitiateDeploymentRequest;
+use App\Client\Resources\Environments\GetEnvironmentRequest;
+use App\Client\Resources\Environments\ListEnvironmentsRequest;
+use App\ConfigRepository;
+use App\Git;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Sleep;
+use Laravel\Prompts\Prompt;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+
+beforeEach(function () {
+    Sleep::fake();
+
+    $this->mockGit = Mockery::mock(Git::class);
+    $this->mockGit->shouldReceive('isRepo')->andReturn(true)->byDefault();
+    $this->mockGit->shouldReceive('getRoot')->andReturn('/tmp/test-repo')->byDefault();
+    $this->mockGit->shouldReceive('currentBranch')->andReturn('main')->byDefault();
+    $this->mockGit->shouldReceive('hasGitHubRemote')->andReturn(true)->byDefault();
+    $this->mockGit->shouldReceive('remoteRepo')->andReturn('user/my-app')->byDefault();
+    $this->app->instance(Git::class, $this->mockGit);
+
+    $this->mockConfig = Mockery::mock(ConfigRepository::class);
+    $this->mockConfig->shouldReceive('apiTokens')->andReturn(collect(['test-api-token']));
+    $this->app->instance(ConfigRepository::class, $this->mockConfig);
+});
+
+afterEach(function () {
+    MockClient::destroyGlobal();
+});
+
+function setupDeployWithHealthCheckMocks(): void
+{
+    MockClient::global([
+        ListApplicationsRequest::class => MockResponse::make([
+            'data' => [createApplicationResponse()],
+            'included' => [
+                ['id' => 'org-1', 'type' => 'organizations', 'attributes' => ['name' => 'My Org']],
+                createEnvironmentResponse(),
+            ],
+            'links' => ['next' => null],
+        ], 200),
+
+        ListEnvironmentsRequest::class => MockResponse::make([
+            'data' => [createEnvironmentResponse()],
+            'links' => ['next' => null],
+        ], 200),
+
+        GetEnvironmentRequest::class => MockResponse::make([
+            'data' => createEnvironmentResponse(),
+        ], 200),
+
+        InitiateDeploymentRequest::class => MockResponse::make([
+            'data' => [
+                'id' => 'deploy-123',
+                'type' => 'deployments',
+                'attributes' => [
+                    'status' => 'pending',
+                    'started_at' => now()->toISOString(),
+                    'finished_at' => null,
+                ],
+            ],
+        ], 200),
+
+        GetDeploymentRequest::class => MockResponse::make([
+            'data' => [
+                'id' => 'deploy-123',
+                'type' => 'deployments',
+                'attributes' => [
+                    'status' => 'deployment.succeeded',
+                    'started_at' => now()->toISOString(),
+                    'finished_at' => now()->toISOString(),
+                ],
+            ],
+        ], 200),
+    ]);
+}
+
+it('performs health check after successful deployment', function () {
+    Prompt::fake();
+    setupDeployWithHealthCheckMocks();
+
+    Http::fake([
+        'https://my-app.cloud.laravel.com/up' => Http::response('OK', 200),
+    ]);
+
+    $this->artisan('deploy', [
+        'application' => 'My App',
+        'environment' => 'production',
+    ])->assertSuccessful();
+});
+
+it('warns when health check returns non-200 status', function () {
+    Prompt::fake();
+    setupDeployWithHealthCheckMocks();
+
+    Http::fake([
+        'https://my-app.cloud.laravel.com/up' => Http::response('Service Unavailable', 503),
+    ]);
+
+    $this->artisan('deploy', [
+        'application' => 'My App',
+        'environment' => 'production',
+    ])->assertSuccessful();
+});
+
+it('handles health check connection failure gracefully', function () {
+    Prompt::fake();
+    setupDeployWithHealthCheckMocks();
+
+    Http::fake([
+        'https://my-app.cloud.laravel.com/up' => Http::response('', 500),
+    ]);
+
+    $this->artisan('deploy', [
+        'application' => 'My App',
+        'environment' => 'production',
+    ])->assertSuccessful();
+});


### PR DESCRIPTION
## Summary

- **`cloud debug` command** (#97): Displays diagnostic information for an environment including last 3 deployments, recent errors (last 5 min), resource status (databases, caches), instance count, and env var count (not values). Supports `--json` for automation.
- **Post-deploy health check** (#98): After a successful deployment in `Deploy.php`, automatically hits the `/up` endpoint. Reports 200 success or warns with recent log entries on failure. Informational only — never fails the deploy command.
- **`cloud ci:setup` command** (#99): Generates a `.github/workflows/cloud-deploy.yml` GitHub Actions workflow for automated deploys. Implements `NoAuthRequired` (no API token needed). Supports `--branch`, `--provider`, and `--force` flags.

Closes #97, closes #98, closes #99

## Test plan

- [x] All 10 new tests pass (`DebugTest`, `CiSetupTest`, `DeployHealthCheckTest`)
- [x] All 41 existing + new tests pass (`./vendor/bin/pest`)
- [x] PHPStan level 5 passes with no errors
- [ ] Manual test: `cloud debug` with a real environment
- [ ] Manual test: `cloud deploy` and verify health check output
- [ ] Manual test: `cloud ci:setup` generates correct workflow file

🤖 Generated with [Claude Code](https://claude.com/claude-code)