### PR TITLE
Accept bucket arg on bucket-key:delete and bucket-key:update

### DIFF
--- a/app/Commands/BucketKeyDelete.php
+++ b/app/Commands/BucketKeyDelete.php
@@ -8,6 +8,7 @@ use function Laravel\Prompts\spin;
 class BucketKeyDelete extends BaseCommand
 {
     protected $signature = 'bucket-key:delete
+                            {bucket? : The bucket ID or name}
                             {key? : The key ID or name}
                             {--force : Skip confirmation}';
 
@@ -19,7 +20,7 @@ class BucketKeyDelete extends BaseCommand
 
         intro('Deleting Bucket Key');
 
-        $bucket = $this->resolvers()->objectStorageBucket()->resolve();
+        $bucket = $this->resolvers()->objectStorageBucket()->from($this->argument('bucket'));
         $key = $this->resolvers()->bucketKey()->from($bucket, $this->argument('key'));
 
         $this->confirmDestructive("Delete key '{$key->name}'?");

--- a/app/Commands/BucketKeyUpdate.php
+++ b/app/Commands/BucketKeyUpdate.php
@@ -14,6 +14,7 @@ class BucketKeyUpdate extends BaseCommand
     protected ?string $jsonDataClass = BucketKey::class;
 
     protected $signature = 'bucket-key:update
+                            {bucket? : The bucket ID or name}
                             {key? : The key ID or name}
                             {--name= : Key name}
                             {--force : Force update without confirmation}';
@@ -26,7 +27,7 @@ class BucketKeyUpdate extends BaseCommand
 
         intro('Updating Bucket Key');
 
-        $bucket = $this->resolvers()->objectStorageBucket()->resolve();
+        $bucket = $this->resolvers()->objectStorageBucket()->from($this->argument('bucket'));
         $key = $this->resolvers()->bucketKey()->from($bucket, $this->argument('key'));
 
         $this->defineFields($key);


### PR DESCRIPTION
Both commands were missing the `{bucket?}` positional argument that the other `bucket-key:*` commands already accept, which meant the bucket could only be picked interactively. That blocked any non-interactive use and was inconsistent with siblings like `bucket-key:create|get|list`.

Adds the arg to both signatures and swaps the `->resolve()` call for `->from($this->argument('bucket'))` so the identifier actually flows through to the resolver.

Refs #115
