### PR TITLE
Fix websocket-cluster:create in non-interactive mode

### DIFF
--- a/app/Commands/WebsocketClusterCreate.php
+++ b/app/Commands/WebsocketClusterCreate.php
@@ -17,7 +17,8 @@ class WebsocketClusterCreate extends BaseCommand
 
     protected $signature = 'websocket-cluster:create
                             {--name= : Cluster name}
-                            {--region= : Region}';
+                            {--region= : Region}
+                            {--max-connections= : Maximum connections per server}';
 
     protected $description = 'Create a WebSocket cluster';
 
@@ -32,11 +33,12 @@ class WebsocketClusterCreate extends BaseCommand
         $defaults = array_filter([
             'name' => $this->option('name'),
             'region' => $this->option('region') ?: $this->getDefaultRegion(),
+            'max_connections' => $this->option('max-connections'),
         ]);
 
-        $cluster = $this->loopUntilValid(
-            fn () => $this->createWebSocketCluster($defaults),
-        );
+        $cluster = $this->isInteractive()
+            ? $this->loopUntilValid(fn () => $this->createWebSocketCluster($defaults))
+            : $this->createWebSocketClusterWithOptions($defaults);
 
         $this->outputJsonIfWanted($cluster);
 


### PR DESCRIPTION
websocket-cluster:create threw in non-interactive mode because the shared prompt flow has no fallbacks. Added a --max-connections option and, when non-interactive, routed through the existing createWebSocketClusterWithOptions bypass that cloud ship already uses. Interactive behavior is unchanged.

Part of #47 (splitting into three PRs, one per affected command).
