### PR TITLE
[main] [bug] Catch RequestException instead of Throwable in DatabaseDelete

### DIFF
--- a/app/Commands/DatabaseDelete.php
+++ b/app/Commands/DatabaseDelete.php
@@ -2,7 +2,7 @@
 
 namespace App\Commands;
 
-use Throwable;
+use Saloon\Exceptions\Request\RequestException;
 
 use function Laravel\Prompts\error;
 use function Laravel\Prompts\intro;
@@ -44,7 +44,7 @@ class DatabaseDelete extends BaseCommand
             success('Database deleted.');
 
             return self::SUCCESS;
-        } catch (Throwable $e) {
+        } catch (RequestException $e) {
             error('Failed to delete database: '.$e->getMessage());
 
             return self::FAILURE;


### PR DESCRIPTION
Fixes #46

## Summary

`DatabaseDelete` catches `Throwable` instead of `RequestException`. This catches everything including `TypeError`, `OutOfMemoryError`, and other non-API errors, masking real bugs as "Failed to delete database" messages. All other delete commands catch `RequestException`.

## Proof

```
BEFORE: catch(Throwable) - current code
  API error (RequestException): CAUGHT - shown as 'Failed to delete database'
  Type bug (TypeError): CAUGHT - shown as 'Failed to delete database'
  Memory crash (Error): CAUGHT - shown as 'Failed to delete database'
  Bad method call: CAUGHT - shown as 'Failed to delete database'

AFTER: catch(RequestException) - this PR
  API error (RequestException): CAUGHT - friendly API error message
  Type bug (TypeError): NOT CAUGHT - propagates correctly as TypeError
  Memory crash (Error): NOT CAUGHT - propagates correctly as Error
  Bad method call: NOT CAUGHT - propagates correctly as BadMethodCallException
```

## Before / After

```php
// Before - catches everything, masks real bugs:
use Throwable;

} catch (Throwable $e) {
    error('Failed to delete database: '.$e->getMessage());
}

// After - only catches API errors, consistent with other delete commands:
use Saloon\Exceptions\Request\RequestException;

} catch (RequestException $e) {
    error('Failed to delete database: '.$e->getMessage());
}
```

## Consistency

Every other delete command already catches `RequestException`:
- `ApplicationDelete`
- `BackgroundProcessDelete`
- `DatabaseClusterDelete`
- `DomainDelete`
- `EnvironmentDelete`
- `InstanceDelete`

`DatabaseDelete` was the only outlier.