### PR TITLE
[main] [bug] Add missing --json option to all delete commands

### DIFF
--- a/app/Commands/ApplicationDelete.php
+++ b/app/Commands/ApplicationDelete.php
@@ -12,7 +12,8 @@ class ApplicationDelete extends BaseCommand
 {
     protected $signature = 'application:delete
                             {application? : The application ID or name}
-                            {--force : Skip confirmation}';
+                            {--force : Skip confirmation}
+                            {--json : Output as JSON}';
 
     protected $description = 'Delete an application';
 

--- a/app/Commands/BackgroundProcessDelete.php
+++ b/app/Commands/BackgroundProcessDelete.php
@@ -10,10 +10,7 @@ use function Laravel\Prompts\spin;
 
 class BackgroundProcessDelete extends BaseCommand
 {
-    protected $signature = 'background-process:delete
-                            {process? : The background process ID}
-                            {--force : Skip confirmation}
-                            {--json : Output as JSON}';
+    protected $signature = 'background-process:delete {process? : The background process ID} {--force : Skip confirmation} {--json : Output as JSON}';
 
     protected $description = 'Delete a background process';
 

--- a/app/Commands/BackgroundProcessDelete.php
+++ b/app/Commands/BackgroundProcessDelete.php
@@ -10,7 +10,10 @@ use function Laravel\Prompts\spin;
 
 class BackgroundProcessDelete extends BaseCommand
 {
-    protected $signature = 'background-process:delete {process? : The background process ID} {--force : Skip confirmation}';
+    protected $signature = 'background-process:delete
+                            {process? : The background process ID}
+                            {--force : Skip confirmation}
+                            {--json : Output as JSON}';
 
     protected $description = 'Delete a background process';
 

--- a/app/Commands/BucketDelete.php
+++ b/app/Commands/BucketDelete.php
@@ -9,7 +9,8 @@ class BucketDelete extends BaseCommand
 {
     protected $signature = 'bucket:delete
                             {bucket? : The bucket ID or name}
-                            {--force : Skip confirmation}';
+                            {--force : Skip confirmation}
+                            {--json : Output as JSON}';
 
     protected $description = 'Delete an object storage bucket';
 

--- a/app/Commands/BucketKeyDelete.php
+++ b/app/Commands/BucketKeyDelete.php
@@ -9,7 +9,8 @@ class BucketKeyDelete extends BaseCommand
 {
     protected $signature = 'bucket-key:delete
                             {key? : The key ID or name}
-                            {--force : Skip confirmation}';
+                            {--force : Skip confirmation}
+                            {--json : Output as JSON}';
 
     protected $description = 'Delete a bucket key';
 

--- a/app/Commands/CacheDelete.php
+++ b/app/Commands/CacheDelete.php
@@ -9,7 +9,8 @@ class CacheDelete extends BaseCommand
 {
     protected $signature = 'cache:delete
                             {cache? : The cache ID or name}
-                            {--force : Skip confirmation}';
+                            {--force : Skip confirmation}
+                            {--json : Output as JSON}';
 
     protected $description = 'Delete a cache';
 

--- a/app/Commands/DatabaseClusterDelete.php
+++ b/app/Commands/DatabaseClusterDelete.php
@@ -12,10 +12,7 @@ use function Laravel\Prompts\spin;
 
 class DatabaseClusterDelete extends BaseCommand
 {
-    protected $signature = 'database-cluster:delete
-                            {database? : The database ID or name}
-                            {--force : Skip confirmation}
-                            {--json : Output as JSON}';
+    protected $signature = 'database-cluster:delete {database? : The database ID or name} {--force : Skip confirmation} {--json : Output as JSON}';
 
     protected $description = 'Delete a database cluster';
 

--- a/app/Commands/DatabaseClusterDelete.php
+++ b/app/Commands/DatabaseClusterDelete.php
@@ -12,7 +12,10 @@ use function Laravel\Prompts\spin;
 
 class DatabaseClusterDelete extends BaseCommand
 {
-    protected $signature = 'database-cluster:delete {database? : The database ID or name} {--force : Skip confirmation}';
+    protected $signature = 'database-cluster:delete
+                            {database? : The database ID or name}
+                            {--force : Skip confirmation}
+                            {--json : Output as JSON}';
 
     protected $description = 'Delete a database cluster';
 

--- a/app/Commands/DatabaseDelete.php
+++ b/app/Commands/DatabaseDelete.php
@@ -13,7 +13,8 @@ class DatabaseDelete extends BaseCommand
     protected $signature = 'database:delete
                             {cluster? : The database cluster ID or name}
                             {database? : The database (schema) ID or name}
-                            {--force : Skip confirmation}';
+                            {--force : Skip confirmation}
+                            {--json : Output as JSON}';
 
     protected $description = 'Delete a database (schema) from a database cluster';
 

--- a/app/Commands/DatabaseSnapshotDelete.php
+++ b/app/Commands/DatabaseSnapshotDelete.php
@@ -10,7 +10,8 @@ class DatabaseSnapshotDelete extends BaseCommand
     protected $signature = 'database-snapshot:delete
                             {cluster? : The database cluster ID or name}
                             {snapshot? : The snapshot ID or name}
-                            {--force : Skip confirmation}';
+                            {--force : Skip confirmation}
+                            {--json : Output as JSON}';
 
     protected $description = 'Delete a database snapshot';
 

--- a/app/Commands/DomainDelete.php
+++ b/app/Commands/DomainDelete.php
@@ -10,10 +10,7 @@ use function Laravel\Prompts\spin;
 
 class DomainDelete extends BaseCommand
 {
-    protected $signature = 'domain:delete
-                            {domain? : The domain ID}
-                            {--force : Skip confirmation}
-                            {--json : Output as JSON}';
+    protected $signature = 'domain:delete {domain? : The domain ID} {--force : Skip confirmation} {--json : Output as JSON}';
 
     protected $description = 'Delete a domain';
 

--- a/app/Commands/DomainDelete.php
+++ b/app/Commands/DomainDelete.php
@@ -10,7 +10,10 @@ use function Laravel\Prompts\spin;
 
 class DomainDelete extends BaseCommand
 {
-    protected $signature = 'domain:delete {domain? : The domain ID} {--force : Skip confirmation}';
+    protected $signature = 'domain:delete
+                            {domain? : The domain ID}
+                            {--force : Skip confirmation}
+                            {--json : Output as JSON}';
 
     protected $description = 'Delete a domain';
 

--- a/app/Commands/EnvironmentDelete.php
+++ b/app/Commands/EnvironmentDelete.php
@@ -12,7 +12,8 @@ class EnvironmentDelete extends BaseCommand
 {
     protected $signature = 'environment:delete
                             {environment? : The environment ID}
-                            {--force : Skip confirmation}';
+                            {--force : Skip confirmation}
+                            {--json : Output as JSON}';
 
     protected $description = 'Delete an environment';
 

--- a/app/Commands/InstanceDelete.php
+++ b/app/Commands/InstanceDelete.php
@@ -10,7 +10,10 @@ use function Laravel\Prompts\spin;
 
 class InstanceDelete extends BaseCommand
 {
-    protected $signature = 'instance:delete {instance? : The instance ID} {--force : Skip confirmation}';
+    protected $signature = 'instance:delete
+                            {instance? : The instance ID}
+                            {--force : Skip confirmation}
+                            {--json : Output as JSON}';
 
     protected $description = 'Delete an instance';
 

--- a/app/Commands/InstanceDelete.php
+++ b/app/Commands/InstanceDelete.php
@@ -10,10 +10,7 @@ use function Laravel\Prompts\spin;
 
 class InstanceDelete extends BaseCommand
 {
-    protected $signature = 'instance:delete
-                            {instance? : The instance ID}
-                            {--force : Skip confirmation}
-                            {--json : Output as JSON}';
+    protected $signature = 'instance:delete {instance? : The instance ID} {--force : Skip confirmation} {--json : Output as JSON}';
 
     protected $description = 'Delete an instance';
 

--- a/app/Commands/WebsocketApplicationDelete.php
+++ b/app/Commands/WebsocketApplicationDelete.php
@@ -9,7 +9,8 @@ class WebsocketApplicationDelete extends BaseCommand
 {
     protected $signature = 'websocket-application:delete
                             {application? : The application ID or name}
-                            {--force : Skip confirmation}';
+                            {--force : Skip confirmation}
+                            {--json : Output as JSON}';
 
     protected $description = 'Delete a WebSocket application';
 

--- a/app/Commands/WebsocketClusterDelete.php
+++ b/app/Commands/WebsocketClusterDelete.php
@@ -9,7 +9,8 @@ class WebsocketClusterDelete extends BaseCommand
 {
     protected $signature = 'websocket-cluster:delete
                             {cluster? : The cluster ID or name}
-                            {--force : Skip confirmation}';
+                            {--force : Skip confirmation}
+                            {--json : Output as JSON}';
 
     protected $description = 'Delete a WebSocket cluster';
 


### PR DESCRIPTION
## Summary

All 13 delete commands call `outputJsonIfWanted()` but none declare `{--json}` in their signature. Since `requestedJson()` checks `hasOption('json')`, the `--json` flag is silently ignored in interactive mode.

**Affected commands:** ApplicationDelete, BackgroundProcessDelete, BucketDelete, BucketKeyDelete, CacheDelete, DatabaseClusterDelete, DatabaseDelete, DatabaseSnapshotDelete, DomainDelete, EnvironmentDelete, InstanceDelete, WebsocketApplicationDelete, WebsocketClusterDelete.

Closes #48

## Test plan

- [x] `./vendor/bin/pest` - 33 tests pass
- [x] `./vendor/bin/pint --test` - no style issues