### PR TITLE
Attach database, cache, and WebSocket app via environment:update

### DIFF
--- a/app/Commands/EnvironmentUpdate.php
+++ b/app/Commands/EnvironmentUpdate.php
@@ -171,7 +171,7 @@ class EnvironmentUpdate extends BaseCommand
             $selectedClusterId = (string) select(
                 label: 'Database cluster',
                 options: $clusterOptions,
-                default: $currentCluster?->id ?? '',
+                default: $currentCluster !== null ? $currentCluster->id : '',
             );
 
             if ($selectedClusterId === '') {
@@ -248,7 +248,7 @@ class EnvironmentUpdate extends BaseCommand
             $selectedClusterId = (string) select(
                 label: 'WebSocket cluster',
                 options: $clusterOptions,
-                default: $currentCluster?->id ?? '',
+                default: $currentCluster !== null ? $currentCluster->id : '',
             );
 
             if ($selectedClusterId === '') {

--- a/app/Commands/EnvironmentUpdate.php
+++ b/app/Commands/EnvironmentUpdate.php
@@ -3,11 +3,16 @@
 namespace App\Commands;
 
 use App\Client\Requests\UpdateEnvironmentRequestData;
+use App\Dto\Cache;
+use App\Dto\Database;
 use App\Dto\Environment;
+use App\Dto\WebsocketApplication;
+use App\Dto\WebsocketCluster;
 use App\Exceptions\CommandExitException;
 
 use function Laravel\Prompts\intro;
 use function Laravel\Prompts\multiselect;
+use function Laravel\Prompts\select;
 use function Laravel\Prompts\spin;
 use function Laravel\Prompts\text;
 use function Laravel\Prompts\textarea;
@@ -21,6 +26,9 @@ class EnvironmentUpdate extends BaseCommand
                             {--branch= : Git branch}
                             {--build-command= : Build command}
                             {--deploy-command= : Deploy command}
+                            {--database-id= : Database ID to attach (empty string to detach)}
+                            {--cache-id= : Cache ID to attach (empty string to detach)}
+                            {--websocket-application-id= : WebSocket application ID to attach (empty string to detach)}
                             {--force : Force update without confirmation}';
 
     protected $description = 'Update an environment';
@@ -64,6 +72,9 @@ class EnvironmentUpdate extends BaseCommand
                     branch: $this->form()->get('branch'),
                     buildCommand: $this->form()->get('build_command'),
                     deployCommand: $this->form()->get('deploy_command'),
+                    databaseSchemaId: $this->form()->get('database_id'),
+                    cacheId: $this->form()->get('cache_id'),
+                    websocketApplicationId: $this->form()->get('websocket_application_id'),
                 ),
             ),
             'Updating environment...',
@@ -105,6 +116,169 @@ class EnvironmentUpdate extends BaseCommand
             ),
             'deploy-command',
         )->setPreviousValue($environment->deployCommand ?? '');
