### PR TITLE
Autocomplete artisan commands in command:run prompt

### DIFF
--- a/app/Commands/CommandRun.php
+++ b/app/Commands/CommandRun.php
@@ -4,16 +4,21 @@ namespace App\Commands;
 
 use App\Client\Requests\RunCommandRequestData;
 use App\Concerns\InteractsWithClipbboard;
+use App\Dto\Application;
 use App\Dto\Command;
+use App\Dto\Environment;
 use App\Enums\CommandStatus;
+use App\Git;
+use App\LocalConfig;
 use App\Prompts\MonitorCommand;
 use App\Support\ValueResolver;
 use Carbon\CarbonInterval;
 use Illuminate\Support\Sleep;
+use Throwable;
 
+use function Laravel\Prompts\autocomplete;
 use function Laravel\Prompts\intro;
 use function Laravel\Prompts\select;
-use function Laravel\Prompts\text;
 
 class CommandRun extends BaseCommand
 {
@@ -39,7 +44,7 @@ class CommandRun extends BaseCommand
         intro('Running Command');
 
         $environment = $this->resolvers()->environment()->from($this->argument('environment'));
-        $command = $this->loopUntilValid(fn () => $this->runCommandOnEnvironment($environment->id));
+        $command = $this->loopUntilValid(fn () => $this->runCommandOnEnvironment($environment));
 
         if ($this->option('no-monitor')) {
             $this->outputJsonIfWanted($command);
@@ -100,14 +105,17 @@ class CommandRun extends BaseCommand
         }
     }
 
-    protected function runCommandOnEnvironment(string $environmentId): Command
+    protected function runCommandOnEnvironment(Environment $environment): Command
     {
+        $artisanCommands = $this->localArtisanCommands($environment->application);
+
         $this->form()->prompt(
             'command',
             fn (ValueResolver $resolver) => $resolver->fromInput(
-                fn ($value) => text(
+                fn ($value) => autocomplete(
                     label: 'Command',
-                    default: $this->resolveDefaultCommand($value, $environmentId),
+                    default: $this->resolveDefaultCommand($value, $environment->id),
+                    options: ! $artisanCommands ? [] : fn (string $value) => $this->getCommandSuggestions($value, $artisanCommands),
                     required: true,
                 ),
             ),
@@ -117,12 +125,48 @@ class CommandRun extends BaseCommand
         return dynamicSpinner(
             fn () => $this->client->commands()->run(
                 new RunCommandRequestData(
-                    environmentId: $environmentId,
+                    environmentId: $environment->id,
                     command: $this->form()->get('command'),
                 ),
             ),
             'Running command...',
         );
+    }
+
+    protected function getCommandSuggestions(string $value, array $artisanCommands): array
+    {
+        if (! str_starts_with($value, 'php artisan ')) {
+            return [];
+        }
+
+        $rest = substr($value, strlen('php artisan '));
+        $spacePos = strpos($rest, ' ');
+
+        // Still completing the command name
+        if ($spacePos === false) {
+            return collect(array_keys($artisanCommands))
+                ->filter(fn (string $cmd) => str_starts_with($cmd, $rest))
+                ->map(fn (string $cmd) => 'php artisan '.$cmd)
+                ->values()
+                ->all();
+        }
+
+        // Completing options for a known command
+        $commandName = substr($rest, 0, $spacePos);
+
+        if (! isset($artisanCommands[$commandName])) {
+            return [];
+        }
+
+        $tokens = explode(' ', $rest);
+        $lastToken = end($tokens);
+        $prefix = 'php artisan '.implode(' ', array_slice($tokens, 0, -1)).' ';
+
+        return collect($artisanCommands[$commandName])
+            ->filter(fn (string $opt) => str_starts_with($opt, $lastToken))
+            ->map(fn (string $opt) => $prefix.$opt)
+            ->values()
+            ->all();
     }
 
     protected function resolveDefaultCommand(?string $value, string $environmentId): string
@@ -138,6 +182,72 @@ class CommandRun extends BaseCommand
         }
 
         return $default;
+    }
+
+    protected function localRepoMatchesApplication(?Application $application): bool
+    {
+        if (! $application?->repositoryFullName) {
+            return false;
+        }
+
+        // Fast path: local config already stores which app this repo maps to
+        if (app(LocalConfig::class)->applicationId() === $application->id) {
+            return true;
+        }
+
+        // Fallback: compare the git remote to the app's repository
+        try {
+            return app(Git::class)->remoteRepo() === $application->repositoryFullName;
+        } catch (Throwable) {
+            return false;
+        }
+    }
+
+    protected function localArtisanCommands(?Application $application): ?array
+    {
+        if (! $this->localRepoMatchesApplication($application) || ! file_exists(getcwd().'/artisan')) {
+            return null;
+        }
+
+        try {
+            $output = shell_exec('php artisan list --format=json 2>/dev/null');
+
+            if (! $output) {
+                return null;
+            }
+
+            $data = json_decode($output, true, 512, JSON_THROW_ON_ERROR);
+
+            $globalOptions = ['--help', '--quiet', '--verbose', '--version', '--ansi', '--no-ansi', '--no-interaction', '--env'];
+
+            $result = [];
+
+            foreach ($data['commands'] ?? [] as $command) {
+                $name = $command['name'] ?? null;
+
+                if (! $name) {
+                    continue;
+                }
+
+                $options = [];
+
+                foreach ($command['definition']['options'] ?? [] as $option) {
+                    $optionName = $option['name'] ?? null;
+
+                    if (! $optionName || in_array($optionName, $globalOptions)) {
+                        continue;
+                    }
+
+                    $options[] = ($option['accept_value'] ?? false) ? $optionName.'=' : $optionName;
+                }
+
+                $result[$name] = $options;
+            }
+
+            return $result ?: null;
+        } catch (Throwable) {
+            return null;
+        }
     }
 
     protected function selectFromHistory(string $environmentId): ?string

