### PR TITLE
Add `skills:install` command

### DIFF
--- a/app/Commands/SkillsInstall.php
+++ b/app/Commands/SkillsInstall.php
@@ -107,12 +107,9 @@ class SkillsInstall extends BaseCommand implements NoAuthRequired
         $home = $_SERVER['HOME'] ?? $_SERVER['USERPROFILE'] ?? '';
         $cwd = getcwd();
 
-        $global = $this->option('global');
-        $project = $this->option('project');
-
         $isProject = match (true) {
-            $global => false,
-            $project => true,
+            $this->option('global') => false,
+            $this->option('project') => true,
             default => File::isDirectory($cwd.'/vendor/laravel/cloud-cli'),
         };
 

--- a/app/Commands/SkillsInstall.php
+++ b/app/Commands/SkillsInstall.php
@@ -18,7 +18,7 @@ class SkillsInstall extends BaseCommand implements NoAuthRequired
     protected $signature = 'skills:install
                             {--global : Install skills globally}
                             {--project : Install skills to the current project}
-                            {--agent=* : Agents to install for (e.g. claude, cursor, junie)}
+                            {--agent=* : Agents to install for (claude, cursor, junie, github, agents)}
                             {--force : Overwrite existing skills}';
 
     protected $description = 'Install Laravel Cloud CLI agent skills for all supported coding agents';

--- a/app/Commands/SkillsInstall.php
+++ b/app/Commands/SkillsInstall.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Http;
 use RuntimeException;
 
 use function Laravel\Prompts\intro;
+use function Laravel\Prompts\multiselect;
 use function Laravel\Prompts\spin;
 use function Laravel\Prompts\warning;
 
@@ -17,6 +18,7 @@ class SkillsInstall extends BaseCommand implements NoAuthRequired
     protected $signature = 'skills:install
                             {--global : Install skills globally}
                             {--project : Install skills to the current project}
+                            {--agent=* : Agents to install for (e.g. claude, cursor, junie)}
                             {--force : Overwrite existing skills}';
 
     protected $description = 'Install Laravel Cloud CLI agent skills for all supported coding agents';
@@ -25,20 +27,13 @@ class SkillsInstall extends BaseCommand implements NoAuthRequired
 
     protected string $repoPath = 'laravel-cloud/skills';
 
