### PR TITLE
[main] [bug] Initialize Form errors property to prevent TypeError

### DIFF
--- a/app/Support/Form.php
+++ b/app/Support/Form.php
@@ -15,7 +15,7 @@ class Form
 
     protected array $arguments = [];
 
-    protected ValidationErrors $errors = new ValidationErrors;
+    protected ?ValidationErrors $errors = null;
 
     protected bool $isInteractive;
 
@@ -33,6 +33,8 @@ class Form
         if (! in_array($key, $this->prompted)) {
             $this->prompted[] = $key;
         }
+
+        $this->errors ??= new ValidationErrors;
 
         $result = ($this->fields[$key]['callback'])($this->fields[$key]['resolver'])->errors($this->errors);
         $result->retrieve();

--- a/app/Support/Form.php
+++ b/app/Support/Form.php
@@ -15,7 +15,7 @@ class Form
 
     protected array $arguments = [];
 
-    protected ValidationErrors $errors;
+    protected ValidationErrors $errors = new ValidationErrors;
 
     protected bool $isInteractive;
 

--- a/tests/Feature/DatabaseRestoreCreateTest.php
+++ b/tests/Feature/DatabaseRestoreCreateTest.php
@@ -1,0 +1,152 @@
+<?php
+
+use App\Client\Resources\DatabaseClusters\GetDatabaseClusterRequest;
+use App\Client\Resources\DatabaseClusters\ListDatabaseClustersRequest;
+use App\Client\Resources\DatabaseRestores\CreateDatabaseRestoreRequest;
+use App\ConfigRepository;
+use App\Git;
+use Illuminate\Support\Sleep;
+use Laravel\Prompts\Prompt;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+
+beforeEach(function () {
+    Sleep::fake();
+
+    $this->mockGit = Mockery::mock(Git::class);
+    $this->mockGit->shouldReceive('isRepo')->andReturn(true)->byDefault();
+    $this->mockGit->shouldReceive('getRoot')->andReturn('/tmp/test-repo')->byDefault();
+    $this->mockGit->shouldReceive('currentBranch')->andReturn('main')->byDefault();
+    $this->mockGit->shouldReceive('remoteRepo')->andReturn('')->byDefault();
+    $this->mockGit->shouldReceive('hasGitHubRemote')->andReturn(false)->byDefault();
+    $this->app->instance(Git::class, $this->mockGit);
+
+    $this->mockConfig = Mockery::mock(ConfigRepository::class);
+    $this->mockConfig->shouldReceive('apiTokens')->andReturn(collect(['test-api-token']));
+    $this->app->instance(ConfigRepository::class, $this->mockConfig);
+});
+
+afterEach(fn () => MockClient::destroyGlobal());
+
+function dbRestoreClusterResponse(): array
+{
+    return [
+        'data' => [
+            'id' => 'db-cluster-1',
+            'type' => 'databaseClusters',
+            'attributes' => [
+                'name' => 'my-cluster',
+                'type' => 'laravel_mysql_8',
+                'status' => 'running',
+                'region' => 'us-east-1',
+                'config' => [],
+                'connection' => [],
+                'created_at' => now()->toISOString(),
+                'updated_at' => now()->toISOString(),
+            ],
+        ],
+        'included' => [],
+    ];
+}
+
+function dbRestoreCreatedResponse(): array
+{
+    return [
+        'data' => [
+            'id' => 'db-cluster-restored',
+            'type' => 'databaseClusters',
+            'attributes' => [
+                'name' => 'my-restore',
+                'type' => 'laravel_mysql_8',
+                'status' => 'creating',
+                'region' => 'us-east-1',
+                'config' => [],
+                'connection' => [],
+                'created_at' => now()->toISOString(),
+                'updated_at' => now()->toISOString(),
+            ],
+        ],
+        'included' => [],
+    ];
+}
+
+it('creates a restore from snapshot in non-interactive mode', function () {
+    Prompt::fake();
+
+    MockClient::global([
+        GetDatabaseClusterRequest::class => MockResponse::make(dbRestoreClusterResponse(), 200),
+        CreateDatabaseRestoreRequest::class => MockResponse::make(dbRestoreCreatedResponse(), 200),
+    ]);
+
+    $this->artisan('database-restore:create', [
+        'cluster' => 'db-cluster-1',
+        'name' => 'my-restore',
+        '--snapshot' => 'snap-123',
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+});
+
+it('creates a restore from point-in-time in non-interactive mode', function () {
+    Prompt::fake();
+
+    MockClient::global([
+        GetDatabaseClusterRequest::class => MockResponse::make(dbRestoreClusterResponse(), 200),
+        CreateDatabaseRestoreRequest::class => MockResponse::make(dbRestoreCreatedResponse(), 200),
+    ]);
+
+    $this->artisan('database-restore:create', [
+        'cluster' => 'db-cluster-1',
+        'name' => 'my-restore',
+        '--point-in-time' => '2024-01-15T12:00:00Z',
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+});
+
+it('resolves cluster by name for restore', function () {
+    Prompt::fake();
+
+    MockClient::global([
+        ListDatabaseClustersRequest::class => MockResponse::make([
+            'data' => [
+                [
+                    'id' => 'db-cluster-1',
+                    'type' => 'databaseClusters',
+                    'attributes' => [
+                        'name' => 'my-cluster',
+                        'type' => 'laravel_mysql_8',
+                        'status' => 'running',
+                        'region' => 'us-east-1',
+                        'config' => [],
+                        'connection' => [],
+                        'created_at' => now()->toISOString(),
+                        'updated_at' => now()->toISOString(),
+                    ],
+                ],
+            ],
+            'included' => [],
+            'links' => ['next' => null],
+        ], 200),
+        CreateDatabaseRestoreRequest::class => MockResponse::make(dbRestoreCreatedResponse(), 200),
+    ]);
+
+    $this->artisan('database-restore:create', [
+        'cluster' => 'my-cluster',
+        'name' => 'my-restore',
+        '--snapshot' => 'snap-123',
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+});
+
+it('fails when neither snapshot nor point-in-time is provided', function () {
+    Prompt::fake();
+
+    MockClient::global([
+        GetDatabaseClusterRequest::class => MockResponse::make(dbRestoreClusterResponse(), 200),
+    ]);
+
+    $this->artisan('database-restore:create', [
+        'cluster' => 'db-cluster-1',
+        'name' => 'my-restore',
+        '--no-interaction' => true,
+    ])->assertFailed();
+});


### PR DESCRIPTION
Relates to #55

## Summary

`Form::$errors` is declared as a typed property with no default value. Commands that call `$this->form()->prompt()` directly (like `DatabaseRestoreCreate`) trigger a TypeError because `$errors` is accessed before initialization.

Commands that go through `loopUntilValid()` don't hit this because the `Validates` trait initializes errors via `$this->form()->errors($this->errors)` first. But direct `prompt()` calls bypass that path entirely.

## Before / After

| Scenario | Before | After |
|----------|--------|-------|
| `database-restore:create` with `--snapshot` | TypeError: `$errors` must not be accessed before initialization | Works |
| `database-restore:create` with `--point-in-time` | TypeError (same) | Works |
| Commands using `loopUntilValid()` | Unaffected (trait initializes errors) | Unaffected |

## Fix

Make `$errors` nullable with a null default, then lazy-initialize in `prompt()`:

```php
// Property declaration
protected ?ValidationErrors $errors = null;

// In prompt(), before accessing $errors
$this->errors ??= new ValidationErrors;
```

This matches the pattern already used in the `Validates` trait (`protected ?ValidationErrors $errors = null`).

> **Note:** The initial commit used `= new ValidationErrors` as a property default, but `new` expressions are not valid in property defaults in PHP. The second commit corrects this.

## Test Plan

- [x] Creates restore from snapshot in non-interactive mode
- [x] Creates restore from point-in-time in non-interactive mode
- [x] Resolves cluster by name for restore
- [x] Fails when neither `--snapshot` nor `--point-in-time` provided

Live CLI testing not possible: all available clusters are Neon serverless postgres with no snapshots available (`database-snapshot:list` returns `[]` on all 7 clusters).