### PR TITLE
[main] [bug] Fix Saloon RequestException import in 7 delete commands

### DIFF
--- a/AI_BEST_PRACTICES.md
+++ b/AI_BEST_PRACTICES.md
@@ -10,10 +10,10 @@ The `CloudClient` uses `->throw()` which means **all HTTP errors throw exception
 ```php
 try {
     $application = $client->getApplication($applicationId);
-} catch (Illuminate\Http\Client\RequestException $e) {
+} catch (Saloon\Exceptions\Request\RequestException $e) {
     // Handle error
-    $statusCode = $e->response->status();
-    $errorBody = $e->response->json();
+    $statusCode = $e->getResponse()->status();
+    $errorBody = $e->getResponse()->json();
 }
 ```
 

--- a/app/Commands/ApplicationDelete.php
+++ b/app/Commands/ApplicationDelete.php
@@ -2,7 +2,7 @@
 
 namespace App\Commands;
 
-use Illuminate\Http\Client\RequestException;
+use Saloon\Exceptions\Request\RequestException;
 
 use function Laravel\Prompts\error;
 use function Laravel\Prompts\intro;

--- a/app/Commands/BackgroundProcessDelete.php
+++ b/app/Commands/BackgroundProcessDelete.php
@@ -2,7 +2,7 @@
 
 namespace App\Commands;
 
-use Illuminate\Http\Client\RequestException;
+use Saloon\Exceptions\Request\RequestException;
 
 use function Laravel\Prompts\error;
 use function Laravel\Prompts\intro;

--- a/app/Commands/DatabaseClusterDelete.php
+++ b/app/Commands/DatabaseClusterDelete.php
@@ -3,8 +3,8 @@
 namespace App\Commands;
 
 use Carbon\CarbonInterval;
-use Saloon\Exceptions\Request\RequestException;
 use Illuminate\Support\Sleep;
+use Saloon\Exceptions\Request\RequestException;
 
 use function Laravel\Prompts\error;
 use function Laravel\Prompts\intro;

--- a/app/Commands/DatabaseClusterDelete.php
+++ b/app/Commands/DatabaseClusterDelete.php
@@ -3,7 +3,7 @@
 namespace App\Commands;
 
 use Carbon\CarbonInterval;
-use Illuminate\Http\Client\RequestException;
+use Saloon\Exceptions\Request\RequestException;
 use Illuminate\Support\Sleep;
 
 use function Laravel\Prompts\error;

--- a/app/Commands/DomainDelete.php
+++ b/app/Commands/DomainDelete.php
@@ -2,7 +2,7 @@
 
 namespace App\Commands;
 
-use Illuminate\Http\Client\RequestException;
+use Saloon\Exceptions\Request\RequestException;
 
 use function Laravel\Prompts\error;
 use function Laravel\Prompts\intro;

--- a/app/Commands/DomainVerify.php
+++ b/app/Commands/DomainVerify.php
@@ -3,7 +3,7 @@
 namespace App\Commands;
 
 use App\Dto\Domain;
-use Illuminate\Http\Client\RequestException;
+use Saloon\Exceptions\Request\RequestException;
 
 use function Laravel\Prompts\error;
 use function Laravel\Prompts\intro;

--- a/app/Commands/EnvironmentDelete.php
+++ b/app/Commands/EnvironmentDelete.php
@@ -2,7 +2,7 @@
 
 namespace App\Commands;
 
-use Illuminate\Http\Client\RequestException;
+use Saloon\Exceptions\Request\RequestException;
 
 use function Laravel\Prompts\error;
 use function Laravel\Prompts\intro;

--- a/app/Commands/InstanceDelete.php
+++ b/app/Commands/InstanceDelete.php
@@ -2,7 +2,7 @@
 
 namespace App\Commands;
 
-use Illuminate\Http\Client\RequestException;
+use Saloon\Exceptions\Request\RequestException;
 
 use function Laravel\Prompts\error;
 use function Laravel\Prompts\intro;


### PR DESCRIPTION
Fixes #50

## Summary

7 delete/verify commands import `Illuminate\Http\Client\RequestException` but the CLI uses Saloon, which throws `Saloon\Exceptions\Request\RequestException`. The catch blocks never match, so API errors crash with unhandled exceptions instead of showing friendly error messages.

`AI_BEST_PRACTICES.md` also referenced the wrong exception class and used Illuminate's `->response->` API instead of Saloon v4's `->getResponse()->`, which would cause AI agents to reproduce the same bug.

## Proof

The two exception classes are completely unrelated:

```
Illuminate: Illuminate\Http\Client\RequestException
Saloon:     Saloon\Exceptions\Request\RequestException
Same class? NO
Subclass?   NO
```

Tested with a real Saloon v4 `RequestException` thrown against both catch blocks:

```
BEFORE (current code - Illuminate catch):
  NOT CAUGHT by Illuminate\Http\Client\RequestException
  User sees: Saloon\Exceptions\Request\RequestException: Request failed
  This crashes the CLI instead of showing a friendly error.

AFTER (this PR - Saloon catch):
  Caught! Can show friendly message.
  Status: 422
  Message: Cannot delete: has active deployments
```

## Before / After

```php
// Before (broken) - catch never matches:
use Illuminate\Http\Client\RequestException;

try {
    $this->client->applications()->delete($application->id);
} catch (RequestException $e) {
    // Never catches - Saloon throws a different class
    error($e->getResponse()->json('message'));
}

// After (fixed) - catch matches:
use Saloon\Exceptions\Request\RequestException;

try {
    $this->client->applications()->delete($application->id);
} catch (RequestException $e) {
    // Now correctly catches Saloon exceptions
    error($e->getResponse()->json('message'));
}
```

## Changes

**Commands** (wrong import fixed in 7 files):
- `app/Commands/ApplicationDelete.php`
- `app/Commands/BackgroundProcessDelete.php`
- `app/Commands/DatabaseClusterDelete.php`
- `app/Commands/DomainDelete.php`
- `app/Commands/DomainVerify.php`
- `app/Commands/EnvironmentDelete.php`
- `app/Commands/InstanceDelete.php`

**Documentation** (wrong exception class and API method):
- `AI_BEST_PRACTICES.md` - fixed class reference and `->response->` to `->getResponse()->`

Other commands (Auth, Ship, Validates, HasAClient) already correctly use Saloon's exception.
