### PR TITLE
[main] [bug] Remove credential leak in database:open

### DIFF
--- a/app/Commands/DatabaseOpen.php
+++ b/app/Commands/DatabaseOpen.php
@@ -27,7 +27,7 @@ class DatabaseOpen extends BaseCommand
 
         $url = $this->buildUrl($cluster, $database);
 
-        info($url);
+        info('Opening database connection...');
 
         openUrl($url);
 

--- a/app/Commands/DatabaseOpen.php
+++ b/app/Commands/DatabaseOpen.php
@@ -27,7 +27,7 @@ class DatabaseOpen extends BaseCommand
 
         $url = $this->buildUrl($cluster, $database);
 
-        info("Opening database \"{$database->name}\" on \"{$cluster->connection['hostname']}\"...");
+        info("Opening database \"{$database->name}\" on \"{$cluster->connection['hostname']}:{$cluster->connection['port']}\" (cluster: {$cluster->name})");
 
         openUrl($url);
 

--- a/app/Commands/DatabaseOpen.php
+++ b/app/Commands/DatabaseOpen.php
@@ -27,7 +27,7 @@ class DatabaseOpen extends BaseCommand
 
         $url = $this->buildUrl($cluster, $database);
 
-        info("Opening {$database->name}...");
+        info("Opening {$database->name} on {$cluster->connection['hostname']}...");
 
         openUrl($url);
 

--- a/app/Commands/DatabaseOpen.php
+++ b/app/Commands/DatabaseOpen.php
@@ -27,7 +27,7 @@ class DatabaseOpen extends BaseCommand
 
         $url = $this->buildUrl($cluster, $database);
 
-        info('Opening database connection...');
+        info("Opening {$database->name}...");
 
         openUrl($url);
 

--- a/app/Commands/DatabaseOpen.php
+++ b/app/Commands/DatabaseOpen.php
@@ -27,7 +27,7 @@ class DatabaseOpen extends BaseCommand
 
         $url = $this->buildUrl($cluster, $database);
 
-        info("Opening {$database->name} on {$cluster->connection['hostname']}...");
+        info("Opening database \"{$database->name}\" on \"{$cluster->connection['hostname']}\"...");
 
         openUrl($url);
 


### PR DESCRIPTION
## Summary

`database:open` prints the full connection URL (including username and password) to the terminal via `info($url)`. This leaks credentials to terminal scrollback, screen sharing, and logs.

Replaced with a descriptive message that shows the database name, hostname, port, and cluster name - giving users the context they need to confirm they opened the correct database without exposing credentials.

**Before:**
`postgres://user:password@hostname:5432/main?Name=my-cluster&Environment=...`

**After:**
`Opening database "main" on "hostname:5432" (cluster: my-cluster)`

Closes #83

## Test plan

- [x] `./vendor/bin/pest` - 33 tests pass
- [x] `./vendor/bin/pint --test` - no style issues
- [x] Tested against live Cloud database cluster