### PR TITLE
Move all packages from `require` to `require-dev` to avoid conflicts on installation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,24 +20,24 @@
         }
     ],
     "require": {
-        "php": "^8.2",
+        "php": "^8.2"
+    },
+    "require-dev": {
         "illuminate/http": "^12.17",
         "illuminate/translation": "^12.53",
         "illuminate/validation": "^12.53",
+        "laravel-zero/framework": "^12.0.2",
         "laravel-zero/phar-updater": "^1.4",
+        "laravel/pint": "^1.25.1",
+        "mockery/mockery": "^1.6.12",
+        "pestphp/pest": "^3.8.4|^4.1.2",
         "php-parallel-lint/php-console-highlighter": "^1.0",
+        "phpstan/phpstan": "^2.1",
         "saloonphp/cache-plugin": "^3.1",
         "saloonphp/pagination-plugin": "^2.3",
         "saloonphp/saloon": "^4.0",
         "shipfastlabs/agent-detector": "^1.0",
         "spatie/laravel-data": "^4.19"
-    },
-    "require-dev": {
-        "laravel-zero/framework": "^12.0.2",
-        "laravel/pint": "^1.25.1",
-        "mockery/mockery": "^1.6.12",
-        "pestphp/pest": "^3.8.4|^4.1.2",
-        "phpstan/phpstan": "^2.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "89b8cd27131096e576a6a52a2c47399e",
+    "content-hash": "d86b733a0c022f2a6b8da023dac894ca",
     "packages": [
         {
             "name": "brick/math",

--- a/release.sh
+++ b/release.sh
@@ -136,6 +136,22 @@ if [ -f ".env.bak" ]; then
     info "Restored .env from .env.bak"
 fi
 
+info "Smoke testing binary..."
+
+if [ ! -f "builds/cloud" ]; then
+    abort "Build output builds/cloud not found."
+fi
+
+SMOKE_VERSION=$(./builds/cloud --version 2>&1) || abort "Binary failed to execute: $SMOKE_VERSION"
+
+if ! echo "$SMOKE_VERSION" | grep -qF "$NEW_TAG"; then
+    abort "Binary reported unexpected version. Expected '$NEW_TAG', got: $SMOKE_VERSION"
+fi
+
+./builds/cloud list >/dev/null 2>&1 || abort "Binary failed to list commands — bundled dependencies may be broken."
+
+success "Smoke test passed: $SMOKE_VERSION"
+
 info "Committing build..."
 git add builds/cloud
 git commit -m "Build $NEW_TAG"


### PR DESCRIPTION
Since the CLI is shipped as a self-contained PHAR, the runtime deps in `require` were just conflict surface for anyone running `composer global require laravel/cloud-cli`, a pinned `illuminate/*` in another global package would block the install even though the PHAR doesn't need the outer vendor at all. Moved everything except `php: ^8.2` to `require-dev` so global installs have nothing left to collide with.

Also added a smoke test to `release.sh` that runs the freshly-built PHAR before the commit/push: checks the file exists, that `--version` matches the tag we just built, and that `list` boots cleanly (which exercises most bundled deps). Any failure aborts before anything is pushed or released.
