### PR TITLE
Added install skills middleware

### DIFF
--- a/app/Commands/SkillsInstall.php
+++ b/app/Commands/SkillsInstall.php
@@ -2,6 +2,7 @@
 
 namespace App\Commands;
 
+use App\Concerns\DetectsInstallScope;
 use App\Concerns\HasAgentSkillPaths;
 use App\Contracts\NoAuthRequired;
 use Illuminate\Http\Client\Pool;
@@ -16,6 +17,7 @@ use function Laravel\Prompts\warning;
 
 class SkillsInstall extends BaseCommand implements NoAuthRequired
 {
+    use DetectsInstallScope;
     use HasAgentSkillPaths;
 
     protected $signature = 'skills:install
@@ -104,7 +106,7 @@ class SkillsInstall extends BaseCommand implements NoAuthRequired
         $isProject = match (true) {
             $this->option('global') => false,
             $this->option('project') => true,
-            default => File::isDirectory(getcwd().'/vendor/laravel/cloud-cli'),
+            default => ! $this->isGloballyInstalled(),
         };
 
         $scope = $isProject ? 'project' : 'global';

--- a/app/Commands/SkillsInstall.php
+++ b/app/Commands/SkillsInstall.php
@@ -2,6 +2,7 @@
 
 namespace App\Commands;
 
+use App\Concerns\HasAgentSkillPaths;
 use App\Contracts\NoAuthRequired;
 use Illuminate\Http\Client\Pool;
 use Illuminate\Support\Facades\File;
@@ -15,6 +16,8 @@ use function Laravel\Prompts\warning;
 
 class SkillsInstall extends BaseCommand implements NoAuthRequired
 {
+    use HasAgentSkillPaths;
+
     protected $signature = 'skills:install
                             {--global : Install skills globally}
                             {--project : Install skills to the current project}
@@ -26,15 +29,6 @@ class SkillsInstall extends BaseCommand implements NoAuthRequired
     protected string $repo = 'laravel/agent-skills';
 
     protected string $repoPath = 'laravel-cloud/skills';
-
-    /** @var array<string, array{global: string, project: string}> */
-    protected array $agents = [
-        'claude' => ['global' => '~/.claude/skills', 'project' => '.claude/skills'],
-        'cursor' => ['global' => '~/.cursor/skills', 'project' => '.cursor/skills'],
-        'junie' => ['global' => '~/.junie/skills', 'project' => '.junie/skills'],
-        'github' => ['global' => '~/.github/skills', 'project' => '.github/skills'],
-        'agents' => ['global' => '~/.agents/skills', 'project' => '.agents/skills'],
-    ];
 
     public function handle(): int
     {
@@ -107,33 +101,24 @@ class SkillsInstall extends BaseCommand implements NoAuthRequired
      */
     protected function resolveSkillPaths(): array
     {
-        $home = $_SERVER['HOME'] ?? $_SERVER['USERPROFILE'] ?? '';
-        $cwd = getcwd();
-
         $isProject = match (true) {
             $this->option('global') => false,
             $this->option('project') => true,
-            default => File::isDirectory($cwd.'/vendor/laravel/cloud-cli'),
+            default => File::isDirectory(getcwd().'/vendor/laravel/cloud-cli'),
         };
 
         $scope = $isProject ? 'project' : 'global';
-        $selectedAgents = $this->resolveAgents($scope, $home, $cwd);
 
-        return array_map(function (string $agent) use ($scope, $home, $cwd) {
-            $path = $this->agents[$agent][$scope];
-
-            if ($scope === 'project') {
-                return $cwd.'/'.$path;
-            }
-
-            return str_replace('~', $home, $path);
-        }, $selectedAgents);
+        return array_map(
+            fn (string $agent) => $this->resolveAgentSkillPath($agent, $scope),
+            $this->resolveAgents($scope),
+        );
     }
 
     /**
      * @return array<int, string>
      */
-    protected function resolveAgents(string $scope, string $home, string $cwd): array
+    protected function resolveAgents(string $scope): array
     {
         $explicit = array_filter($this->option('agent'));
 
@@ -141,7 +126,7 @@ class SkillsInstall extends BaseCommand implements NoAuthRequired
             return array_values(array_intersect($explicit, array_keys($this->agents)));
         }
 
-        $detected = $this->detectAgents($scope, $home, $cwd);
+        $detected = $this->detectAgents($scope);
 
         if ($this->input->isInteractive()) {
             $options = collect($this->agents)->keys()->mapWithKeys(fn (string $agent) => [
@@ -159,31 +144,6 @@ class SkillsInstall extends BaseCommand implements NoAuthRequired
         }
 
         return $detected ?: array_keys($this->agents);
-    }
-
-    /**
-     * @return array<int, string>
-     */
-    protected function detectAgents(string $scope, string $home, string $cwd): array
-    {
-        $detected = [];
-
-        foreach ($this->agents as $agent => $paths) {
-            $skillPath = $paths[$scope];
-            $parentDir = dirname($skillPath);
-
-            if ($scope === 'project') {
-                $parentDir = $cwd.'/'.$parentDir;
-            } else {
-                $parentDir = str_replace('~', $home, $parentDir);
-            }
-
-            if (File::isDirectory($parentDir)) {
-                $detected[] = $agent;
-            }
-        }
-
-        return $detected;
     }
 
     /**

--- a/app/Concerns/DetectsInstallScope.php
+++ b/app/Concerns/DetectsInstallScope.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Concerns;
+
+use Illuminate\Support\Facades\File;
+
+trait DetectsInstallScope
+{
+    /**
+     * Whether the CLI is installed globally (as opposed to being
+     * required as a project-level dependency in the current directory).
+     */
+    protected function isGloballyInstalled(): bool
+    {
+        $cwd = getcwd();
+
+        if ($cwd === false) {
+            return true;
+        }
+
+        return ! File::isDirectory($cwd.'/vendor/laravel/cloud-cli');
+    }
+}

--- a/app/Concerns/HasAgentSkillPaths.php
+++ b/app/Concerns/HasAgentSkillPaths.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Concerns;
+
+use Illuminate\Support\Facades\File;
+
+trait HasAgentSkillPaths
+{
+    /** @var array<string, array{global: string, project: string}> */
+    protected array $agents = [
+        'claude' => ['global' => '~/.claude/skills', 'project' => '.claude/skills'],
+        'cursor' => ['global' => '~/.cursor/skills', 'project' => '.cursor/skills'],
+        'junie' => ['global' => '~/.junie/skills', 'project' => '.junie/skills'],
+        'github' => ['global' => '~/.github/skills', 'project' => '.github/skills'],
+        'agents' => ['global' => '~/.agents/skills', 'project' => '.agents/skills'],
+    ];
+
+    protected function resolveAgentSkillPath(string $agent, string $scope = 'global'): string
+    {
+        $path = $this->agents[$agent][$scope];
+
+        if ($scope === 'project') {
+            return getcwd().'/'.$path;
+        }
+
+        $home = $_SERVER['HOME'] ?? $_SERVER['USERPROFILE'] ?? '';
+
+        return str_replace('~', $home, $path);
+    }
+
+    /**
+     * Agents whose parent directory exists on disk for the given scope.
+     *
+     * @return array<int, string>
+     */
+    protected function detectAgents(string $scope = 'global'): array
+    {
+        $detected = [];
+
+        foreach (array_keys($this->agents) as $agent) {
+            $parent = dirname($this->resolveAgentSkillPath($agent, $scope));
+
+            if (File::isDirectory($parent)) {
+                $detected[] = $agent;
+            }
+        }
+
+        return $detected;
+    }
+}

--- a/app/Middleware/Concerns/SkipsInternalCommands.php
+++ b/app/Middleware/Concerns/SkipsInternalCommands.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Middleware\Concerns;
+
+trait SkipsInternalCommands
+{
+    /**
+     * Framework/tooling commands that user-flow middleware should skip.
+     */
+    protected function isInternalCommand(mixed $command): bool
+    {
+        $name = is_string($command) ? $command : $command?->getName();
+
+        return in_array($name, [
+            'list',
+            'help',
+            'app:build',
+            '_complete',
+            'completion',
+        ], true);
+    }
+}

--- a/app/Middleware/OffersSkillsInstall.php
+++ b/app/Middleware/OffersSkillsInstall.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace App\Middleware;
+
+use App\Concerns\HasAgentSkillPaths;
+use App\ConfigRepository;
+use App\Middleware\Concerns\SkipsInternalCommands;
+use App\Support\DetectsNonInteractiveEnvironments;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+
+use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\note;
+
+class OffersSkillsInstall implements CommandMiddleware
+{
+    use DetectsNonInteractiveEnvironments;
+    use HasAgentSkillPaths;
+    use SkipsInternalCommands;
+
+    protected const SKIP_COMMANDS = [
+        'skills:install',
+        'auth',
+        'login',
+    ];
+
+    protected const MARKER_SKILL = 'deploying-laravel-cloud';
+
+    public function handle($command, callable $next)
+    {
+        if ($this->isInternalCommand($command)) {
+            return $next();
+        }
+
+        $name = is_string($command) ? $command : $command?->getName();
+
+        if (in_array($name, self::SKIP_COMMANDS, true)) {
+            return $next();
+        }
+
+        if (! $this->isInteractiveSession()) {
+            return $next();
+        }
+
+        if (! $this->isGloballyInstalled()) {
+            return $next();
+        }
+
+        $detectedAgents = $this->detectAgents();
+
+        if ($detectedAgents === []) {
+            return $next();
+        }
+
+        if ($this->skillsAlreadyInstalled($detectedAgents)) {
+            return $next();
+        }
+
+        $config = app(ConfigRepository::class);
+
+        if ($config->get('skills_install_prompted')) {
+            return $next();
+        }
+
+        $config->set('skills_install_prompted', true);
+
+        $install = confirm(
+            label: 'Install Laravel Cloud skills for AI agents?',
+            default: true,
+            hint: 'Adds slash commands/guidance so your agent knows how to use the CLI.',
+        );
+
+        if ($install) {
+            $this->runInstall();
+        } else {
+            $this->showDeclineHint();
+        }
+
+        return $next();
+    }
+
+    protected function runInstall(): void
+    {
+        Artisan::call('skills:install');
+    }
+
+    protected function showDeclineHint(): void
+    {
+        note('You can install them later with: cloud skills:install');
+    }
+
+    protected function isInteractiveSession(): bool
+    {
+        if ($this->isNonInteractiveEnvironment()) {
+            return false;
+        }
+
+        if (! stream_isatty(STDIN)) {
+            return false;
+        }
+
+        $args = $_SERVER['argv'] ?? [];
+
+        return collect($args)->intersect(['--json', '--no-interaction', '-n'])->isEmpty();
+    }
+
+    protected function isGloballyInstalled(): bool
+    {
+        $cwd = getcwd();
+
+        if ($cwd === false) {
+            return true;
+        }
+
+        return ! File::isDirectory($cwd.'/vendor/laravel/cloud-cli');
+    }
+
+    /**
+     * @param  array<int, string>  $agents
+     */
+    protected function skillsAlreadyInstalled(array $agents): bool
+    {
+        foreach ($agents as $agent) {
+            $skillsPath = $this->resolveAgentSkillPath($agent);
+
+            if (File::isDirectory($skillsPath.'/'.self::MARKER_SKILL)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/app/Middleware/OffersSkillsInstall.php
+++ b/app/Middleware/OffersSkillsInstall.php
@@ -2,6 +2,8 @@
 
 namespace App\Middleware;
 
+use App\Commands\SkillsInstall;
+use App\Concerns\DetectsInstallScope;
 use App\Concerns\HasAgentSkillPaths;
 use App\ConfigRepository;
 use App\Middleware\Concerns\SkipsInternalCommands;
@@ -11,10 +13,10 @@ use Illuminate\Support\Facades\File;
 
 use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\info;
-use function Laravel\Prompts\note;
 
 class OffersSkillsInstall implements CommandMiddleware
 {
+    use DetectsInstallScope;
     use DetectsNonInteractiveEnvironments;
     use HasAgentSkillPaths;
     use SkipsInternalCommands;
@@ -74,23 +76,12 @@ class OffersSkillsInstall implements CommandMiddleware
 
     protected function runInstall(): void
     {
-        Artisan::call('skills:install');
+        Artisan::call(SkillsInstall::class);
     }
 
     protected function showDeclineHint(): void
     {
         info('You can install them later with: <comment>cloud skills:install</comment>');
-    }
-
-    protected function isGloballyInstalled(): bool
-    {
-        $cwd = getcwd();
-
-        if ($cwd === false) {
-            return true;
-        }
-
-        return ! File::isDirectory($cwd . '/vendor/laravel/cloud-cli');
     }
 
     /**
@@ -101,7 +92,7 @@ class OffersSkillsInstall implements CommandMiddleware
         foreach ($agents as $agent) {
             $skillsPath = $this->resolveAgentSkillPath($agent);
 
-            if (File::isDirectory($skillsPath . '/' . self::MARKER_SKILL)) {
+            if (File::isDirectory($skillsPath.'/'.self::MARKER_SKILL)) {
                 return true;
             }
         }

--- a/app/Middleware/OffersSkillsInstall.php
+++ b/app/Middleware/OffersSkillsInstall.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\File;
 
 use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\info;
 use function Laravel\Prompts\note;
 
 class OffersSkillsInstall implements CommandMiddleware
@@ -50,14 +51,14 @@ class OffersSkillsInstall implements CommandMiddleware
 
         $config = app(ConfigRepository::class);
 
-        if ($config->get('skills_install_prompted')) {
+        if ($config->get('skills_install_prompted_at')) {
             return $next();
         }
 
-        $config->set('skills_install_prompted', true);
+        $config->set('skills_install_prompted_at', now()->toIso8601String());
 
         $install = confirm(
-            label: 'Install Laravel Cloud skills for AI agents?',
+            label: 'Install Laravel Cloud CLI skills for AI agents?',
             default: true,
             hint: 'Adds slash commands/guidance so your agent knows how to use the CLI.',
         );
@@ -78,7 +79,7 @@ class OffersSkillsInstall implements CommandMiddleware
 
     protected function showDeclineHint(): void
     {
-        note('You can install them later with: cloud skills:install');
+        info('You can install them later with: <comment>cloud skills:install</comment>');
     }
 
     protected function isGloballyInstalled(): bool

--- a/app/Middleware/OffersSkillsInstall.php
+++ b/app/Middleware/OffersSkillsInstall.php
@@ -34,25 +34,17 @@ class OffersSkillsInstall implements CommandMiddleware
 
         $name = is_string($command) ? $command : $command?->getName();
 
-        if (in_array($name, self::SKIP_COMMANDS, true)) {
-            return $next();
-        }
-
-        if (! $this->isInteractiveSession()) {
-            return $next();
-        }
-
-        if (! $this->isGloballyInstalled()) {
+        if (
+            in_array($name, self::SKIP_COMMANDS)
+            || ! $this->isInteractiveSession()
+            || ! $this->isGloballyInstalled()
+        ) {
             return $next();
         }
 
         $detectedAgents = $this->detectAgents();
 
-        if ($detectedAgents === []) {
-            return $next();
-        }
-
-        if ($this->skillsAlreadyInstalled($detectedAgents)) {
+        if ($detectedAgents === [] || $this->skillsAlreadyInstalled($detectedAgents)) {
             return $next();
         }
 
@@ -89,21 +81,6 @@ class OffersSkillsInstall implements CommandMiddleware
         note('You can install them later with: cloud skills:install');
     }
 
-    protected function isInteractiveSession(): bool
-    {
-        if ($this->isNonInteractiveEnvironment()) {
-            return false;
-        }
-
-        if (! stream_isatty(STDIN)) {
-            return false;
-        }
-
-        $args = $_SERVER['argv'] ?? [];
-
-        return collect($args)->intersect(['--json', '--no-interaction', '-n'])->isEmpty();
-    }
-
     protected function isGloballyInstalled(): bool
     {
         $cwd = getcwd();
@@ -112,7 +89,7 @@ class OffersSkillsInstall implements CommandMiddleware
             return true;
         }
 
-        return ! File::isDirectory($cwd.'/vendor/laravel/cloud-cli');
+        return ! File::isDirectory($cwd . '/vendor/laravel/cloud-cli');
     }
 
     /**
@@ -123,7 +100,7 @@ class OffersSkillsInstall implements CommandMiddleware
         foreach ($agents as $agent) {
             $skillsPath = $this->resolveAgentSkillPath($agent);
 
-            if (File::isDirectory($skillsPath.'/'.self::MARKER_SKILL)) {
+            if (File::isDirectory($skillsPath . '/' . self::MARKER_SKILL)) {
                 return true;
             }
         }

--- a/app/Middleware/RequiresAuthToken.php
+++ b/app/Middleware/RequiresAuthToken.php
@@ -4,16 +4,18 @@ namespace App\Middleware;
 
 use App\Concerns\HasAClient;
 use App\Contracts\NoAuthRequired;
+use App\Middleware\Concerns\SkipsInternalCommands;
 use Illuminate\Support\Facades\Artisan;
 use RuntimeException;
 
 class RequiresAuthToken implements CommandMiddleware
 {
     use HasAClient;
+    use SkipsInternalCommands;
 
     public function handle($command, callable $next)
     {
-        if (in_array($command, ['list', 'help', 'app:build', '_complete', 'completion'])) {
+        if ($this->isInternalCommand($command)) {
             return $next();
         }
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use App\Middleware\CommandMiddlewareManager;
+use App\Middleware\OffersSkillsInstall;
 use App\Middleware\RequiresAuthToken;
 use App\Middleware\SuppressOutputIfJson;
 use App\Prompts\Answered;
@@ -81,6 +82,7 @@ class AppServiceProvider extends ServiceProvider
 
         $manager->register(SuppressOutputIfJson::class);
         $manager->register(RequiresAuthToken::class);
+        $manager->register(OffersSkillsInstall::class);
 
         if ($this->app->bound(EventDispatcherInterface::class)) {
             $dispatcher = $this->app->make(EventDispatcherInterface::class);

--- a/app/Support/DetectsNonInteractiveEnvironments.php
+++ b/app/Support/DetectsNonInteractiveEnvironments.php
@@ -34,4 +34,23 @@ trait DetectsNonInteractiveEnvironments
 
         return false;
     }
+
+    /**
+     * Pre-option-parse interactivity check — suitable for middleware where
+     * Symfony hasn't bound options yet, so we scan argv directly.
+     */
+    protected function isInteractiveSession(): bool
+    {
+        if ($this->isNonInteractiveEnvironment()) {
+            return false;
+        }
+
+        if (! stream_isatty(STDIN)) {
+            return false;
+        }
+
+        $args = $_SERVER['argv'] ?? [];
+
+        return collect($args)->intersect(['--json', '--no-interaction', '-n'])->isEmpty();
+    }
 }

--- a/tests/Feature/OffersSkillsInstallTest.php
+++ b/tests/Feature/OffersSkillsInstallTest.php
@@ -1,0 +1,113 @@
+<?php
+
+use App\ConfigRepository;
+use App\Middleware\OffersSkillsInstall;
+use Laravel\Prompts\Key;
+use Laravel\Prompts\Prompt;
+
+beforeEach(function () {
+    $this->mockConfig = Mockery::mock(ConfigRepository::class);
+    $this->app->instance(ConfigRepository::class, $this->mockConfig);
+});
+
+function runMiddleware(OffersSkillsInstall $middleware, string $command = 'application:list'): bool
+{
+    $called = false;
+
+    $middleware->handle($command, function () use (&$called) {
+        $called = true;
+    });
+
+    return $called;
+}
+
+function partialMiddleware(array $overrides = []): OffersSkillsInstall
+{
+    $defaults = [
+        'isInteractiveSession' => true,
+        'isGloballyInstalled' => true,
+        'detectAgents' => ['claude'],
+        'skillsAlreadyInstalled' => false,
+    ];
+
+    $middleware = Mockery::mock(OffersSkillsInstall::class)->makePartial();
+    $middleware->shouldAllowMockingProtectedMethods();
+
+    foreach (array_merge($defaults, $overrides) as $method => $value) {
+        $middleware->shouldReceive($method)->andReturn($value);
+    }
+
+    return $middleware;
+}
+
+it('skips when the command is in the skip list', function () {
+    $this->mockConfig->shouldNotReceive('get');
+
+    expect(runMiddleware(new OffersSkillsInstall, 'auth'))->toBeTrue();
+});
+
+it('skips when the session is non-interactive', function () {
+    // Under phpunit, STDIN is not a TTY so isInteractiveSession() returns false.
+    $this->mockConfig->shouldNotReceive('get');
+
+    expect(runMiddleware(new OffersSkillsInstall))->toBeTrue();
+});
+
+it('skips when the CLI is a project dependency', function () {
+    $this->mockConfig->shouldNotReceive('get');
+
+    $middleware = partialMiddleware(['isGloballyInstalled' => false]);
+
+    expect(runMiddleware($middleware))->toBeTrue();
+});
+
+it('skips when no agents are detected', function () {
+    $this->mockConfig->shouldNotReceive('get');
+
+    $middleware = partialMiddleware(['detectAgents' => []]);
+
+    expect(runMiddleware($middleware))->toBeTrue();
+});
+
+it('skips when skills are already installed for a detected agent', function () {
+    $this->mockConfig->shouldNotReceive('get');
+
+    $middleware = partialMiddleware(['skillsAlreadyInstalled' => true]);
+
+    expect(runMiddleware($middleware))->toBeTrue();
+});
+
+it('skips when the prompted flag is already set', function () {
+    $this->mockConfig->shouldReceive('get')->with('skills_install_prompted')->andReturn(true);
+    $this->mockConfig->shouldNotReceive('set');
+
+    $middleware = partialMiddleware();
+
+    expect(runMiddleware($middleware))->toBeTrue();
+});
+
+it('prompts, installs skills, and records the choice when the user confirms', function () {
+    Prompt::fake([Key::ENTER]);
+
+    $this->mockConfig->shouldReceive('get')->with('skills_install_prompted')->andReturn(false);
+    $this->mockConfig->shouldReceive('set')->with('skills_install_prompted', true)->once();
+
+    $middleware = partialMiddleware();
+    $middleware->shouldReceive('runInstall')->once();
+    $middleware->shouldReceive('showDeclineHint')->never();
+
+    expect(runMiddleware($middleware))->toBeTrue();
+});
+
+it('records the choice without installing when the user declines', function () {
+    Prompt::fake([Key::TAB, Key::ENTER]);
+
+    $this->mockConfig->shouldReceive('get')->with('skills_install_prompted')->andReturn(false);
+    $this->mockConfig->shouldReceive('set')->with('skills_install_prompted', true)->once();
+
+    $middleware = partialMiddleware();
+    $middleware->shouldReceive('runInstall')->never();
+    $middleware->shouldReceive('showDeclineHint')->once();
+
+    expect(runMiddleware($middleware))->toBeTrue();
+});

--- a/tests/Feature/OffersSkillsInstallTest.php
+++ b/tests/Feature/OffersSkillsInstallTest.php
@@ -78,7 +78,7 @@ it('skips when skills are already installed for a detected agent', function () {
 });
 
 it('skips when the prompted flag is already set', function () {
-    $this->mockConfig->shouldReceive('get')->with('skills_install_prompted')->andReturn(true);
+    $this->mockConfig->shouldReceive('get')->with('skills_install_prompted_at')->andReturn('2026-04-20T12:00:00+00:00');
     $this->mockConfig->shouldNotReceive('set');
 
     $middleware = partialMiddleware();
@@ -89,8 +89,10 @@ it('skips when the prompted flag is already set', function () {
 it('prompts, installs skills, and records the choice when the user confirms', function () {
     Prompt::fake([Key::ENTER]);
 
-    $this->mockConfig->shouldReceive('get')->with('skills_install_prompted')->andReturn(false);
-    $this->mockConfig->shouldReceive('set')->with('skills_install_prompted', true)->once();
+    $this->mockConfig->shouldReceive('get')->with('skills_install_prompted_at')->andReturn(null);
+    $this->mockConfig->shouldReceive('set')
+        ->with('skills_install_prompted_at', Mockery::type('string'))
+        ->once();
 
     $middleware = partialMiddleware();
     $middleware->shouldReceive('runInstall')->once();
@@ -102,8 +104,10 @@ it('prompts, installs skills, and records the choice when the user confirms', fu
 it('records the choice without installing when the user declines', function () {
     Prompt::fake([Key::TAB, Key::ENTER]);
 
-    $this->mockConfig->shouldReceive('get')->with('skills_install_prompted')->andReturn(false);
-    $this->mockConfig->shouldReceive('set')->with('skills_install_prompted', true)->once();
+    $this->mockConfig->shouldReceive('get')->with('skills_install_prompted_at')->andReturn(null);
+    $this->mockConfig->shouldReceive('set')
+        ->with('skills_install_prompted_at', Mockery::type('string'))
+        ->once();
 
     $middleware = partialMiddleware();
     $middleware->shouldReceive('runInstall')->never();


### PR DESCRIPTION
On first run, offer to install the Laravel Cloud CLI skills for any AI agents detected on the user's machine (Claude, Cursor, etc.). Yes runs `skills:install`, no prints a hint about `cloud skills:install` and records the timestamp in `~/.config/cloud/config.json` so we never ask again. 

The prompt is gated to interactive sessions on a globally-installed CLI where skills aren't already there and at least one agent directory exists, agents running the CLI non-interactively won't see it. Done as a `CommandMiddleware` that runs after auth.