### PR TITLE
Fix TypeError when startedAt is null in monitor renderers

### DIFF
--- a/app/Prompts/MonitorCommandRenderer.php
+++ b/app/Prompts/MonitorCommandRenderer.php
@@ -45,7 +45,7 @@ class MonitorCommandRenderer extends Renderer
             $this->box(
                 title: $this->dim('Command Completed'),
                 body: $body,
-                info: $command->startedAt?->toDateTimeString(),
+                info: $command->startedAt?->toDateTimeString() ?? '',
                 symbol: $symbol,
             );
 

--- a/app/Prompts/MonitorDeploymentsRenderer.php
+++ b/app/Prompts/MonitorDeploymentsRenderer.php
@@ -37,7 +37,7 @@ class MonitorDeploymentsRenderer extends Renderer
             $this->box(
                 title: $this->dim('Last Deployment'),
                 body: $body,
-                info: $monitor->lastDeployment->startedAt?->toDateTimeString(),
+                info: $monitor->lastDeployment->startedAt?->toDateTimeString() ?? '',
                 symbol: TimelineSymbol::SUCCESS,
             );
 

--- a/tests/Unit/MonitorRendererTest.php
+++ b/tests/Unit/MonitorRendererTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use App\Dto\Command;
+use App\Dto\Deployment;
+use App\Enums\CommandStatus;
+use App\Prompts\MonitorCommand;
+use App\Prompts\MonitorCommandRenderer;
+use App\Prompts\MonitorDeployments;
+use App\Prompts\MonitorDeploymentsRenderer;
+
+it('renders a command with null startedAt', function () {
+    $command = Command::from([
+        'id' => 'cmd-1',
+        'command' => 'php artisan migrate',
+        'status' => CommandStatus::SUCCESS,
+        'output' => 'Migration complete',
+        'exitCode' => 0,
+        'startedAt' => null,
+        'finishedAt' => null,
+    ]);
+
+    $monitor = new MonitorCommand(
+        getCommand: fn () => null,
+        command: null,
+    );
+    $monitor->lastCommand = $command;
+
+    $renderer = new MonitorCommandRenderer($monitor);
+
+    expect($renderer($monitor))->not->toBeNull();
+});
+
+it('renders a deployment with null startedAt', function () {
+    $deployment = Deployment::from([
+        'id' => 'deploy-1',
+        'status' => 'deployment.succeeded',
+        'commitMessage' => 'Initial commit',
+        'commitAuthor' => 'Test User',
+        'startedAt' => null,
+        'finishedAt' => null,
+    ]);
+
+    $monitor = new MonitorDeployments(
+        getDeployment: fn () => null,
+    );
+    $monitor->lastDeployment = $deployment;
+
+    $renderer = new MonitorDeploymentsRenderer($monitor);
+
+    expect($renderer($monitor))->not->toBeNull();
+});


### PR DESCRIPTION
## Summary

Fixes #108.

When a command or deployment has `null` `startedAt` (e.g. on a hibernating environment), the monitor renderers pass `null` to `DrawsThemeBoxes::box()` which expects `string $info`, causing a TypeError.

Coalesces to empty string at the two call sites.

Changes inspired by https://github.com/laravel/cloud-cli/pull/109, was unable to push to that PR.