### PR TITLE
[main] [bug] Fix credential leak in database:open command

### DIFF
--- a/app/Commands/DatabaseOpen.php
+++ b/app/Commands/DatabaseOpen.php
@@ -27,7 +27,7 @@ class DatabaseOpen extends BaseCommand
 
         $url = $this->buildUrl($cluster, $database);
 
-        info($url);
+        info('Opening database connection...');
 
         openUrl($url);
 


### PR DESCRIPTION
Fixes #83

## Summary

`database:open` prints the full database connection URL to the terminal via `info($url)`. The URL contains plaintext username and password:

```
postgres://admin:s3cret_p4ssw0rd@db-host.cloud.laravel.com:5432/mydb?Name=...
```

Anyone looking at the terminal, screen sharing, or reviewing terminal history sees the credentials.

## Fix

Replace `info($url)` with `info('Opening database connection...')`. The URL is still passed to `openUrl()` to open the database client, it just isn't printed to the screen.

## Before / After

```php
// Before - credentials printed to terminal:
info($url);
// Output: postgres://admin:s3cret_p4ssw0rd@host:5432/mydb

// After - generic message, credentials stay hidden:
info('Opening database connection...');
// Output: Opening database connection...
```
