### PR TITLE
[main] [bug] Guard against empty token list in auth:token --remove

### DIFF
--- a/app/Commands/AuthToken.php
+++ b/app/Commands/AuthToken.php
@@ -98,6 +98,12 @@ class AuthToken extends BaseCommand implements NoAuthRequired
 
     protected function removeToken(Collection $existingTokens): void
     {
+        if ($existingTokens->isEmpty()) {
+            warning('No API tokens to remove.');
+
+            return;
+        }
+
         $token = select(
             label: 'Select a token to remove',
             options: $existingTokens,

--- a/app/Commands/AuthToken.php
+++ b/app/Commands/AuthToken.php
@@ -101,7 +101,7 @@ class AuthToken extends BaseCommand implements NoAuthRequired
         if ($existingTokens->isEmpty()) {
             warning('No API tokens to remove.');
 
-            return;
+            throw new CommandExitException(self::FAILURE);
         }
 
         $token = select(


### PR DESCRIPTION
## Summary

`auth:token --remove` calls `select()` with no options when no tokens exist, which crashes. Added an early return with a warning message and `CommandExitException(self::FAILURE)`, matching the same pattern used in `listTokens()` for empty state.

Closes #86

## Test plan

- [x] `./vendor/bin/pest` - 33 tests pass (before and after, no regressions)
- [x] `./vendor/bin/pint --test` - no style issues