--- a/app/Prompts/AutocompletePromptRenderer.php
+++ b/app/Prompts/AutocompletePromptRenderer.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Prompts;
+
+use App\Concerns\DrawsThemeBoxes;
+use App\Enums\TimelineSymbol;
+use Laravel\Prompts\AutoCompletePrompt;
+
+class AutoCompletePromptRenderer extends Renderer
+{
+    use DrawsThemeBoxes;
+
+    /**
+     * Render the text prompt.
+     */
+    public function __invoke(AutoCompletePrompt $prompt): string
+    {
+        $maxWidth = $prompt->terminal()->cols() - 6;
+
+        return match ($prompt->state) {
+            'submit' => $this
+                ->box(
+                    $this->dim($this->truncate($prompt->label, $prompt->terminal()->cols() - 6)),
+                    $this->truncate($prompt->value(), $maxWidth),
+                    symbol: TimelineSymbol::SUCCESS,
+                ),
+
+            'cancel' => $this
+                ->box(
+                    $this->truncate($prompt->label, $prompt->terminal()->cols() - 6),
+                    $this->strikethrough($this->dim($this->truncate($prompt->value() ?: $prompt->placeholder, $maxWidth))),
+                    color: 'red',
+                    symbol: TimelineSymbol::FAILURE,
+                )
+                ->error($prompt->cancelMessage),
+
+            'error' => $this
+                ->box(
+                    $this->truncate($prompt->label, $prompt->terminal()->cols() - 6),
+                    $prompt->valueWithCursor($maxWidth),
+                    color: 'yellow',
+                    symbol: TimelineSymbol::WARNING,
+                )
+                ->warning($this->truncate($prompt->error, $prompt->terminal()->cols() - 5)),
+
+            default => $this
+                ->box(
+                    $this->cyan($this->truncate($prompt->label, $prompt->terminal()->cols() - 6)),
+                    $prompt->valueWithCursor($maxWidth),
+                )
+                ->when(
+                    $prompt->hint,
+                    fn () => $this->hint($prompt->hint),
+                    fn () => $this->newLine(), // Space for errors
+                ),
+        };
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -49,6 +49,7 @@ class AppServiceProvider extends ServiceProvider
             'CodeBlockRenderer',
             'TextareaPromptRenderer',
             'TextPromptRenderer',
+            'AutoCompletePromptRenderer',
         ])
             ->mapWithKeys(function ($class) {
                 $promptClass = str_replace('Renderer', '', $class);


### PR DESCRIPTION
When running `command:run` from inside a Laravel app directory, the command prompt now uses autocomplete instead of plain text. It detects whether the local repo matches the target cloud app (via local config or git remote), and if so, runs `php artisan list` locally to populate suggestions. Typing `php artisan ` autocompletes command names; once a command is selected, it switches to suggesting that command's options and flags. Falls back gracefully if PHP isn't available, the artisan file doesn't exist, or the repo doesn't match.
