### PR TITLE
Return SUCCESS when list commands find no results

### DIFF
--- a/app/Commands/ApplicationList.php
+++ b/app/Commands/ApplicationList.php
@@ -39,7 +39,7 @@ class ApplicationList extends BaseCommand
         if ($applications->isEmpty()) {
             warning('No applications found.');
 
-            return self::FAILURE;
+            return self::SUCCESS;
         }
 
         dataTable(

--- a/app/Commands/BackgroundProcessList.php
+++ b/app/Commands/BackgroundProcessList.php
@@ -41,7 +41,7 @@ class BackgroundProcessList extends BaseCommand
         if ($items->isEmpty()) {
             warning('No background processes found.');
 
-            return self::FAILURE;
+            return self::SUCCESS;
         }
 
         dataTable(

--- a/app/Commands/BucketKeyList.php
+++ b/app/Commands/BucketKeyList.php
@@ -40,7 +40,7 @@ class BucketKeyList extends BaseCommand
         if ($items->isEmpty()) {
             warning('No keys found.');
 
-            return self::FAILURE;
+            return self::SUCCESS;
         }
 
         dataTable(

--- a/app/Commands/BucketList.php
+++ b/app/Commands/BucketList.php
@@ -44,7 +44,7 @@ class BucketList extends BaseCommand
         if ($buckets->isEmpty()) {
             warning('No buckets found.');
 
-            return self::FAILURE;
+            return self::SUCCESS;
         }
 
         dataTable(

--- a/app/Commands/CacheList.php
+++ b/app/Commands/CacheList.php
@@ -39,7 +39,7 @@ class CacheList extends BaseCommand
         if ($items->isEmpty()) {
             warning('No caches found.');
 
-            return self::FAILURE;
+            return self::SUCCESS;
         }
 
         dataTable(

--- a/app/Commands/CacheTypes.php
+++ b/app/Commands/CacheTypes.php
@@ -37,7 +37,7 @@ class CacheTypes extends BaseCommand
         if ($items->isEmpty()) {
             warning('No cache types found.');
 
-            return self::FAILURE;
+            return self::SUCCESS;
         }
 
         $rows = collect($types)->map(fn (CacheType $type, $index) => [

--- a/app/Commands/DatabaseClusterList.php
+++ b/app/Commands/DatabaseClusterList.php
@@ -39,7 +39,7 @@ class DatabaseClusterList extends BaseCommand
         if ($items->isEmpty()) {
             warning('No databases found.');
 
-            return self::FAILURE;
+            return self::SUCCESS;
         }
 
         dataTable(

--- a/app/Commands/DatabaseList.php
+++ b/app/Commands/DatabaseList.php
@@ -40,7 +40,7 @@ class DatabaseList extends BaseCommand
         if ($databases->isEmpty()) {
             warning('No databases found.');
 
-            return self::FAILURE;
+            return self::SUCCESS;
         }
 
         dataTable(

--- a/app/Commands/DatabaseSnapshotList.php
+++ b/app/Commands/DatabaseSnapshotList.php
@@ -42,7 +42,7 @@ class DatabaseSnapshotList extends BaseCommand
         if ($items->isEmpty()) {
             warning('No snapshots found.');
 
-            return self::FAILURE;
+            return self::SUCCESS;
         }
 
         dataTable(

--- a/app/Commands/DedicatedClusterList.php
+++ b/app/Commands/DedicatedClusterList.php
@@ -38,7 +38,7 @@ class DedicatedClusterList extends BaseCommand
         if ($items->isEmpty()) {
             warning('No dedicated clusters found.');
 
-            return self::FAILURE;
+            return self::SUCCESS;
         }
 
         $rows = $items->map(fn (DedicatedCluster $cluster) => [

--- a/app/Commands/DeploymentList.php
+++ b/app/Commands/DeploymentList.php
@@ -39,7 +39,7 @@ class DeploymentList extends BaseCommand
         if ($items->isEmpty()) {
             warning('No deployments found.');
 
-            return self::FAILURE;
+            return self::SUCCESS;
         }
 
         dataTable(

--- a/app/Commands/DomainList.php
+++ b/app/Commands/DomainList.php
@@ -39,7 +39,7 @@ class DomainList extends BaseCommand
         if ($items->isEmpty()) {
             warning('No domains found.');
 
-            return self::FAILURE;
+            return self::SUCCESS;
         }
 
         dataTable(

--- a/app/Commands/EnvironmentList.php
+++ b/app/Commands/EnvironmentList.php
@@ -44,7 +44,7 @@ class EnvironmentList extends BaseCommand
         if ($envItems->isEmpty()) {
             warning('No environments found.');
 
-            return self::FAILURE;
+            return self::SUCCESS;
         }
 
         dataTable(

--- a/app/Commands/InstanceList.php
+++ b/app/Commands/InstanceList.php
@@ -40,7 +40,7 @@ class InstanceList extends BaseCommand
         if ($items->isEmpty()) {
             warning('No instances found.');
 
-            return self::FAILURE;
+            return self::SUCCESS;
         }
 
         dataTable(

--- a/app/Commands/WebsocketApplicationList.php
+++ b/app/Commands/WebsocketApplicationList.php
@@ -42,7 +42,7 @@ class WebsocketApplicationList extends BaseCommand
         if ($items->isEmpty()) {
             warning('No WebSocket applications found.');
 
-            return self::FAILURE;
+            return self::SUCCESS;
         }
 
         dataTable(

--- a/app/Commands/WebsocketClusterList.php
+++ b/app/Commands/WebsocketClusterList.php
@@ -41,7 +41,7 @@ class WebsocketClusterList extends BaseCommand
         if ($items->isEmpty()) {
             warning('No WebSocket clusters found.');
 
-            return self::FAILURE;
+            return self::SUCCESS;
         }
 
         dataTable(


### PR DESCRIPTION
List commands were inconsistent: --json mode exited 0 on empty results (outputJsonIfWanted throws SUCCESS after writing), but interactive mode exited 1 with a warning. Normalizing toward 0 in both cases since an empty list is a valid state, not an error. Matches how gh, kubectl, doctl, and ls behave on empty results.

The "No X found." warning still prints in interactive mode so users aren't left wondering.

Closes #44
