### PR TITLE
[main] [bug] Use self::FAILURE constant in InstanceDelete

### DIFF
--- a/app/Commands/InstanceDelete.php
+++ b/app/Commands/InstanceDelete.php
@@ -36,7 +36,7 @@ class InstanceDelete extends BaseCommand
         } catch (RequestException $e) {
             error('Failed to delete instance: '.$e->getMessage());
 
-            return 1;
+            return self::FAILURE;
         }
     }
 }


### PR DESCRIPTION
## Summary

InstanceDelete catch block returns integer `1` instead of `self::FAILURE`. Every other delete command uses the constant.

Closes #85

## Test plan

- [x] `./vendor/bin/pest` - 33 tests pass
- [x] `./vendor/bin/pint --test` - no style issues