+
+        $this->form()->define(
+            'database_id',
+            fn ($resolver) => $resolver->fromInput(
+                fn ($value) => $this->selectDatabase($value, $environment->databaseSchemaId),
+            ),
+            'database-id',
+        )->setPreviousValue($environment->databaseSchemaId ?? '');
+
+        $this->form()->define(
+            'cache_id',
+            fn ($resolver) => $resolver->fromInput(
+                fn ($value) => $this->selectCache($value, $environment->cacheId),
+            ),
+            'cache-id',
+        )->setPreviousValue($environment->cacheId ?? '');
+
+        $this->form()->define(
+            'websocket_application_id',
+            fn ($resolver) => $resolver->fromInput(
+                fn ($value) => $this->selectWebsocketApplication($value, $environment->websocketApplicationId),
+            ),
+            'websocket-application-id',
+        )->setPreviousValue($environment->websocketApplicationId ?? '');
+    }
+
+    protected function selectDatabase(?string $value, ?string $currentId): string
+    {
+        $clusters = spin(
+            fn () => $this->client->databaseClusters()->include('schemas')->list()->collect(),
+            'Fetching databases...',
+        );
+
+        $clustersWithSchemas = $clusters->filter(fn ($cluster) => ! empty($cluster->schemas))->values();
+
+        if ($clustersWithSchemas->isEmpty()) {
+            $this->failAndExit('No databases found. Create one with `cloud database-cluster:create` and `cloud database:create`.');
+        }
+
+        $currentCluster = $clustersWithSchemas->first(
+            fn ($cluster) => collect($cluster->schemas)->contains(fn (Database $schema) => $schema->id === $currentId),
+        );
+
+        if ($clustersWithSchemas->count() === 1) {
+            $selectedCluster = $clustersWithSchemas->first();
+        } else {
+            $clusterOptions = $currentId ? ['' => '— Detach —'] : [];
+
+            foreach ($clustersWithSchemas as $cluster) {
+                $clusterOptions[$cluster->id] = $cluster->name;
+            }
+
+            $selectedClusterId = (string) select(
+                label: 'Database cluster',
+                options: $clusterOptions,
+                default: $currentCluster?->id ?? '',
+            );
+
+            if ($selectedClusterId === '') {
+                return '';
+            }
+
+            $selectedCluster = $clustersWithSchemas->firstWhere('id', $selectedClusterId);
+        }
+
+        $options = $currentId ? ['' => '— Detach —'] : [];
+
+        foreach ($selectedCluster->schemas as $schema) {
+            /** @var Database $schema */
+            $options[$schema->id] = $schema->id === $currentId ? "{$schema->name} (current)" : $schema->name;
+        }
+
+        return (string) select(
+            label: 'Database to attach',
+            options: $options,
+            default: $value ?? ($selectedCluster->id === $currentCluster?->id ? $currentId : null) ?? '',
+        );
+    }
+
+    protected function selectCache(?string $value, ?string $currentId): string
+    {
+        $caches = spin(
+            fn () => $this->client->caches()->list()->collect(),
+            'Fetching caches...',
+        );
+
+        if ($caches->isEmpty()) {
+            $this->failAndExit('No caches found. Create one with `cloud cache:create`.');
+        }
+
+        $options = $currentId ? ['' => '— Detach —'] : [];
+
+        foreach ($caches as $cache) {
+            /** @var Cache $cache */
+            $options[$cache->id] = $cache->id === $currentId ? "{$cache->name} (current)" : $cache->name;
+        }
+
+        return (string) select(
+            label: 'Cache to attach',
+            options: $options,
+            default: $value ?? $currentId ?? '',
+        );
+    }
+
+    protected function selectWebsocketApplication(?string $value, ?string $currentId): string
+    {
+        $clusters = spin(
+            fn () => $this->client->websocketClusters()->list()->collect(),
+            'Fetching WebSocket clusters...',
+        );
+
+        if ($clusters->isEmpty()) {
+            $this->failAndExit('No WebSocket clusters found. Create one with `cloud websocket-cluster:create` and `cloud websocket-application:create`.');
+        }
+
+        $currentCluster = $clusters->first(
+            fn (WebsocketCluster $cluster) => in_array($currentId, $cluster->applicationIds, true),
+        );
+
+        if ($clusters->count() === 1) {
+            $selectedCluster = $clusters->first();
+        } else {
+            $clusterOptions = $currentId ? ['' => '— Detach —'] : [];
+
+            foreach ($clusters as $cluster) {
+                /** @var WebsocketCluster $cluster */
+                $clusterOptions[$cluster->id] = $cluster->name;
+            }
+
+            $selectedClusterId = (string) select(
+                label: 'WebSocket cluster',
+                options: $clusterOptions,
+                default: $currentCluster?->id ?? '',
+            );
+
+            if ($selectedClusterId === '') {
+                return '';
+            }
+
+            $selectedCluster = $clusters->firstWhere('id', $selectedClusterId);
+        }
+
+        $apps = spin(
+            fn () => $this->client->websocketApplications()->list($selectedCluster->id)->collect(),
+            'Fetching WebSocket applications...',
+        );
+
+        if ($apps->isEmpty()) {
+            $this->failAndExit('No WebSocket applications in that cluster. Create one with `cloud websocket-application:create`.');
+        }
+
+        $options = $currentId ? ['' => '— Detach —'] : [];
+
+        foreach ($apps as $app) {
+            /** @var WebsocketApplication $app */
+            $options[$app->id] = $app->id === $currentId ? "{$app->name} (current)" : $app->name;
+        }
+
+        return (string) select(
+            label: 'WebSocket application to attach',
+            options: $options,
+            default: $value ?? ($selectedCluster->id === $currentCluster?->id ? $currentId : null) ?? '',
+        );
     }
 
     protected function collectDataAndUpdate(Environment $environment): Environment

--- a/app/Dto/Environment.php
+++ b/app/Dto/Environment.php
@@ -43,6 +43,9 @@ class Environment extends Data
         public readonly ?string $currentDeploymentId = null,
         public readonly array $domainIds = [],
         public readonly ?string $primaryDomainId = null,
+        public readonly ?string $databaseSchemaId = null,
+        public readonly ?string $cacheId = null,
+        public readonly ?string $websocketApplicationId = null,
     ) {
         //
     }
@@ -108,6 +111,18 @@ class Environment extends Data
 
         if (isset($relationships['primaryDomain']['data']['id'])) {
             $transformed['primaryDomainId'] = $relationships['primaryDomain']['data']['id'];
+        }
+
+        if (isset($relationships['database']['data']['id'])) {
+            $transformed['databaseSchemaId'] = $relationships['database']['data']['id'];
+        }
+
+        if (isset($relationships['cache']['data']['id'])) {
+            $transformed['cacheId'] = $relationships['cache']['data']['id'];
+        }
+
+        if (isset($relationships['websocketApplication']['data']['id'])) {
+            $transformed['websocketApplicationId'] = $relationships['websocketApplication']['data']['id'];
         }
 
         return self::from($transformed);

--- a/app/Support/ValueResolver.php
+++ b/app/Support/ValueResolver.php
@@ -28,7 +28,7 @@ class ValueResolver
         protected mixed $value = null,
         public readonly string $resolveFromType = 'argument',
     ) {
-        $this->label = str($argumentName)->replace('-', ' ')->ucfirst()->toString();
+        $this->label = str($argumentName)->replace('-', ' ')->replace(' id', '')->ucfirst()->toString();
     }
 
     public function setPreviousValue(mixed $value): self


### PR DESCRIPTION
Closes #130. 

The API's `PATCH /environments/{id}` has always accepted `database_schema_id`, `cache_id`, and `websocket_application_id` and the `UpdateEnvironmentRequestData` DTO already had them wired, but no CLI command surfaced it, so users were stuck using the dashboard to attach databases to environments.

Adds `--database-id`, `--cache-id`, and `--websocket-application-id` flags to `environment:update`. Pass an empty string to detach. Interactive mode fetches the relevant resources from the API and shows a select with the currently attached item marked `(current)`; for databases and WebSockets the user picks a cluster first when there's more than one.

Also extends the `Environment` DTO to parse the `database`, `cache`, and `websocketApplication` relationships, so those IDs now appear in `--json` output.