-    /** @var array<int, string> */
-    protected array $globalSkillPaths = [
-        '~/.claude/skills',
-        '~/.cursor/skills',
-        '~/.agents/skills',
-    ];
-
-    /** @var array<int, string> */
-    protected array $projectSkillPaths = [
-        '.claude/skills',
-        '.cursor/skills',
-        '.agents/skills',
-        '.github/skills',
-        '.junie/skills',
+    /** @var array<string, array{global: string, project: string}> */
+    protected array $agents = [
+        'claude' => ['global' => '~/.claude/skills', 'project' => '.claude/skills'],
+        'cursor' => ['global' => '~/.cursor/skills', 'project' => '.cursor/skills'],
+        'junie' => ['global' => '~/.junie/skills', 'project' => '.junie/skills'],
+        'github' => ['global' => '~/.github/skills', 'project' => '.github/skills'],
+        'agents' => ['global' => '~/.agents/skills', 'project' => '.agents/skills'],
     ];
 
     public function handle(): int
@@ -60,6 +55,7 @@ class SkillsInstall extends BaseCommand implements NoAuthRequired
 
         foreach ($skills as $skillName => $files) {
             $skillInstalled = false;
+            $filePaths = [];
 
             foreach ($skillPaths as $basePath) {
                 $targetDir = $basePath.'/'.$skillName;
@@ -74,17 +70,17 @@ class SkillsInstall extends BaseCommand implements NoAuthRequired
 
                 foreach ($files as $relativePath => $content) {
                     $filePath = $targetDir.'/'.$relativePath;
+                    $filePaths[] = $filePath;
 
                     File::ensureDirectoryExists(dirname($filePath));
                     File::put($filePath, $content);
-
-                    success("Installed skill '{$skillName}' to {$filePath}");
                 }
 
                 $skillInstalled = true;
             }
 
             if ($skillInstalled) {
+                success("Installed skill <comment>{$skillName}</comment> <info>to:</info>".PHP_EOL.PHP_EOL.implode(PHP_EOL, $filePaths));
                 $installedSkills[] = $skillName;
             } else {
                 warning("Skill '{$skillName}' already exists in all target locations. Use --force to overwrite.");
@@ -120,11 +116,74 @@ class SkillsInstall extends BaseCommand implements NoAuthRequired
             default => File::isDirectory($cwd.'/vendor/laravel/cloud-cli'),
         };
 
-        if ($isProject) {
-            return array_map(fn (string $path) => $cwd.'/'.$path, $this->projectSkillPaths);
+        $scope = $isProject ? 'project' : 'global';
+        $selectedAgents = $this->resolveAgents($scope, $home, $cwd);
+
+        return array_map(function (string $agent) use ($scope, $home, $cwd) {
+            $path = $this->agents[$agent][$scope];
+
+            if ($scope === 'project') {
+                return $cwd.'/'.$path;
+            }
+
+            return str_replace('~', $home, $path);
+        }, $selectedAgents);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    protected function resolveAgents(string $scope, string $home, string $cwd): array
+    {
+        $explicit = array_filter($this->option('agent'));
+
+        if ($explicit !== []) {
+            return array_values(array_intersect($explicit, array_keys($this->agents)));
         }
 
-        return array_map(fn (string $path) => str_replace('~', $home, $path), $this->globalSkillPaths);
+        $detected = $this->detectAgents($scope, $home, $cwd);
+
+        if ($this->input->isInteractive()) {
+            $options = collect($this->agents)->keys()->mapWithKeys(fn (string $agent) => [
+                $agent => match ($agent) {
+                    'agents' => 'Generic agent skills (for any agent)',
+                    default => ucfirst($agent),
+                },
+            ])->all();
+
+            return multiselect(
+                label: 'Which agents do you want to install skills for?',
+                options: $options,
+                default: $detected ?: array_keys($this->agents),
+            );
+        }
+
+        return $detected ?: array_keys($this->agents);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    protected function detectAgents(string $scope, string $home, string $cwd): array
+    {
+        $detected = [];
+
+        foreach ($this->agents as $agent => $paths) {
+            $skillPath = $paths[$scope];
+            $parentDir = dirname($skillPath);
+
+            if ($scope === 'project') {
+                $parentDir = $cwd.'/'.$parentDir;
+            } else {
+                $parentDir = str_replace('~', $home, $parentDir);
+            }
+
+            if (File::isDirectory($parentDir)) {
+                $detected[] = $agent;
+            }
+        }
+
+        return $detected;
     }
 
     /**

--- a/app/Commands/SkillsInstall.php
+++ b/app/Commands/SkillsInstall.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace App\Commands;
+
+use App\Contracts\NoAuthRequired;
+use Illuminate\Http\Client\Pool;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Http;
+use RuntimeException;
+
+use function Laravel\Prompts\intro;
+use function Laravel\Prompts\spin;
+use function Laravel\Prompts\warning;
+
+class SkillsInstall extends BaseCommand implements NoAuthRequired
+{
+    protected $signature = 'skills:install
+                            {--force : Overwrite existing skills}';
+
+    protected $description = 'Install Laravel Cloud CLI agent skills for all supported coding agents';
+
+    protected string $repo = 'laravel/agent-skills';
+
+    protected string $repoPath = 'laravel-cloud/skills';
+
+    /** @var array<int, string> */
+    protected array $skillPaths = [
+        '~/.claude/skills',
+        '~/.cursor/skills',
+        '~/.agents/skills',
+    ];
+
+    public function handle(): int
+    {
+        intro('Install Agent Skills');
+
+        $home = $_SERVER['HOME'] ?? $_SERVER['USERPROFILE'] ?? '';
+
+        $skills = spin(
+            fn () => $this->fetchSkills(),
+            'Fetching skills from GitHub...',
+        );
+
+        if ($skills === []) {
+            $this->failAndExit('No skills found in the repository.');
+        }
+
+        $installedSkills = [];
+        $skippedSkills = [];
+
+        foreach ($skills as $skillName => $files) {
+            $skillInstalled = false;
+
+            foreach ($this->skillPaths as $basePath) {
+                $resolvedPath = str_replace('~', $home, $basePath);
+                $targetDir = $resolvedPath.'/'.$skillName;
+
+                if (File::isDirectory($targetDir) && ! $this->option('force')) {
+                    continue;
+                }
+
+                if (File::isDirectory($targetDir)) {
+                    File::deleteDirectory($targetDir);
+                }
+
+                foreach ($files as $relativePath => $content) {
+                    $filePath = $targetDir.'/'.$relativePath;
+
+                    File::ensureDirectoryExists(dirname($filePath));
+                    File::put($filePath, $content);
+
+                    success("Installed skill '{$skillName}' to {$filePath}");
+                }
+
+                $skillInstalled = true;
+            }
+
+            if ($skillInstalled) {
+                $installedSkills[] = $skillName;
+            } else {
+                warning("Skill '{$skillName}' already exists in all target locations. Use --force to overwrite.");
+                $skippedSkills[] = $skillName;
+            }
+        }
+
+        if ($installedSkills === [] && $skippedSkills !== []) {
+            warning('All skills already installed. Use --force to overwrite.');
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return array<string, array<string, string>>
+     */
+    protected function fetchSkills(): array
+    {
+        $tree = $this->fetchTree();
+        $prefix = $this->repoPath.'/';
+
+        // Find skill directories by locating SKILL.md files
+        $skillMarkers = collect($tree)
+            ->filter(
+                fn (array $item) => $item['type'] === 'blob'
+                    && basename($item['path']) === 'SKILL.md'
+                    && str_starts_with($item['path'], $prefix),
+            );
+
+        if ($skillMarkers->isEmpty()) {
+            return [];
+        }
+
+        $skills = [];
+
+        foreach ($skillMarkers as $marker) {
+            $skillDir = dirname($marker['path']);
+            $skillName = basename($skillDir);
+
+            // Collect all files belonging to this skill
+            $skillFiles = collect($tree)
+                ->filter(
+                    fn (array $item) => $item['type'] === 'blob'
+                        && str_starts_with($item['path'], $skillDir.'/'),
+                );
+
+            $fileUrls = $skillFiles->mapWithKeys(fn (array $item) => [
+                $item['path'] => $this->rawUrl($item['path']),
+            ]);
+
+            // Download all files in parallel
+            $responses = Http::pool(fn (Pool $pool) => $fileUrls->map(
+                fn (string $url, string $path) => $pool->as($path)
+                    ->withHeaders(['User-Agent' => 'Laravel-Cloud-CLI'])
+                    ->timeout(30)
+                    ->get($url),
+            )->all());
+
+            $downloaded = [];
+
+            foreach ($skillFiles as $file) {
+                $response = $responses[$file['path']] ?? null;
+
+                if ($response === null || $response->failed()) {
+                    continue;
+                }
+
+                $relativePath = substr($file['path'], strlen($skillDir.'/'));
+                $downloaded[$relativePath] = $response->body();
+            }
+
+            if ($downloaded !== []) {
+                $skills[$skillName] = $downloaded;
+            }
+        }
+
+        return $skills;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    protected function fetchTree(): array
+    {
+        $response = Http::withHeaders([
+            'Accept' => 'application/vnd.github.v3+json',
+            'User-Agent' => 'Laravel-Cloud-CLI',
+        ])->timeout(30)->get(
+            "https://api.github.com/repos/{$this->repo}/git/trees/main?recursive=1",
+        );
+
+        if ($response->failed()) {
+            throw new RuntimeException(
+                'Failed to fetch repository tree from GitHub: '
+                    .($response->json('message') ?? 'Unknown error')
+                    ." (HTTP {$response->status()})",
+            );
+        }
+
+        return $response->json('tree', []);
+    }
+
+    protected function rawUrl(string $path): string
+    {
+        return "https://raw.githubusercontent.com/{$this->repo}/main/{$path}";
+    }
+}

--- a/app/Commands/SkillsInstall.php
+++ b/app/Commands/SkillsInstall.php
@@ -15,6 +15,8 @@ use function Laravel\Prompts\warning;
 class SkillsInstall extends BaseCommand implements NoAuthRequired
 {
     protected $signature = 'skills:install
+                            {--global : Install skills globally}
+                            {--project : Install skills to the current project}
                             {--force : Overwrite existing skills}';
 
     protected $description = 'Install Laravel Cloud CLI agent skills for all supported coding agents';
@@ -24,17 +26,24 @@ class SkillsInstall extends BaseCommand implements NoAuthRequired
     protected string $repoPath = 'laravel-cloud/skills';
 
     /** @var array<int, string> */
-    protected array $skillPaths = [
+    protected array $globalSkillPaths = [
         '~/.claude/skills',
         '~/.cursor/skills',
         '~/.agents/skills',
     ];
 
+    /** @var array<int, string> */
+    protected array $projectSkillPaths = [
+        '.claude/skills',
+        '.cursor/skills',
+        '.agents/skills',
+        '.github/skills',
+        '.junie/skills',
+    ];
+
     public function handle(): int
     {
         intro('Install Agent Skills');
-
-        $home = $_SERVER['HOME'] ?? $_SERVER['USERPROFILE'] ?? '';
 
         $skills = spin(
             fn () => $this->fetchSkills(),
@@ -45,15 +54,15 @@ class SkillsInstall extends BaseCommand implements NoAuthRequired
             $this->failAndExit('No skills found in the repository.');
         }
 
+        $skillPaths = $this->resolveSkillPaths();
         $installedSkills = [];
         $skippedSkills = [];
 
         foreach ($skills as $skillName => $files) {
             $skillInstalled = false;
 
-            foreach ($this->skillPaths as $basePath) {
-                $resolvedPath = str_replace('~', $home, $basePath);
-                $targetDir = $resolvedPath.'/'.$skillName;
+            foreach ($skillPaths as $basePath) {
+                $targetDir = $basePath.'/'.$skillName;
 
                 if (File::isDirectory($targetDir) && ! $this->option('force')) {
                     continue;
@@ -88,6 +97,30 @@ class SkillsInstall extends BaseCommand implements NoAuthRequired
         }
 
         return self::SUCCESS;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    protected function resolveSkillPaths(): array
+    {
+        $home = $_SERVER['HOME'] ?? $_SERVER['USERPROFILE'] ?? '';
+        $cwd = getcwd();
+
+        $global = $this->option('global');
+        $project = $this->option('project');
+
+        $isProject = match (true) {
+            $global => false,
+            $project => true,
+            default => File::isDirectory($cwd.'/vendor/laravel/cloud-cli'),
+        };
+
+        if ($isProject) {
+            return array_map(fn (string $path) => $cwd.'/'.$path, $this->projectSkillPaths);
+        }
+
+        return array_map(fn (string $path) => str_replace('~', $home, $path), $this->globalSkillPaths);
     }
 
     /**

--- a/app/Commands/SkillsInstall.php
+++ b/app/Commands/SkillsInstall.php
@@ -92,8 +92,15 @@ class SkillsInstall extends BaseCommand implements NoAuthRequired
             }
         }
 
+        $this->outputJsonIfWanted([
+            'installed' => $installedSkills,
+            'skipped' => $skippedSkills,
+        ]);
+
         if ($installedSkills === [] && $skippedSkills !== []) {
             warning('All skills already installed. Use --force to overwrite.');
+
+            return self::FAILURE;
         }
 
         return self::SUCCESS;

--- a/app/Middleware/SuppressOutputIfJson.php
+++ b/app/Middleware/SuppressOutputIfJson.php
@@ -2,11 +2,9 @@
 
 namespace App\Middleware;
 
-use App\Contracts\NoAuthRequired;
 use App\Prompts\Renderer;
 use App\Prompts\SuppressedOutput;
 use App\Support\DetectsNonInteractiveEnvironments;
-use Illuminate\Support\Facades\Artisan;
 use Laravel\Prompts\Prompt;
 
 class SuppressOutputIfJson implements CommandMiddleware

--- a/app/Middleware/SuppressOutputIfJson.php
+++ b/app/Middleware/SuppressOutputIfJson.php
@@ -22,15 +22,9 @@ class SuppressOutputIfJson implements CommandMiddleware
             return $next();
         }
 
-        $commandClass = Artisan::all()[$command] ?? null;
-
-        if ($commandClass === null || $commandClass instanceof NoAuthRequired) {
-            return $next();
-        }
-
         $args = $_SERVER['argv'] ?? [];
 
-        Renderer::$suppressOutput = collect($args)->intersect(['--json', '--no-interaction'])->isNotEmpty() || $this->isNonInteractiveEnvironment();
+        Renderer::$suppressOutput = collect($args)->intersect(['--json', '--no-interaction', '-n'])->isNotEmpty() || $this->isNonInteractiveEnvironment();
 
         if (Renderer::$suppressOutput) {
             Prompt::setOutput(new SuppressedOutput);

--- a/skills/deploying-laravel-cloud/SKILL.md
+++ b/skills/deploying-laravel-cloud/SKILL.md
@@ -96,6 +96,42 @@ Use your judgment:
 - Order of provisioning — no strict sequence required
 - How to present output — summarize, show raw, or extract fields based on context
 
+## Remote Access
+
+### Tinker
+
+Run PHP code directly in a Cloud environment:
+
+```sh
+cloud tinker {environment} --code='Your PHP code here' --timeout=60 -n
+```
+
+- `--code` — PHP code to execute (required in non-interactive mode)
+- `--timeout` — max seconds to wait for output (default: 60)
+
+The code must explicitly output results using `echo`, `dump`, or similar — expressions alone produce no output.
+
+Always pass `--code` and `-n` to avoid interactive prompts.
+
+### Remote Commands
+
+Run shell commands on a Cloud environment:
+
+```sh
+cloud command:run {environment} --cmd='your command here' -n
+```
+
+- `--cmd` — the command to run (required in non-interactive mode)
+- `--no-monitor` — skip real-time output streaming
+- `--copy-output` — copy output to clipboard
+
+Review past commands:
+
+- `cloud command:list {environment} --json -n` — list command history
+- `cloud command:get {commandId} --json -n` — get details and output of a specific command
+
+Delegate `command:run` to a subagent when output may be long.
+
 ## Config
 
 1. Global: `~/.config/cloud/config.json` — auth tokens and preferences


### PR DESCRIPTION
Add `skills:install` command and document remote access in SKILL.md

- New `skills:install` command that fetches agent skills from `laravel/agent-skills` on GitHub and installs them to the appropriate directories for each coding agent (Claude, Cursor, Junie, GitHub Copilot, etc.)
- Supports `--global` / `--project` scope, `--agent` for explicit agent selection, and `--force` to overwrite
- Auto-detects which agents are installed based on existing directories; in interactive mode, presents a multiselect pre-populated with detected agents
- Fix `SuppressOutputIfJson` middleware to recognize `-n` shorthand and suppress output for `NoAuthRequired` commands
- Add `tinker` and `command:run` documentation to the deploying-laravel-cloud skill