### PR TITLE
Fix websocket-application:create in non-interactive mode

### DIFF
--- a/app/Commands/WebsocketApplicationCreate.php
+++ b/app/Commands/WebsocketApplicationCreate.php
@@ -15,7 +15,10 @@ class WebsocketApplicationCreate extends BaseCommand
 
     protected $signature = 'websocket-application:create
                             {cluster? : The WebSocket cluster ID or name}
-                            {--name= : Application name}';
+                            {--name= : Application name}
+                            {--ping-interval= : Ping interval in seconds}
+                            {--activity-timeout= : Activity timeout in seconds}
+                            {--allowed-origins= : Allowed origins (newline-separated)}';
 
     protected $description = 'Create a WebSocket application';
 
@@ -31,11 +34,14 @@ class WebsocketApplicationCreate extends BaseCommand
 
         $defaults = array_filter([
             'name' => $this->option('name'),
+            'ping_interval' => $this->option('ping-interval'),
+            'activity_timeout' => $this->option('activity-timeout'),
+            'allowed_origins' => $this->option('allowed-origins'),
         ]);
 
-        $app = $this->loopUntilValid(
-            fn () => $this->createWebSocketApplication($cluster, $defaults),
-        );
+        $app = $this->isInteractive()
+            ? $this->loopUntilValid(fn () => $this->createWebSocketApplication($cluster, $defaults))
+            : $this->createWebSocketApplicationWithOptions($cluster, $defaults);
 
         $this->outputJsonIfWanted($app);
 


### PR DESCRIPTION
websocket-application:create threw in non-interactive mode because the shared prompt flow has no fallbacks. Added --ping-interval, --activity-timeout, and --allowed-origins options, and when non-interactive routed through the existing createWebSocketApplicationWithOptions bypass that cloud ship already uses. Interactive behavior is unchanged.

Part of #47 (splitting into three PRs, one per affected command).
