### PR TITLE
Mask environment variable values in JSON output

### DIFF
--- a/app/Client/Requests/AddEnvironmentVariablesRequestData.php
+++ b/app/Client/Requests/AddEnvironmentVariablesRequestData.php
@@ -2,6 +2,8 @@
 
 namespace App\Client\Requests;
 
+use SensitiveParameter;
+
 class AddEnvironmentVariablesRequestData extends RequestData
 {
     /**
@@ -9,6 +11,7 @@ class AddEnvironmentVariablesRequestData extends RequestData
      */
     public function __construct(
         public readonly string $environmentId,
+        #[SensitiveParameter]
         public readonly array $variables,
         public readonly string $method = 'append',
     ) {

--- a/app/Client/Requests/ReplaceEnvironmentVariablesRequestData.php
+++ b/app/Client/Requests/ReplaceEnvironmentVariablesRequestData.php
@@ -2,12 +2,16 @@
 
 namespace App\Client\Requests;
 
+use SensitiveParameter;
+
 class ReplaceEnvironmentVariablesRequestData extends RequestData
 {
     public function __construct(
         public readonly string $environmentId,
+        #[SensitiveParameter]
         public readonly ?string $content = null,
         /** @var list<array{key: string, value: string}>|null */
+        #[SensitiveParameter]
         public readonly ?array $variables = null,
     ) {
         //

--- a/app/Client/Requests/UpdateEnvironmentRequestData.php
+++ b/app/Client/Requests/UpdateEnvironmentRequestData.php
@@ -2,6 +2,8 @@
 
 namespace App\Client\Requests;
 
+use SensitiveParameter;
+
 class UpdateEnvironmentRequestData extends RequestData
 {
     public function __construct(
@@ -25,6 +27,7 @@ class UpdateEnvironmentRequestData extends RequestData
         public readonly ?int $sleepTimeout = null,
         public readonly ?int $shutdownTimeout = null,
         public readonly ?bool $usesPurgeEdgeCacheOnDeploy = null,
+        #[SensitiveParameter]
         public readonly ?string $nightwatchToken = null,
         public readonly ?string $cacheStrategy = null,
         public readonly ?string $responseHeadersFrame = null,

--- a/app/Commands/BaseCommand.php
+++ b/app/Commands/BaseCommand.php
@@ -10,6 +10,7 @@ use App\Prompts\SuppressedOutput;
 use App\Resolvers\Resolvers;
 use App\Support\DetectsNonInteractiveEnvironments;
 use App\Support\Form;
+use App\Support\SensitiveValues;
 use App\Support\ValueResolver;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Support\Arr;
@@ -51,6 +52,7 @@ abstract class BaseCommand extends Command
 
         $this->addOption('json', null, InputOption::VALUE_NONE, 'Output as JSON');
         $this->addOption('fields', null, InputOption::VALUE_REQUIRED, 'Filter JSON output to specific fields (comma-separated, supports dot notation for nested fields)');
+        $this->addOption('show-sensitive', null, InputOption::VALUE_NONE, 'Reveal sensitive values (e.g. environment variables) in JSON output (masked by default)');
 
         if ($this->jsonDataClass) {
             $fields = $this->describeJsonFields($this->jsonDataClass);
@@ -236,6 +238,8 @@ abstract class BaseCommand extends Command
         if (! $this->wantsJson()) {
             return;
         }
+
+        SensitiveValues::$reveal = (bool) $this->option('show-sensitive');
 
         $json = $this->toJson($data);
 

--- a/app/Commands/EnvironmentVariables.php
+++ b/app/Commands/EnvironmentVariables.php
@@ -8,6 +8,7 @@ use App\Dto\Environment;
 
 use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\intro;
+use function Laravel\Prompts\password;
 use function Laravel\Prompts\spin;
 use function Laravel\Prompts\text;
 
@@ -112,6 +113,8 @@ class EnvironmentVariables extends BaseCommand
 
     protected function collectVariables(Environment $environment): array
     {
+        $reveal = (bool) $this->option('show-sensitive');
+        $variables = [];
         $adding = true;
         $counter = 0;
 
@@ -125,19 +128,31 @@ class EnvironmentVariables extends BaseCommand
                 )),
             );
 
+            $key = $this->form()->get('variables.'.$counter.'.key');
+
             $existingValue = collect($environment->environmentVariables)->firstWhere(
                 'key',
-                $this->form()->get('variables.'.$counter.'.key'),
+                $key,
             )['value'] ?? '';
 
-            $this->form()->prompt(
-                'variables.'.$counter.'.value',
-                fn ($resolver) => $resolver->fromInput(fn ($value) => text(
-                    label: 'Value',
-                    required: true,
-                    default: $value ?? $existingValue,
-                )),
-            );
+            if ($existingValue !== '' && confirm(
+                label: "Keep existing value for {$key}?",
+                default: true,
+            )) {
+                $value = $existingValue;
+            } else {
+                $this->form()->prompt(
+                    'variables.'.$counter.'.value',
+                    fn ($resolver) => $resolver->fromInput(fn ($value) => $reveal
+                        ? text(label: 'Value', required: true, default: $value ?? '')
+                        : password(label: 'Value', required: true),
+                    ),
+                );
+
+                $value = $this->form()->get('variables.'.$counter.'.value');
+            }
+
+            $variables[] = ['key' => $key, 'value' => $value];
 
             $adding = confirm(
                 'Add another variable?',
@@ -149,16 +164,6 @@ class EnvironmentVariables extends BaseCommand
             $counter++;
         }
 
-        $variables = collect($this->form()->filled())
-            ->filter(fn ($field) => str_starts_with($field->key, 'variables.'))
-            ->undot()
-            ->toArray();
-
-        return collect($variables['variables'])
-            ->map(fn ($var) => [
-                'key' => $var['key']->value(),
-                'value' => $var['value']->value(),
-            ])
-            ->toArray();
+        return $variables;
     }
 }

--- a/app/Dto/Environment.php
+++ b/app/Dto/Environment.php
@@ -2,9 +2,11 @@
 
 namespace App\Dto;
 
+use App\Dto\Transformers\MaskEnvironmentVariables;
 use App\Enums\EnvironmentStatus;
 use Carbon\CarbonImmutable;
 use Spatie\LaravelData\Attributes\WithCast;
+use Spatie\LaravelData\Attributes\WithTransformer;
 use Spatie\LaravelData\Casts\DateTimeInterfaceCast;
 use Spatie\LaravelData\Casts\EnumCast;
 use Spatie\LaravelData\Data;
@@ -31,6 +33,7 @@ class Environment extends Data
         public readonly bool $usesHibernation = false,
         public readonly bool $usesPushToDeploy = false,
         public readonly bool $usesDeployHook = false,
+        #[WithTransformer(MaskEnvironmentVariables::class)]
         public readonly array $environmentVariables = [],
         public readonly array $networkSettings = [],
         #[WithCast(DateTimeInterfaceCast::class, type: CarbonImmutable::class)]

--- a/app/Dto/Transformers/MaskEnvironmentVariables.php
+++ b/app/Dto/Transformers/MaskEnvironmentVariables.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Dto\Transformers;
+
+use App\Support\SensitiveValues;
+use Spatie\LaravelData\Support\DataProperty;
+use Spatie\LaravelData\Support\Transformation\TransformationContext;
+use Spatie\LaravelData\Transformers\Transformer;
+
+class MaskEnvironmentVariables implements Transformer
+{
+    public function transform(DataProperty $property, mixed $value, TransformationContext $context): array
+    {
+        if (SensitiveValues::$reveal) {
+            return $value;
+        }
+
+        return array_map(
+            fn(array $item) => array_merge($item, [
+                'value' => '*****',
+            ]),
+            $value,
+        );
+    }
+}

--- a/app/Dto/Transformers/MaskEnvironmentVariables.php
+++ b/app/Dto/Transformers/MaskEnvironmentVariables.php
@@ -16,7 +16,7 @@ class MaskEnvironmentVariables implements Transformer
         }
 
         return array_map(
-            fn(array $item) => array_merge($item, [
+            fn (array $item) => array_merge($item, [
                 'value' => '*****',
             ]),
             $value,

--- a/app/Support/SensitiveValues.php
+++ b/app/Support/SensitiveValues.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Support;
+
+class SensitiveValues
+{
+    public static bool $reveal = false;
+}

--- a/tests/Feature/SensitiveJsonOutputTest.php
+++ b/tests/Feature/SensitiveJsonOutputTest.php
@@ -1,0 +1,73 @@
+<?php
+
+use App\Commands\BaseCommand;
+use App\Dto\Environment;
+use App\Support\SensitiveValues;
+use Illuminate\Support\Facades\Artisan;
+
+beforeEach(function () {
+    Artisan::registerCommand(new SensitiveJsonOutputTestCommand);
+});
+
+afterEach(function () {
+    SensitiveValues::$reveal = false;
+});
+
+it('masks environmentVariables in JSON output by default', function () {
+    $exitCode = Artisan::call('test:sensitive-json', ['--no-interaction' => true]);
+
+    expect($exitCode)->toBe(0);
+
+    $payload = json_decode(Artisan::output(), true);
+
+    expect($payload['environmentVariables'])->toEqual([
+        ['key' => 'APP_KEY', 'value' => '*****'],
+        ['key' => 'STRIPE_SECRET', 'value' => '*****'],
+    ]);
+});
+
+it('reveals environmentVariables when --show-sensitive is passed', function () {
+    $exitCode = Artisan::call('test:sensitive-json', [
+        '--no-interaction' => true,
+        '--show-sensitive' => true,
+    ]);
+
+    expect($exitCode)->toBe(0);
+
+    $payload = json_decode(Artisan::output(), true);
+
+    expect($payload['environmentVariables'])->toEqual([
+        ['key' => 'APP_KEY', 'value' => 'base64:secret'],
+        ['key' => 'STRIPE_SECRET', 'value' => 'sk_live_xyz'],
+    ]);
+});
+
+class SensitiveJsonOutputTestCommand extends BaseCommand
+{
+    protected $signature = 'test:sensitive-json';
+
+    public function handle(): void
+    {
+        $env = Environment::from([
+            'id' => 'env-1',
+            'url' => 'https://example.com',
+            'name' => 'production',
+            'branch' => 'main',
+            'status' => 'running',
+            'instances' => null,
+            'buildCommand' => null,
+            'deployCommand' => null,
+            'slug' => 'production',
+            'statusEnum' => 'running',
+            'createdFromAutomation' => false,
+            'vanityDomain' => 'example.com',
+            'phpMajorVersion' => '8.3',
+            'environmentVariables' => [
+                ['key' => 'APP_KEY', 'value' => 'base64:secret'],
+                ['key' => 'STRIPE_SECRET', 'value' => 'sk_live_xyz'],
+            ],
+        ]);
+
+        $this->outputJsonIfWanted($env);
+    }
+}

--- a/tests/Unit/MaskSensitiveValuesTest.php
+++ b/tests/Unit/MaskSensitiveValuesTest.php
@@ -1,0 +1,87 @@
+<?php
+
+use App\Dto\Application;
+use App\Dto\Environment;
+use App\Support\SensitiveValues;
+
+afterEach(function () {
+    SensitiveValues::$reveal = false;
+});
+
+function makeEnvironment(array $vars): Environment
+{
+    return Environment::from([
+        'id' => 'env-1',
+        'url' => 'https://example.com',
+        'name' => 'production',
+        'branch' => 'main',
+        'status' => 'running',
+        'instances' => null,
+        'buildCommand' => null,
+        'deployCommand' => null,
+        'slug' => 'production',
+        'statusEnum' => 'running',
+        'createdFromAutomation' => false,
+        'vanityDomain' => 'example.com',
+        'phpMajorVersion' => '8.3',
+        'environmentVariables' => $vars,
+    ]);
+}
+
+it('masks environmentVariables values when serialized to array', function () {
+    $env = makeEnvironment([
+        ['key' => 'APP_KEY', 'value' => 'base64:secret'],
+        ['key' => 'STRIPE_SECRET', 'value' => 'sk_live_xyz'],
+    ]);
+
+    expect($env->toArray()['environmentVariables'])->toEqual([
+        ['key' => 'APP_KEY', 'value' => '*****'],
+        ['key' => 'STRIPE_SECRET', 'value' => '*****'],
+    ]);
+});
+
+it('reveals real values when SensitiveValues::$reveal is true', function () {
+    SensitiveValues::$reveal = true;
+
+    $env = makeEnvironment([
+        ['key' => 'APP_KEY', 'value' => 'base64:secret'],
+    ]);
+
+    expect($env->toArray()['environmentVariables'])->toEqual([
+        ['key' => 'APP_KEY', 'value' => 'base64:secret'],
+    ]);
+});
+
+it('leaves the underlying property untouched so internal reads still see real values', function () {
+    $env = makeEnvironment([
+        ['key' => 'APP_KEY', 'value' => 'base64:secret'],
+    ]);
+
+    expect($env->environmentVariables)->toEqual([
+        ['key' => 'APP_KEY', 'value' => 'base64:secret'],
+    ]);
+});
+
+it('masks values inside environments nested under an Application DTO', function () {
+    $app = Application::from([
+        'id' => 'app-1',
+        'name' => 'My App',
+        'slug' => 'my-app',
+        'region' => 'us-east-1',
+        'environmentIds' => ['env-1'],
+        'environments' => [
+            makeEnvironment([
+                ['key' => 'TOKEN', 'value' => 'super-secret'],
+            ]),
+        ],
+    ]);
+
+    expect($app->toArray()['environments'][0]['environmentVariables'][0])
+        ->toEqual(['key' => 'TOKEN', 'value' => '*****']);
+});
+
+it('handles empty environmentVariables arrays', function () {
+    $env = makeEnvironment([]);
+
+    expect($env->toArray()['environmentVariables'])->toBe([]);
+});


### PR DESCRIPTION
Env var values are masked as `*****` in JSON output by default. Pass `--show-sensitive` to see the real values.

The interactive `env:vars` flow now uses a hidden `password()` prompt for values, with `--show-sensitive` switching back to a regular `text()` prompt. When editing an existing key, you get a "Keep existing value?" confirm so you don't have to retype it.

Also tagged the env-var and Nightwatch token request DTOs with `#[SensitiveParameter]` so PHP redacts them in stack traces.

Fixes https://github.com/laravel/cloud-cli/issues/154