### PR TITLE
Add managed queue commands

### DIFF
--- a/app/Client/Requests/CreateInstanceRequestData.php
+++ b/app/Client/Requests/CreateInstanceRequestData.php
@@ -15,6 +15,9 @@ class CreateInstanceRequestData extends RequestData
         public readonly ?bool $usesScheduler = null,
         public readonly ?int $scalingCpuThresholdPercentage = null,
         public readonly ?int $scalingMemoryThresholdPercentage = null,
+        public readonly ?int $visibilityTimeout = null,
+        public readonly ?int $pollingInterval = null,
+        public readonly ?int $shutdownTimeout = null,
     ) {
         //
     }
@@ -31,6 +34,9 @@ class CreateInstanceRequestData extends RequestData
             'uses_scheduler' => $this->usesScheduler,
             'scaling_cpu_threshold_percentage' => $this->scalingCpuThresholdPercentage,
             'scaling_memory_threshold_percentage' => $this->scalingMemoryThresholdPercentage,
+            'visibility_timeout' => $this->visibilityTimeout,
+            'polling_interval' => $this->pollingInterval,
+            'shutdown_timeout' => $this->shutdownTimeout,
         ]);
     }
 }

--- a/app/Client/Requests/CreateInstanceRequestData.php
+++ b/app/Client/Requests/CreateInstanceRequestData.php
@@ -2,14 +2,17 @@
 
 namespace App\Client\Requests;
 
+use App\Enums\InstanceScalingType;
+use App\Enums\InstanceType;
+
 class CreateInstanceRequestData extends RequestData
 {
     public function __construct(
         public readonly string $environmentId,
         public readonly string $name,
-        public readonly string $type,
+        public readonly InstanceType $type,
         public readonly string $size,
-        public readonly string $scalingType,
+        public readonly InstanceScalingType $scalingType,
         public readonly int $minReplicas,
         public readonly int $maxReplicas,
         public readonly ?bool $usesScheduler = null,
@@ -18,6 +21,7 @@ class CreateInstanceRequestData extends RequestData
         public readonly ?int $visibilityTimeout = null,
         public readonly ?int $pollingInterval = null,
         public readonly ?int $shutdownTimeout = null,
+        public readonly ?array $backgroundProcesses = null,
     ) {
         //
     }
@@ -26,9 +30,9 @@ class CreateInstanceRequestData extends RequestData
     {
         return $this->filter([
             'name' => $this->name,
-            'type' => $this->type,
+            'type' => $this->type->value,
             'size' => $this->size,
-            'scaling_type' => $this->scalingType,
+            'scaling_type' => $this->scalingType->value,
             'min_replicas' => $this->minReplicas,
             'max_replicas' => $this->maxReplicas,
             'uses_scheduler' => $this->usesScheduler,
@@ -37,6 +41,7 @@ class CreateInstanceRequestData extends RequestData
             'visibility_timeout' => $this->visibilityTimeout,
             'polling_interval' => $this->pollingInterval,
             'shutdown_timeout' => $this->shutdownTimeout,
+            'background_processes' => $this->backgroundProcesses,
         ]);
     }
 }

--- a/app/Client/Requests/UpdateInstanceRequestData.php
+++ b/app/Client/Requests/UpdateInstanceRequestData.php
@@ -19,6 +19,9 @@ class UpdateInstanceRequestData extends RequestData
         public readonly ?int $sleepTimeout = null,
         public readonly ?int $scalingCpuThresholdPercentage = null,
         public readonly ?int $scalingMemoryThresholdPercentage = null,
+        public readonly ?int $visibilityTimeout = null,
+        public readonly ?int $pollingInterval = null,
+        public readonly ?int $shutdownTimeout = null,
     ) {
         //
     }
@@ -39,6 +42,9 @@ class UpdateInstanceRequestData extends RequestData
             'sleep_timeout' => $this->sleepTimeout,
             'scaling_cpu_threshold_percentage' => $this->scalingCpuThresholdPercentage,
             'scaling_memory_threshold_percentage' => $this->scalingMemoryThresholdPercentage,
+            'visibility_timeout' => $this->visibilityTimeout,
+            'polling_interval' => $this->pollingInterval,
+            'shutdown_timeout' => $this->shutdownTimeout,
         ]);
     }
 }

--- a/app/Client/Resources/Instances/DeleteManagedQueueFailedJobRequest.php
+++ b/app/Client/Resources/Instances/DeleteManagedQueueFailedJobRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Client\Resources\Instances;
+
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+class DeleteManagedQueueFailedJobRequest extends Request
+{
+    protected Method $method = Method::DELETE;
+
+    public function __construct(
+        protected string $instanceId,
+        protected string $jobId,
+    ) {
+        //
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return "/instances/{$this->instanceId}/failed-jobs/{$this->jobId}";
+    }
+}

--- a/app/Client/Resources/Instances/ListManagedQueueFailedJobsRequest.php
+++ b/app/Client/Resources/Instances/ListManagedQueueFailedJobsRequest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Client\Resources\Instances;
+
+use App\Dto\ManagedQueueFailedJob;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Http\Response;
+use Saloon\PaginationPlugin\Contracts\Paginatable;
+
+class ListManagedQueueFailedJobsRequest extends Request implements Paginatable
+{
+    protected Method $method = Method::GET;
+
+    public function __construct(
+        protected string $instanceId,
+    ) {
+        //
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return "/instances/{$this->instanceId}/failed-jobs";
+    }
+
+    public function createDtoFromResponse(Response $response): mixed
+    {
+        return array_map(
+            fn ($job) => ManagedQueueFailedJob::createFromResponse(['data' => $job]),
+            $response->json('data'),
+        );
+    }
+}

--- a/app/Client/Resources/Instances/PauseManagedQueueRequest.php
+++ b/app/Client/Resources/Instances/PauseManagedQueueRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Client\Resources\Instances;
+
+use App\Dto\EnvironmentInstance;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Http\Response;
+
+class PauseManagedQueueRequest extends Request
+{
+    protected Method $method = Method::POST;
+
+    public function __construct(
+        protected string $instanceId,
+    ) {
+        //
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return "/instances/{$this->instanceId}/pause";
+    }
+
+    public function createDtoFromResponse(Response $response): mixed
+    {
+        return EnvironmentInstance::createFromResponse($response->json());
+    }
+}

--- a/app/Client/Resources/Instances/PurgeManagedQueueRequest.php
+++ b/app/Client/Resources/Instances/PurgeManagedQueueRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Client\Resources\Instances;
+
+use App\Dto\EnvironmentInstance;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Http\Response;
+
+class PurgeManagedQueueRequest extends Request
+{
+    protected Method $method = Method::POST;
+
+    public function __construct(
+        protected string $instanceId,
+    ) {
+        //
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return "/instances/{$this->instanceId}/purge";
+    }
+
+    public function createDtoFromResponse(Response $response): mixed
+    {
+        return EnvironmentInstance::createFromResponse($response->json());
+    }
+}

--- a/app/Client/Resources/Instances/ResumeManagedQueueRequest.php
+++ b/app/Client/Resources/Instances/ResumeManagedQueueRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Client\Resources\Instances;
+
+use App\Dto\EnvironmentInstance;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Http\Response;
+
+class ResumeManagedQueueRequest extends Request
+{
+    protected Method $method = Method::POST;
+
+    public function __construct(
+        protected string $instanceId,
+    ) {
+        //
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return "/instances/{$this->instanceId}/resume";
+    }
+
+    public function createDtoFromResponse(Response $response): mixed
+    {
+        return EnvironmentInstance::createFromResponse($response->json());
+    }
+}

--- a/app/Client/Resources/Instances/RetryManagedQueueFailedJobRequest.php
+++ b/app/Client/Resources/Instances/RetryManagedQueueFailedJobRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Client\Resources\Instances;
+
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+class RetryManagedQueueFailedJobRequest extends Request
+{
+    protected Method $method = Method::POST;
+
+    public function __construct(
+        protected string $instanceId,
+        protected string $jobId,
+    ) {
+        //
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return "/instances/{$this->instanceId}/failed-jobs/{$this->jobId}/retry";
+    }
+}

--- a/app/Client/Resources/Instances/SetDefaultManagedQueueRequest.php
+++ b/app/Client/Resources/Instances/SetDefaultManagedQueueRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Client\Resources\Instances;
+
+use App\Dto\EnvironmentInstance;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Http\Response;
+
+class SetDefaultManagedQueueRequest extends Request
+{
+    protected Method $method = Method::POST;
+
+    public function __construct(
+        protected string $instanceId,
+    ) {
+        //
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return "/instances/{$this->instanceId}/default";
+    }
+
+    public function createDtoFromResponse(Response $response): mixed
+    {
+        return EnvironmentInstance::createFromResponse($response->json());
+    }
+}

--- a/app/Client/Resources/InstancesResource.php
+++ b/app/Client/Resources/InstancesResource.php
@@ -6,9 +6,16 @@ use App\Client\Requests\CreateInstanceRequestData;
 use App\Client\Requests\UpdateInstanceRequestData;
 use App\Client\Resources\Instances\CreateInstanceRequest;
 use App\Client\Resources\Instances\DeleteInstanceRequest;
+use App\Client\Resources\Instances\DeleteManagedQueueFailedJobRequest;
 use App\Client\Resources\Instances\GetInstanceRequest;
 use App\Client\Resources\Instances\ListInstanceSizesRequest;
 use App\Client\Resources\Instances\ListInstancesRequest;
+use App\Client\Resources\Instances\ListManagedQueueFailedJobsRequest;
+use App\Client\Resources\Instances\PauseManagedQueueRequest;
+use App\Client\Resources\Instances\PurgeManagedQueueRequest;
+use App\Client\Resources\Instances\ResumeManagedQueueRequest;
+use App\Client\Resources\Instances\RetryManagedQueueFailedJobRequest;
+use App\Client\Resources\Instances\SetDefaultManagedQueueRequest;
 use App\Client\Resources\Instances\UpdateInstanceRequest;
 use App\Dto\EnvironmentInstance;
 use App\Dto\InstanceSizes;
@@ -58,5 +65,52 @@ class InstancesResource extends Resource
         $response = $this->send($request);
 
         return $request->createDtoFromResponse($response);
+    }
+
+    public function pause(string $instanceId): EnvironmentInstance
+    {
+        $request = new PauseManagedQueueRequest($instanceId);
+        $response = $this->send($request);
+
+        return $request->createDtoFromResponse($response);
+    }
+
+    public function resume(string $instanceId): EnvironmentInstance
+    {
+        $request = new ResumeManagedQueueRequest($instanceId);
+        $response = $this->send($request);
+
+        return $request->createDtoFromResponse($response);
+    }
+
+    public function purge(string $instanceId): EnvironmentInstance
+    {
+        $request = new PurgeManagedQueueRequest($instanceId);
+        $response = $this->send($request);
+
+        return $request->createDtoFromResponse($response);
+    }
+
+    public function setDefault(string $instanceId): EnvironmentInstance
+    {
+        $request = new SetDefaultManagedQueueRequest($instanceId);
+        $response = $this->send($request);
+
+        return $request->createDtoFromResponse($response);
+    }
+
+    public function failedJobs(string $instanceId): Paginator
+    {
+        return $this->paginate(new ListManagedQueueFailedJobsRequest($instanceId));
+    }
+
+    public function deleteFailedJob(string $instanceId, string $jobId): void
+    {
+        $this->send(new DeleteManagedQueueFailedJobRequest($instanceId, $jobId));
+    }
+
+    public function retryFailedJob(string $instanceId, string $jobId): void
+    {
+        $this->send(new RetryManagedQueueFailedJobRequest($instanceId, $jobId));
     }
 }

--- a/app/Commands/InstanceCreate.php
+++ b/app/Commands/InstanceCreate.php
@@ -4,6 +4,8 @@ namespace App\Commands;
 
 use App\Client\Requests\CreateInstanceRequestData;
 use App\Dto\EnvironmentInstance;
+use App\Enums\InstanceScalingType;
+use App\Enums\InstanceType;
 
 use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\intro;
@@ -82,12 +84,12 @@ class InstanceCreate extends BaseCommand
             'scaling_type',
             fn ($resolver) => $resolver
                 ->fromInput(
-                    fn ($value) => $value ?? (confirm('Enable autoscaling?', default: true) ? 'custom' : 'none'),
+                    fn ($value) => $value ?? (confirm('Enable autoscaling?', default: true) ? InstanceScalingType::CUSTOM : InstanceScalingType::NONE),
                 )
                 ->nonInteractively(fn () => 'none'),
         );
 
-        $isCustom = $this->form()->get('scaling_type') === 'custom';
+        $isCustom = $this->form()->get('scaling_type') === InstanceScalingType::CUSTOM;
 
         $this->form()->prompt(
             'min_replicas',
@@ -144,11 +146,6 @@ class InstanceCreate extends BaseCommand
         }
 
         $this->form()->prompt(
-            'type',
-            fn ($resolver) => $resolver->fromInput(fn () => 'service'),
-        );
-
-        $this->form()->prompt(
             'uses_scheduler',
             fn ($resolver) => $resolver
                 ->fromInput(
@@ -165,7 +162,7 @@ class InstanceCreate extends BaseCommand
                 new CreateInstanceRequestData(
                     environmentId: $environmentId,
                     name: $this->form()->get('name'),
-                    type: $this->form()->get('type'),
+                    type: InstanceType::SERVICE,
                     size: $this->form()->get('size'),
                     scalingType: $this->form()->get('scaling_type'),
                     minReplicas: $this->form()->integer('min_replicas'),

--- a/app/Commands/ManagedQueueCreate.php
+++ b/app/Commands/ManagedQueueCreate.php
@@ -31,6 +31,8 @@ class ManagedQueueCreate extends BaseCommand
 
     protected $description = 'Create a new managed queue';
 
+    protected $aliases = ['queue:create'];
+
     public function handle()
     {
         $this->ensureClient();

--- a/app/Commands/ManagedQueueCreate.php
+++ b/app/Commands/ManagedQueueCreate.php
@@ -37,7 +37,7 @@ class ManagedQueueCreate extends BaseCommand
     {
         $this->ensureClient();
 
-        intro('Create Managed Queue');
+        intro('Creating Managed Queue');
 
         $composer = app(Composer::class)->setWorkingPath(getcwd());
 

--- a/app/Commands/ManagedQueueCreate.php
+++ b/app/Commands/ManagedQueueCreate.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace App\Commands;
+
+use App\Client\Requests\CreateInstanceRequestData;
+use App\Dto\EnvironmentInstance;
+use Illuminate\Support\Composer;
+
+use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\intro;
+use function Laravel\Prompts\number;
+use function Laravel\Prompts\search;
+use function Laravel\Prompts\spin;
+use function Laravel\Prompts\text;
+use function Laravel\Prompts\warning;
+
+class ManagedQueueCreate extends BaseCommand
+{
+    protected ?string $jsonDataClass = EnvironmentInstance::class;
+
+    protected $signature = 'managed-queue:create
+                            {environment? : The environment ID or name}
+                            {--name= : Queue name}
+                            {--size= : Instance size}
+                            {--max-workers= : Maximum number of workers}
+                            {--visibility-timeout= : Visibility timeout in seconds (0-43200)}
+                            {--polling-interval= : Polling interval in seconds (0-60)}
+                            {--shutdown-timeout= : Shutdown timeout in seconds}';
+
+    protected $description = 'Create a new managed queue';
+
+    public function handle()
+    {
+        $this->ensureClient();
+
+        intro('Create Managed Queue');
+
+        $composer = app(Composer::class)->setWorkingPath(getcwd());
+
+        if (!$composer->hasPackage('aws/aws-sdk-php')) {
+            warning('The aws/aws-sdk-php package is required to create a managed queue.');
+
+            if (confirm('Would you like to install it now?')) {
+                spin(
+                    fn() => $composer->requirePackages(['aws/aws-sdk-php']),
+                    'Installing aws/aws-sdk-php...',
+                );
+            }
+        }
+
+        $environment = $this->resolvers()->environment()->from($this->argument('environment'));
+
+        $instance = $this->loopUntilValid(fn() => $this->createManagedQueue($environment->id));
+
+        $this->outputJsonIfWanted($instance);
+
+        success("Managed queue created: {$instance->name}");
+    }
+
+    protected function createManagedQueue(string $environmentId)
+    {
+        $this->form()->prompt(
+            'name',
+            fn($resolver) => $resolver->fromInput(
+                fn($value) => text(
+                    label: 'Queue name',
+                    hint: 'Must match the queue name your application dispatches to',
+                    default: $value ?? 'default',
+                    required: true,
+                ),
+            ),
+        );
+
+        $sizes = collect($this->client->instances()->sizes()->all())
+            ->filter(fn($size) => str_starts_with($size->name, 'mq-'));
+
+        $this->form()->prompt(
+            'size',
+            fn($resolver) => $resolver->fromInput(
+                fn($value) => search(
+                    label: 'Size',
+                    options: fn($query) => $sizes
+                        ->filter(
+                            fn($size) => $query === ''
+                                || str_contains(strtolower($size->name), strtolower($query))
+                                || str_contains(strtolower($size->description), strtolower($query)),
+                        )
+                        ->mapWithKeys(fn($size) => [$size->name => $size->description])
+                        ->toArray(),
+                    required: true,
+                ),
+            ),
+        );
+
+        $this->form()->prompt(
+            'max_workers',
+            fn($resolver) => $resolver
+                ->fromInput(
+                    fn($value) => (int) number(
+                        label: 'Maximum workers',
+                        default: $value ?? '3',
+                        min: 1,
+                    ),
+                )
+                ->nonInteractively(fn() => 3),
+            'max-workers',
+        );
+
+        $this->form()->prompt(
+            'visibility_timeout',
+            fn($resolver) => $resolver
+                ->fromInput(
+                    fn($value) => (int) number(
+                        label: 'Visibility timeout (seconds)',
+                        hint: 'How long an in-flight job is hidden from other workers (0-43200)',
+                        default: $value ?? '60',
+                        min: 0,
+                        max: 43200,
+                    ),
+                )
+                ->nonInteractively(fn() => 60),
+            'visibility-timeout',
+        );
+
+        $this->form()->prompt(
+            'polling_interval',
+            fn($resolver) => $resolver
+                ->fromInput(
+                    fn($value) => (int) number(
+                        label: 'Polling interval (seconds)',
+                        hint: 'How often to check queue pressure for scaling decisions (0-60)',
+                        default: $value ?? '5',
+                        min: 0,
+                        max: 60,
+                    ),
+                )
+                ->nonInteractively(fn() => 5),
+            'polling-interval',
+        );
+
+        $this->form()->prompt(
+            'shutdown_timeout',
+            fn($resolver) => $resolver
+                ->fromInput(
+                    fn($value) => (int) number(
+                        label: 'Shutdown timeout (seconds)',
+                        hint: 'Grace period for workers to finish their current job before terminating',
+                        default: $value ?? '90',
+                        min: 1,
+                    ),
+                )
+                ->nonInteractively(fn() => 90),
+            'shutdown-timeout',
+        );
+
+        return spin(
+            fn() => $this->client->instances()->create(
+                new CreateInstanceRequestData(
+                    environmentId: $environmentId,
+                    name: $this->form()->get('name'),
+                    type: 'managed_queue',
+                    size: $this->form()->get('size'),
+                    scalingType: 'auto',
+                    minReplicas: 0,
+                    maxReplicas: $this->form()->integer('max_workers'),
+                    visibilityTimeout: $this->form()->integer('visibility_timeout'),
+                    pollingInterval: $this->form()->integer('polling_interval'),
+                    shutdownTimeout: $this->form()->integer('shutdown_timeout'),
+                ),
+            ),
+            'Creating managed queue...',
+        );
+    }
+}

--- a/app/Commands/ManagedQueueCreate.php
+++ b/app/Commands/ManagedQueueCreate.php
@@ -4,12 +4,14 @@ namespace App\Commands;
 
 use App\Client\Requests\CreateInstanceRequestData;
 use App\Dto\EnvironmentInstance;
+use App\Enums\InstanceScalingType;
+use App\Enums\InstanceType;
 use Illuminate\Support\Composer;
 
 use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\intro;
 use function Laravel\Prompts\number;
-use function Laravel\Prompts\search;
+use function Laravel\Prompts\select;
 use function Laravel\Prompts\spin;
 use function Laravel\Prompts\text;
 use function Laravel\Prompts\warning;
@@ -37,12 +39,12 @@ class ManagedQueueCreate extends BaseCommand
 
         $composer = app(Composer::class)->setWorkingPath(getcwd());
 
-        if (!$composer->hasPackage('aws/aws-sdk-php')) {
+        if (! $composer->hasPackage('aws/aws-sdk-php')) {
             warning('The aws/aws-sdk-php package is required to create a managed queue.');
 
             if (confirm('Would you like to install it now?')) {
                 spin(
-                    fn() => $composer->requirePackages(['aws/aws-sdk-php']),
+                    fn () => $composer->requirePackages(['aws/aws-sdk-php']),
                     'Installing aws/aws-sdk-php...',
                 );
             }
@@ -50,7 +52,7 @@ class ManagedQueueCreate extends BaseCommand
 
         $environment = $this->resolvers()->environment()->from($this->argument('environment'));
 
-        $instance = $this->loopUntilValid(fn() => $this->createManagedQueue($environment->id));
+        $instance = $this->loopUntilValid(fn () => $this->createManagedQueue($environment->id));
 
         $this->outputJsonIfWanted($instance);
 
@@ -61,8 +63,8 @@ class ManagedQueueCreate extends BaseCommand
     {
         $this->form()->prompt(
             'name',
-            fn($resolver) => $resolver->fromInput(
-                fn($value) => text(
+            fn ($resolver) => $resolver->fromInput(
+                fn ($value) => text(
                     label: 'Queue name',
                     hint: 'Must match the queue name your application dispatches to',
                     default: $value ?? 'default',
@@ -72,20 +74,15 @@ class ManagedQueueCreate extends BaseCommand
         );
 
         $sizes = collect($this->client->instances()->sizes()->all())
-            ->filter(fn($size) => str_starts_with($size->name, 'mq-'));
+            ->filter(fn ($size) => str_starts_with($size->name, 'mq-pro'));
 
         $this->form()->prompt(
             'size',
-            fn($resolver) => $resolver->fromInput(
-                fn($value) => search(
+            fn ($resolver) => $resolver->fromInput(
+                fn ($value) => select(
                     label: 'Size',
-                    options: fn($query) => $sizes
-                        ->filter(
-                            fn($size) => $query === ''
-                                || str_contains(strtolower($size->name), strtolower($query))
-                                || str_contains(strtolower($size->description), strtolower($query)),
-                        )
-                        ->mapWithKeys(fn($size) => [$size->name => $size->description])
+                    options: $sizes
+                        ->mapWithKeys(fn ($size) => [$size->name => $size->description])
                         ->toArray(),
                     required: true,
                 ),
@@ -93,24 +90,24 @@ class ManagedQueueCreate extends BaseCommand
         );
 
         $this->form()->prompt(
-            'max_workers',
-            fn($resolver) => $resolver
+            'max_replicas',
+            fn ($resolver) => $resolver
                 ->fromInput(
-                    fn($value) => (int) number(
+                    fn ($value) => (int) number(
                         label: 'Maximum workers',
                         default: $value ?? '3',
                         min: 1,
                     ),
                 )
-                ->nonInteractively(fn() => 3),
+                ->nonInteractively(fn () => 3),
             'max-workers',
         );
 
         $this->form()->prompt(
             'visibility_timeout',
-            fn($resolver) => $resolver
+            fn ($resolver) => $resolver
                 ->fromInput(
-                    fn($value) => (int) number(
+                    fn ($value) => (int) number(
                         label: 'Visibility timeout (seconds)',
                         hint: 'How long an in-flight job is hidden from other workers (0-43200)',
                         default: $value ?? '60',
@@ -118,15 +115,15 @@ class ManagedQueueCreate extends BaseCommand
                         max: 43200,
                     ),
                 )
-                ->nonInteractively(fn() => 60),
+                ->nonInteractively(fn () => 60),
             'visibility-timeout',
         );
 
         $this->form()->prompt(
             'polling_interval',
-            fn($resolver) => $resolver
+            fn ($resolver) => $resolver
                 ->fromInput(
-                    fn($value) => (int) number(
+                    fn ($value) => (int) number(
                         label: 'Polling interval (seconds)',
                         hint: 'How often to check queue pressure for scaling decisions (0-60)',
                         default: $value ?? '5',
@@ -134,38 +131,98 @@ class ManagedQueueCreate extends BaseCommand
                         max: 60,
                     ),
                 )
-                ->nonInteractively(fn() => 5),
+                ->nonInteractively(fn () => 5),
             'polling-interval',
         );
 
         $this->form()->prompt(
             'shutdown_timeout',
-            fn($resolver) => $resolver
+            fn ($resolver) => $resolver
                 ->fromInput(
-                    fn($value) => (int) number(
+                    fn ($value) => (int) number(
                         label: 'Shutdown timeout (seconds)',
                         hint: 'Grace period for workers to finish their current job before terminating',
                         default: $value ?? '90',
                         min: 1,
                     ),
                 )
-                ->nonInteractively(fn() => 90),
+                ->nonInteractively(fn () => 90),
             'shutdown-timeout',
         );
 
+        $this->form()->prompt(
+            'config.backoff',
+            fn ($resolver) => $resolver
+                ->fromInput(fn (?string $value) => number(
+                    label: 'Backoff',
+                    default: $value ?? 0,
+                    min: 0,
+                    required: true,
+                    hint: 'Number of seconds to wait before retrying a failed job.',
+                ))
+                ->nonInteractively(fn () => 0)
+                ->shouldPromptOnce(),
+            'backoff',
+        );
+
+        $this->form()->prompt(
+            'config.tries',
+            fn ($resolver) => $resolver
+                ->fromInput(fn (?string $value) => number(
+                    label: 'Tries',
+                    default: $value ?? 1,
+                    min: 1,
+                    required: true,
+                    hint: 'Number of times a job should be attempted',
+                ))
+                ->nonInteractively(fn () => 1)
+                ->shouldPromptOnce(),
+            'tries',
+        );
+
+        $this->form()->prompt(
+            'config.timeout',
+            fn ($resolver) => $resolver
+                ->fromInput(fn (?string $value) => number(
+                    label: 'Timeout',
+                    default: $value ?? 60,
+                    min: 0,
+                    required: true,
+                    hint: 'Number of seconds a job can run before timing out',
+                ))
+                ->nonInteractively(fn () => 60)
+                ->shouldPromptOnce(),
+            'timeout',
+        );
+
+        $queueName = $this->form()->get('name');
+
         return spin(
-            fn() => $this->client->instances()->create(
+            fn () => $this->client->instances()->create(
                 new CreateInstanceRequestData(
                     environmentId: $environmentId,
-                    name: $this->form()->get('name'),
-                    type: 'managed_queue',
+                    name: $queueName,
+                    type: InstanceType::MANAGED_QUEUE,
                     size: $this->form()->get('size'),
-                    scalingType: 'auto',
-                    minReplicas: 0,
-                    maxReplicas: $this->form()->integer('max_workers'),
+                    scalingType: InstanceScalingType::CUSTOM,
+                    minReplicas: 1,
+                    maxReplicas: $this->form()->integer('max_replicas'),
                     visibilityTimeout: $this->form()->integer('visibility_timeout'),
                     pollingInterval: $this->form()->integer('polling_interval'),
                     shutdownTimeout: $this->form()->integer('shutdown_timeout'),
+                    backgroundProcesses: [
+                        [
+                            'type' => 'worker',
+                            'processes' => 1,
+                            'config' => [
+                                'connection' => 'cloud',
+                                'queue' => $queueName,
+                                'backoff' => $this->form()->integer('config.backoff'),
+                                'tries' => $this->form()->integer('config.tries'),
+                                'timeout' => $this->form()->integer('config.timeout'),
+                            ],
+                        ],
+                    ],
                 ),
             ),
             'Creating managed queue...',

--- a/app/Commands/ManagedQueueFailedJobDelete.php
+++ b/app/Commands/ManagedQueueFailedJobDelete.php
@@ -63,7 +63,9 @@ class ManagedQueueFailedJobDelete extends BaseCommand
             ])->toArray(),
             actions: [
                 Key::ENTER => [
-                    fn ($row) => $row[0],
+                    function ($row) use (&$jobId) {
+                        $jobId = $row[0];
+                    },
                     'Select',
                 ],
             ],

--- a/app/Commands/ManagedQueueFailedJobDelete.php
+++ b/app/Commands/ManagedQueueFailedJobDelete.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Commands;
+
+use function Laravel\Prompts\intro;
+use function Laravel\Prompts\select;
+use function Laravel\Prompts\spin;
+
+class ManagedQueueFailedJobDelete extends BaseCommand
+{
+    protected $signature = 'managed-queue:delete-failed-job {instance? : The instance ID} {job? : The failed job ID} {--force : Skip confirmation}';
+
+    protected $description = 'Delete a failed job from a managed queue';
+
+    public function handle()
+    {
+        $this->ensureClient();
+
+        intro('Delete Failed Job');
+
+        $instance = $this->resolvers()->instance()->from($this->argument('instance'));
+
+        $jobId = $this->argument('job') ?? $this->selectFailedJob($instance->id);
+
+        $this->confirmDestructive("Delete failed job '{$jobId}'?");
+
+        spin(
+            fn () => $this->client->instances()->deleteFailedJob($instance->id, $jobId),
+            'Deleting failed job...',
+        );
+
+        $this->outputJsonIfWanted('Failed job deleted.');
+
+        success('Failed job deleted');
+    }
+
+    protected function selectFailedJob(string $instanceId): string
+    {
+        $jobs = spin(
+            fn () => $this->client->instances()->failedJobs($instanceId)->collect(),
+            'Fetching failed jobs...',
+        );
+
+        if ($jobs->isEmpty()) {
+            $this->outputErrorOrThrow('No failed jobs found.');
+        }
+
+        $this->ensureInteractive('No failed jobs found. Provide a job ID.');
+
+        return select(
+            label: 'Failed Job',
+            options: $jobs->mapWithKeys(fn ($job) => [
+                $job->id => $job->queue.' — '.($job->failedAt?->format('Y-m-d H:i:s') ?? 'unknown'),
+            ])->toArray(),
+        );
+    }
+}

--- a/app/Commands/ManagedQueueFailedJobDelete.php
+++ b/app/Commands/ManagedQueueFailedJobDelete.php
@@ -21,7 +21,7 @@ class ManagedQueueFailedJobDelete extends BaseCommand
     {
         $this->ensureClient();
 
-        intro('Delete Failed Job');
+        intro('Deleting Failed Job');
 
         $instance = $this->resolvers()->instance()->ofType(InstanceType::MANAGED_QUEUE)->from($this->argument('instance'));
 

--- a/app/Commands/ManagedQueueFailedJobDelete.php
+++ b/app/Commands/ManagedQueueFailedJobDelete.php
@@ -15,6 +15,8 @@ class ManagedQueueFailedJobDelete extends BaseCommand
 
     protected $description = 'Delete a failed job from a managed queue';
 
+    protected $aliases = ['queue:delete-failed-job'];
+
     public function handle()
     {
         $this->ensureClient();

--- a/app/Commands/ManagedQueueFailedJobDelete.php
+++ b/app/Commands/ManagedQueueFailedJobDelete.php
@@ -2,8 +2,11 @@
 
 namespace App\Commands;
 
+use App\Enums\InstanceType;
+use Illuminate\Support\Str;
+use Laravel\Prompts\Key;
+
 use function Laravel\Prompts\intro;
-use function Laravel\Prompts\select;
 use function Laravel\Prompts\spin;
 
 class ManagedQueueFailedJobDelete extends BaseCommand
@@ -18,7 +21,7 @@ class ManagedQueueFailedJobDelete extends BaseCommand
 
         intro('Delete Failed Job');
 
-        $instance = $this->resolvers()->instance()->from($this->argument('instance'));
+        $instance = $this->resolvers()->instance()->ofType(InstanceType::MANAGED_QUEUE)->from($this->argument('instance'));
 
         $jobId = $this->argument('job') ?? $this->selectFailedJob($instance->id);
 
@@ -47,11 +50,25 @@ class ManagedQueueFailedJobDelete extends BaseCommand
 
         $this->ensureInteractive('No failed jobs found. Provide a job ID.');
 
-        return select(
-            label: 'Failed Job',
-            options: $jobs->mapWithKeys(fn ($job) => [
-                $job->id => $job->queue.' — '.($job->failedAt?->format('Y-m-d H:i:s') ?? 'unknown'),
+        $jobId = null;
+
+        dataTable(
+            headers: ['ID', 'Name', 'Queue', 'Exception', 'Failed At'],
+            rows: $jobs->map(fn ($job) => [
+                $job->id,
+                $job->name,
+                $job->queue,
+                Str::limit($job->exception ?? '-', 30),
+                $job->failedAt?->format('Y-m-d H:i:s') ?? '-',
             ])->toArray(),
+            actions: [
+                Key::ENTER => [
+                    fn ($row) => $row[0],
+                    'Select',
+                ],
+            ],
         );
+
+        return $jobId ?? '';
     }
 }

--- a/app/Commands/ManagedQueueFailedJobDelete.php
+++ b/app/Commands/ManagedQueueFailedJobDelete.php
@@ -4,9 +4,9 @@ namespace App\Commands;
 
 use App\Enums\InstanceType;
 use Illuminate\Support\Str;
-use Laravel\Prompts\Key;
 
 use function Laravel\Prompts\intro;
+use function Laravel\Prompts\multiselect;
 use function Laravel\Prompts\spin;
 
 class ManagedQueueFailedJobDelete extends BaseCommand
@@ -25,21 +25,29 @@ class ManagedQueueFailedJobDelete extends BaseCommand
 
         $instance = $this->resolvers()->instance()->ofType(InstanceType::MANAGED_QUEUE)->from($this->argument('instance'));
 
-        $jobId = $this->argument('job') ?? $this->selectFailedJob($instance->id);
+        $jobIds = $this->argument('job') ?? $this->selectFailedJob($instance->id);
 
-        $this->confirmDestructive("Delete failed job '{$jobId}'?");
+        if (! is_array($jobIds)) {
+            $jobIds = [$jobIds];
+        }
+
+        $jobLabel = Str::plural('job', count($jobIds));
+
+        $this->confirmDestructive("Delete failed {$jobLabel}?");
 
         spin(
-            fn () => $this->client->instances()->deleteFailedJob($instance->id, $jobId),
-            'Deleting failed job...',
+            fn () => collect($jobIds)->each(
+                fn ($jobId) => $this->client->instances()->deleteFailedJob($instance->id, $jobId),
+            ),
+            "Deleting failed {$jobLabel}...",
         );
 
-        $this->outputJsonIfWanted('Failed job deleted.');
+        $this->outputJsonIfWanted("Failed {$jobLabel} deleted.");
 
-        success('Failed job deleted');
+        success("Failed {$jobLabel} deleted");
     }
 
-    protected function selectFailedJob(string $instanceId): string
+    protected function selectFailedJob(string $instanceId): array
     {
         $jobs = spin(
             fn () => $this->client->instances()->failedJobs($instanceId)->collect(),
@@ -52,27 +60,11 @@ class ManagedQueueFailedJobDelete extends BaseCommand
 
         $this->ensureInteractive('No failed jobs found. Provide a job ID.');
 
-        $jobId = null;
-
-        dataTable(
-            headers: ['ID', 'Name', 'Queue', 'Exception', 'Failed At'],
-            rows: $jobs->map(fn ($job) => [
-                $job->id,
-                $job->name,
-                $job->queue,
-                Str::limit($job->exception ?? '-', 30),
-                $job->failedAt?->format('Y-m-d H:i:s') ?? '-',
+        return multiselect(
+            label: 'Select failed jobs to delete',
+            options: $jobs->mapWithKeys(fn ($job) => [
+                $job->id => "{$job->name} ({$job->queue}, failed at {$job->failedAt?->format('Y-m-d H:i:s')})",
             ])->toArray(),
-            actions: [
-                Key::ENTER => [
-                    function ($row) use (&$jobId) {
-                        $jobId = $row[0];
-                    },
-                    'Select',
-                ],
-            ],
         );
-
-        return $jobId ?? '';
     }
 }

--- a/app/Commands/ManagedQueueFailedJobList.php
+++ b/app/Commands/ManagedQueueFailedJobList.php
@@ -21,6 +21,8 @@ class ManagedQueueFailedJobList extends BaseCommand
 
     protected $description = 'List failed jobs for a managed queue';
 
+    protected $aliases = ['queue:failed-jobs'];
+
     public function handle()
     {
         $this->ensureClient();

--- a/app/Commands/ManagedQueueFailedJobList.php
+++ b/app/Commands/ManagedQueueFailedJobList.php
@@ -31,12 +31,10 @@ class ManagedQueueFailedJobList extends BaseCommand
 
         $instance = $this->resolvers()->instance()->ofType(InstanceType::MANAGED_QUEUE)->from($this->argument('instance'));
 
-        $jobs = spin(
-            fn () => $this->client->instances()->failedJobs($instance->id),
+        $items = spin(
+            fn () => $this->client->instances()->failedJobs($instance->id)->collect(),
             'Fetching failed jobs...',
         );
-
-        $items = $jobs->collect();
 
         $this->outputJsonIfWanted($items);
 

--- a/app/Commands/ManagedQueueFailedJobList.php
+++ b/app/Commands/ManagedQueueFailedJobList.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Commands;
+
+use App\Dto\ManagedQueueFailedJob;
+use Laravel\Prompts\Key;
+
+use function Laravel\Prompts\intro;
+use function Laravel\Prompts\spin;
+use function Laravel\Prompts\warning;
+
+class ManagedQueueFailedJobList extends BaseCommand
+{
+    protected ?string $jsonDataClass = ManagedQueueFailedJob::class;
+
+    protected bool $jsonDataIsCollection = true;
+
+    protected $signature = 'managed-queue:failed-jobs {instance? : The instance ID}';
+
+    protected $description = 'List failed jobs for a managed queue';
+
+    public function handle()
+    {
+        $this->ensureClient();
+
+        intro('Failed Jobs');
+
+        $instance = $this->resolvers()->instance()->ofType('managed_queue')->from($this->argument('instance'));
+
+        $jobs = spin(
+            fn() => $this->client->instances()->failedJobs($instance->id),
+            'Fetching failed jobs...',
+        );
+
+        $items = $jobs->collect();
+
+        $this->outputJsonIfWanted($items);
+
+        if ($items->isEmpty()) {
+            warning('No failed jobs found.');
+
+            return self::SUCCESS;
+        }
+
+        dataTable(
+            headers: ['ID', 'Queue', 'Attempts', 'Failed At'],
+            rows: $items->map(fn($job) => [
+                $job->id,
+                $job->queue,
+                $job->attempts,
+                $job->failedAt?->format('Y-m-d H:i:s') ?? '-',
+            ])->toArray(),
+            actions: [
+                Key::ENTER => [
+                    fn($row) => $this->call('managed-queue:retry-failed-job', [
+                        'instance' => $instance->id,
+                        'job' => $row[0],
+                    ]),
+                    'Retry',
+                ],
+            ],
+        );
+    }
+}

--- a/app/Commands/ManagedQueueFailedJobList.php
+++ b/app/Commands/ManagedQueueFailedJobList.php
@@ -3,6 +3,8 @@
 namespace App\Commands;
 
 use App\Dto\ManagedQueueFailedJob;
+use App\Enums\InstanceType;
+use Illuminate\Support\Str;
 use Laravel\Prompts\Key;
 
 use function Laravel\Prompts\intro;
@@ -25,10 +27,10 @@ class ManagedQueueFailedJobList extends BaseCommand
 
         intro('Failed Jobs');
 
-        $instance = $this->resolvers()->instance()->ofType('managed_queue')->from($this->argument('instance'));
+        $instance = $this->resolvers()->instance()->ofType(InstanceType::MANAGED_QUEUE)->from($this->argument('instance'));
 
         $jobs = spin(
-            fn() => $this->client->instances()->failedJobs($instance->id),
+            fn () => $this->client->instances()->failedJobs($instance->id),
             'Fetching failed jobs...',
         );
 
@@ -43,22 +45,49 @@ class ManagedQueueFailedJobList extends BaseCommand
         }
 
         dataTable(
-            headers: ['ID', 'Queue', 'Attempts', 'Failed At'],
-            rows: $items->map(fn($job) => [
+            headers: ['ID', 'Name', 'Queue', 'Exception', 'Failed At'],
+            rows: $items->map(fn ($job) => [
                 $job->id,
+                $job->name,
                 $job->queue,
-                $job->attempts,
+                Str::limit($job->exception ?? '-', 30),
                 $job->failedAt?->format('Y-m-d H:i:s') ?? '-',
             ])->toArray(),
             actions: [
-                Key::ENTER => [
-                    fn($row) => $this->call('managed-queue:retry-failed-job', [
+                'r' => [
+                    fn ($row) => $this->call('managed-queue:retry-failed-job', [
                         'instance' => $instance->id,
                         'job' => $row[0],
                     ]),
                     'Retry',
                 ],
+                'd' => [
+                    fn ($row) => $this->call('managed-queue:delete-failed-job', [
+                        'instance' => $instance->id,
+                        'job' => $row[0],
+                    ]),
+                    'Delete',
+                ],
+                Key::ENTER => [
+                    fn ($row) => $this->showJobDetail($items->firstWhere('id', $row[0])),
+                    'Details',
+                ],
             ],
         );
+    }
+
+    protected function showJobDetail(ManagedQueueFailedJob $job)
+    {
+        dataList([
+            'ID' => $job->id,
+            'Name' => $job->name,
+            'Queue' => $job->queue,
+            'Attempts' => $job->attempts,
+            'Exception' => $job->exception ?? '-',
+            'Failed At' => $job->failedAt?->format('Y-m-d H:i:s') ?? '-',
+            'Started At' => $job->startedAt?->format('Y-m-d H:i:s') ?? '-',
+            'Retried At' => $job->retriedAt?->format('Y-m-d H:i:s') ?? '-',
+            'Retry Reserved Until' => $job->retryReservedUntil?->format('Y-m-d H:i:s') ?? '-',
+        ]);
     }
 }

--- a/app/Commands/ManagedQueueFailedJobRetry.php
+++ b/app/Commands/ManagedQueueFailedJobRetry.php
@@ -15,6 +15,8 @@ class ManagedQueueFailedJobRetry extends BaseCommand
 
     protected $description = 'Retry a failed job on a managed queue';
 
+    protected $aliases = ['queue:retry-failed-job'];
+
     public function handle()
     {
         $this->ensureClient();

--- a/app/Commands/ManagedQueueFailedJobRetry.php
+++ b/app/Commands/ManagedQueueFailedJobRetry.php
@@ -21,7 +21,7 @@ class ManagedQueueFailedJobRetry extends BaseCommand
     {
         $this->ensureClient();
 
-        intro('Retry Failed Job');
+        intro('Retrying Failed Job');
 
         $instance = $this->resolvers()->instance()->ofType(InstanceType::MANAGED_QUEUE)->from($this->argument('instance'));
 

--- a/app/Commands/ManagedQueueFailedJobRetry.php
+++ b/app/Commands/ManagedQueueFailedJobRetry.php
@@ -4,9 +4,9 @@ namespace App\Commands;
 
 use App\Enums\InstanceType;
 use Illuminate\Support\Str;
-use Laravel\Prompts\Key;
 
 use function Laravel\Prompts\intro;
+use function Laravel\Prompts\multiselect;
 use function Laravel\Prompts\spin;
 
 class ManagedQueueFailedJobRetry extends BaseCommand
@@ -25,19 +25,27 @@ class ManagedQueueFailedJobRetry extends BaseCommand
 
         $instance = $this->resolvers()->instance()->ofType(InstanceType::MANAGED_QUEUE)->from($this->argument('instance'));
 
-        $jobId = $this->argument('job') ?? $this->selectFailedJob($instance->id);
+        $jobIds = $this->argument('job') ?? $this->selectFailedJob($instance->id);
+
+        if (! is_array($jobIds)) {
+            $jobIds = [$jobIds];
+        }
+
+        $jobLabel = Str::plural('job', count($jobIds));
 
         spin(
-            fn () => $this->client->instances()->retryFailedJob($instance->id, $jobId),
-            'Retrying failed job...',
+            fn () => collect($jobIds)->each(
+                fn ($jobId) => $this->client->instances()->retryFailedJob($instance->id, $jobId),
+            ),
+            "Retrying failed {$jobLabel}...",
         );
 
-        $this->outputJsonIfWanted('Failed job queued for retry.');
+        $this->outputJsonIfWanted("Failed {$jobLabel} queued for retry.");
 
-        success('Failed job queued for retry');
+        success("Failed {$jobLabel} queued for retry");
     }
 
-    protected function selectFailedJob(string $instanceId): string
+    protected function selectFailedJob(string $instanceId): array
     {
         $jobs = spin(
             fn () => $this->client->instances()->failedJobs($instanceId)->collect(),
@@ -50,27 +58,11 @@ class ManagedQueueFailedJobRetry extends BaseCommand
 
         $this->ensureInteractive('No failed jobs found. Provide a job ID.');
 
-        $jobId = null;
-
-        dataTable(
-            headers: ['ID', 'Name', 'Queue', 'Exception', 'Failed At'],
-            rows: $jobs->map(fn ($job) => [
-                $job->id,
-                $job->name,
-                $job->queue,
-                Str::limit($job->exception ?? '-', 30),
-                $job->failedAt?->format('Y-m-d H:i:s') ?? '-',
+        return multiselect(
+            label: 'Select failed jobs to retry',
+            options: $jobs->mapWithKeys(fn ($job) => [
+                $job->id => "{$job->name} ({$job->queue}, failed at {$job->failedAt?->format('Y-m-d H:i:s')})",
             ])->toArray(),
-            actions: [
-                Key::ENTER => [
-                    function ($row) use (&$jobId) {
-                        $jobId = $row[0];
-                    },
-                    'Select',
-                ],
-            ],
         );
-
-        return $jobId ?? '';
     }
 }

--- a/app/Commands/ManagedQueueFailedJobRetry.php
+++ b/app/Commands/ManagedQueueFailedJobRetry.php
@@ -2,8 +2,11 @@
 
 namespace App\Commands;
 
+use App\Enums\InstanceType;
+use Illuminate\Support\Str;
+use Laravel\Prompts\Key;
+
 use function Laravel\Prompts\intro;
-use function Laravel\Prompts\select;
 use function Laravel\Prompts\spin;
 
 class ManagedQueueFailedJobRetry extends BaseCommand
@@ -18,7 +21,7 @@ class ManagedQueueFailedJobRetry extends BaseCommand
 
         intro('Retry Failed Job');
 
-        $instance = $this->resolvers()->instance()->from($this->argument('instance'));
+        $instance = $this->resolvers()->instance()->ofType(InstanceType::MANAGED_QUEUE)->from($this->argument('instance'));
 
         $jobId = $this->argument('job') ?? $this->selectFailedJob($instance->id);
 
@@ -45,11 +48,25 @@ class ManagedQueueFailedJobRetry extends BaseCommand
 
         $this->ensureInteractive('No failed jobs found. Provide a job ID.');
 
-        return select(
-            label: 'Failed Job',
-            options: $jobs->mapWithKeys(fn ($job) => [
-                $job->id => $job->queue.' — '.($job->failedAt?->format('Y-m-d H:i:s') ?? 'unknown'),
+        $jobId = null;
+
+        dataTable(
+            headers: ['ID', 'Name', 'Queue', 'Exception', 'Failed At'],
+            rows: $jobs->map(fn ($job) => [
+                $job->id,
+                $job->name,
+                $job->queue,
+                Str::limit($job->exception ?? '-', 30),
+                $job->failedAt?->format('Y-m-d H:i:s') ?? '-',
             ])->toArray(),
+            actions: [
+                Key::ENTER => [
+                    fn ($row) => $row[0],
+                    'Select',
+                ],
+            ],
         );
+
+        return $jobId ?? '';
     }
 }

--- a/app/Commands/ManagedQueueFailedJobRetry.php
+++ b/app/Commands/ManagedQueueFailedJobRetry.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Commands;
+
+use function Laravel\Prompts\intro;
+use function Laravel\Prompts\select;
+use function Laravel\Prompts\spin;
+
+class ManagedQueueFailedJobRetry extends BaseCommand
+{
+    protected $signature = 'managed-queue:retry-failed-job {instance? : The instance ID} {job? : The failed job ID}';
+
+    protected $description = 'Retry a failed job on a managed queue';
+
+    public function handle()
+    {
+        $this->ensureClient();
+
+        intro('Retry Failed Job');
+
+        $instance = $this->resolvers()->instance()->from($this->argument('instance'));
+
+        $jobId = $this->argument('job') ?? $this->selectFailedJob($instance->id);
+
+        spin(
+            fn () => $this->client->instances()->retryFailedJob($instance->id, $jobId),
+            'Retrying failed job...',
+        );
+
+        $this->outputJsonIfWanted('Failed job queued for retry.');
+
+        success('Failed job queued for retry');
+    }
+
+    protected function selectFailedJob(string $instanceId): string
+    {
+        $jobs = spin(
+            fn () => $this->client->instances()->failedJobs($instanceId)->collect(),
+            'Fetching failed jobs...',
+        );
+
+        if ($jobs->isEmpty()) {
+            $this->outputErrorOrThrow('No failed jobs found.');
+        }
+
+        $this->ensureInteractive('No failed jobs found. Provide a job ID.');
+
+        return select(
+            label: 'Failed Job',
+            options: $jobs->mapWithKeys(fn ($job) => [
+                $job->id => $job->queue.' — '.($job->failedAt?->format('Y-m-d H:i:s') ?? 'unknown'),
+            ])->toArray(),
+        );
+    }
+}

--- a/app/Commands/ManagedQueueFailedJobRetry.php
+++ b/app/Commands/ManagedQueueFailedJobRetry.php
@@ -61,7 +61,9 @@ class ManagedQueueFailedJobRetry extends BaseCommand
             ])->toArray(),
             actions: [
                 Key::ENTER => [
-                    fn ($row) => $row[0],
+                    function ($row) use (&$jobId) {
+                        $jobId = $row[0];
+                    },
                     'Select',
                 ],
             ],

--- a/app/Commands/ManagedQueuePause.php
+++ b/app/Commands/ManagedQueuePause.php
@@ -22,7 +22,7 @@ class ManagedQueuePause extends BaseCommand
     {
         $this->ensureClient();
 
-        intro('Pause Managed Queue');
+        intro('Pausing Managed Queue');
 
         $instance = $this->resolvers()->instance()->ofType(InstanceType::MANAGED_QUEUE)->from($this->argument('instance'));
 

--- a/app/Commands/ManagedQueuePause.php
+++ b/app/Commands/ManagedQueuePause.php
@@ -3,6 +3,7 @@
 namespace App\Commands;
 
 use App\Dto\EnvironmentInstance;
+use App\Enums\InstanceType;
 
 use function Laravel\Prompts\intro;
 use function Laravel\Prompts\spin;
@@ -11,7 +12,7 @@ class ManagedQueuePause extends BaseCommand
 {
     protected ?string $jsonDataClass = EnvironmentInstance::class;
 
-    protected $signature = 'managed-queue:pause {instance? : The instance ID}';
+    protected $signature = 'managed-queue:pause {instance? : The instance ID} {--force : Skip confirmation}';
 
     protected $description = 'Pause a managed queue';
 
@@ -21,7 +22,9 @@ class ManagedQueuePause extends BaseCommand
 
         intro('Pause Managed Queue');
 
-        $instance = $this->resolvers()->instance()->from($this->argument('instance'));
+        $instance = $this->resolvers()->instance()->ofType(InstanceType::MANAGED_QUEUE)->from($this->argument('instance'));
+
+        $this->confirmDestructive("Pause managed queue '{$instance->name}'?");
 
         $updated = spin(
             fn () => $this->client->instances()->pause($instance->id),

--- a/app/Commands/ManagedQueuePause.php
+++ b/app/Commands/ManagedQueuePause.php
@@ -16,6 +16,8 @@ class ManagedQueuePause extends BaseCommand
 
     protected $description = 'Pause a managed queue';
 
+    protected $aliases = ['queue:pause'];
+
     public function handle()
     {
         $this->ensureClient();

--- a/app/Commands/ManagedQueuePause.php
+++ b/app/Commands/ManagedQueuePause.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Commands;
+
+use App\Dto\EnvironmentInstance;
+
+use function Laravel\Prompts\intro;
+use function Laravel\Prompts\spin;
+
+class ManagedQueuePause extends BaseCommand
+{
+    protected ?string $jsonDataClass = EnvironmentInstance::class;
+
+    protected $signature = 'managed-queue:pause {instance? : The instance ID}';
+
+    protected $description = 'Pause a managed queue';
+
+    public function handle()
+    {
+        $this->ensureClient();
+
+        intro('Pause Managed Queue');
+
+        $instance = $this->resolvers()->instance()->from($this->argument('instance'));
+
+        $updated = spin(
+            fn () => $this->client->instances()->pause($instance->id),
+            'Pausing managed queue...',
+        );
+
+        $this->outputJsonIfWanted($updated);
+
+        success("Managed queue '{$instance->name}' paused");
+    }
+}

--- a/app/Commands/ManagedQueuePurge.php
+++ b/app/Commands/ManagedQueuePurge.php
@@ -3,6 +3,7 @@
 namespace App\Commands;
 
 use App\Dto\EnvironmentInstance;
+use App\Enums\InstanceType;
 
 use function Laravel\Prompts\intro;
 use function Laravel\Prompts\spin;
@@ -21,7 +22,7 @@ class ManagedQueuePurge extends BaseCommand
 
         intro('Purge Managed Queue');
 
-        $instance = $this->resolvers()->instance()->from($this->argument('instance'));
+        $instance = $this->resolvers()->instance()->ofType(InstanceType::MANAGED_QUEUE)->from($this->argument('instance'));
 
         $this->confirmDestructive("Purge all messages from queue '{$instance->name}'?");
 

--- a/app/Commands/ManagedQueuePurge.php
+++ b/app/Commands/ManagedQueuePurge.php
@@ -14,6 +14,8 @@ class ManagedQueuePurge extends BaseCommand
 
     protected $signature = 'managed-queue:purge {instance? : The instance ID} {--force : Skip confirmation}';
 
+    protected $aliases = ['queue:purge'];
+
     protected $description = 'Purge all messages from a managed queue';
 
     public function handle()
@@ -27,7 +29,7 @@ class ManagedQueuePurge extends BaseCommand
         $this->confirmDestructive("Purge all messages from queue '{$instance->name}'?");
 
         $updated = spin(
-            fn () => $this->client->instances()->purge($instance->id),
+            fn() => $this->client->instances()->purge($instance->id),
             'Purging managed queue...',
         );
 

--- a/app/Commands/ManagedQueuePurge.php
+++ b/app/Commands/ManagedQueuePurge.php
@@ -29,7 +29,7 @@ class ManagedQueuePurge extends BaseCommand
         $this->confirmDestructive("Purge all messages from queue '{$instance->name}'?");
 
         $updated = spin(
-            fn() => $this->client->instances()->purge($instance->id),
+            fn () => $this->client->instances()->purge($instance->id),
             'Purging managed queue...',
         );
 

--- a/app/Commands/ManagedQueuePurge.php
+++ b/app/Commands/ManagedQueuePurge.php
@@ -22,7 +22,7 @@ class ManagedQueuePurge extends BaseCommand
     {
         $this->ensureClient();
 
-        intro('Purge Managed Queue');
+        intro('Purging Managed Queue');
 
         $instance = $this->resolvers()->instance()->ofType(InstanceType::MANAGED_QUEUE)->from($this->argument('instance'));
 

--- a/app/Commands/ManagedQueuePurge.php
+++ b/app/Commands/ManagedQueuePurge.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Commands;
+
+use App\Dto\EnvironmentInstance;
+
+use function Laravel\Prompts\intro;
+use function Laravel\Prompts\spin;
+
+class ManagedQueuePurge extends BaseCommand
+{
+    protected ?string $jsonDataClass = EnvironmentInstance::class;
+
+    protected $signature = 'managed-queue:purge {instance? : The instance ID} {--force : Skip confirmation}';
+
+    protected $description = 'Purge all messages from a managed queue';
+
+    public function handle()
+    {
+        $this->ensureClient();
+
+        intro('Purge Managed Queue');
+
+        $instance = $this->resolvers()->instance()->from($this->argument('instance'));
+
+        $this->confirmDestructive("Purge all messages from queue '{$instance->name}'?");
+
+        $updated = spin(
+            fn () => $this->client->instances()->purge($instance->id),
+            'Purging managed queue...',
+        );
+
+        $this->outputJsonIfWanted($updated);
+
+        success("Managed queue '{$instance->name}' purged");
+    }
+}

--- a/app/Commands/ManagedQueueResume.php
+++ b/app/Commands/ManagedQueueResume.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Commands;
+
+use App\Dto\EnvironmentInstance;
+
+use function Laravel\Prompts\intro;
+use function Laravel\Prompts\spin;
+
+class ManagedQueueResume extends BaseCommand
+{
+    protected ?string $jsonDataClass = EnvironmentInstance::class;
+
+    protected $signature = 'managed-queue:resume {instance? : The instance ID}';
+
+    protected $description = 'Resume a managed queue';
+
+    public function handle()
+    {
+        $this->ensureClient();
+
+        intro('Resume Managed Queue');
+
+        $instance = $this->resolvers()->instance()->from($this->argument('instance'));
+
+        $updated = spin(
+            fn () => $this->client->instances()->resume($instance->id),
+            'Resuming managed queue...',
+        );
+
+        $this->outputJsonIfWanted($updated);
+
+        success("Managed queue '{$instance->name}' resumed");
+    }
+}

--- a/app/Commands/ManagedQueueResume.php
+++ b/app/Commands/ManagedQueueResume.php
@@ -16,6 +16,8 @@ class ManagedQueueResume extends BaseCommand
 
     protected $description = 'Resume a managed queue';
 
+    protected $aliases = ['queue:resume'];
+
     public function handle()
     {
         $this->ensureClient();

--- a/app/Commands/ManagedQueueResume.php
+++ b/app/Commands/ManagedQueueResume.php
@@ -22,7 +22,7 @@ class ManagedQueueResume extends BaseCommand
     {
         $this->ensureClient();
 
-        intro('Resume Managed Queue');
+        intro('Resuming Managed Queue');
 
         $instance = $this->resolvers()->instance()->ofType(InstanceType::MANAGED_QUEUE)->from($this->argument('instance'));
 

--- a/app/Commands/ManagedQueueResume.php
+++ b/app/Commands/ManagedQueueResume.php
@@ -3,6 +3,7 @@
 namespace App\Commands;
 
 use App\Dto\EnvironmentInstance;
+use App\Enums\InstanceType;
 
 use function Laravel\Prompts\intro;
 use function Laravel\Prompts\spin;
@@ -11,7 +12,7 @@ class ManagedQueueResume extends BaseCommand
 {
     protected ?string $jsonDataClass = EnvironmentInstance::class;
 
-    protected $signature = 'managed-queue:resume {instance? : The instance ID}';
+    protected $signature = 'managed-queue:resume {instance? : The instance ID} {--force : Skip confirmation}';
 
     protected $description = 'Resume a managed queue';
 
@@ -21,7 +22,9 @@ class ManagedQueueResume extends BaseCommand
 
         intro('Resume Managed Queue');
 
-        $instance = $this->resolvers()->instance()->from($this->argument('instance'));
+        $instance = $this->resolvers()->instance()->ofType(InstanceType::MANAGED_QUEUE)->from($this->argument('instance'));
+
+        $this->confirmDestructive("Resume managed queue '{$instance->name}'?");
 
         $updated = spin(
             fn () => $this->client->instances()->resume($instance->id),

--- a/app/Commands/ManagedQueueResume.php
+++ b/app/Commands/ManagedQueueResume.php
@@ -12,7 +12,7 @@ class ManagedQueueResume extends BaseCommand
 {
     protected ?string $jsonDataClass = EnvironmentInstance::class;
 
-    protected $signature = 'managed-queue:resume {instance? : The instance ID} {--force : Skip confirmation}';
+    protected $signature = 'managed-queue:resume {instance? : The instance ID}';
 
     protected $description = 'Resume a managed queue';
 
@@ -25,8 +25,6 @@ class ManagedQueueResume extends BaseCommand
         intro('Resume Managed Queue');
 
         $instance = $this->resolvers()->instance()->ofType(InstanceType::MANAGED_QUEUE)->from($this->argument('instance'));
-
-        $this->confirmDestructive("Resume managed queue '{$instance->name}'?");
 
         $updated = spin(
             fn () => $this->client->instances()->resume($instance->id),

--- a/app/Commands/ManagedQueueSetDefault.php
+++ b/app/Commands/ManagedQueueSetDefault.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Commands;
+
+use App\Dto\EnvironmentInstance;
+
+use function Laravel\Prompts\intro;
+use function Laravel\Prompts\spin;
+
+class ManagedQueueSetDefault extends BaseCommand
+{
+    protected ?string $jsonDataClass = EnvironmentInstance::class;
+
+    protected $signature = 'managed-queue:set-default {instance? : The instance ID}';
+
+    protected $description = 'Set a managed queue as the default';
+
+    public function handle()
+    {
+        $this->ensureClient();
+
+        intro('Set Default Managed Queue');
+
+        $instance = $this->resolvers()->instance()->from($this->argument('instance'));
+
+        $updated = spin(
+            fn () => $this->client->instances()->setDefault($instance->id),
+            'Setting default managed queue...',
+        );
+
+        $this->outputJsonIfWanted($updated);
+
+        success("Managed queue '{$instance->name}' set as default");
+    }
+}

--- a/app/Commands/ManagedQueueSetDefault.php
+++ b/app/Commands/ManagedQueueSetDefault.php
@@ -22,7 +22,7 @@ class ManagedQueueSetDefault extends BaseCommand
     {
         $this->ensureClient();
 
-        intro('Set Default Managed Queue');
+        intro('Setting Default Managed Queue');
 
         $instance = $this->resolvers()->instance()->ofType(InstanceType::MANAGED_QUEUE)->from($this->argument('instance'));
 

--- a/app/Commands/ManagedQueueSetDefault.php
+++ b/app/Commands/ManagedQueueSetDefault.php
@@ -3,6 +3,7 @@
 namespace App\Commands;
 
 use App\Dto\EnvironmentInstance;
+use App\Enums\InstanceType;
 
 use function Laravel\Prompts\intro;
 use function Laravel\Prompts\spin;
@@ -21,7 +22,7 @@ class ManagedQueueSetDefault extends BaseCommand
 
         intro('Set Default Managed Queue');
 
-        $instance = $this->resolvers()->instance()->from($this->argument('instance'));
+        $instance = $this->resolvers()->instance()->ofType(InstanceType::MANAGED_QUEUE)->from($this->argument('instance'));
 
         $updated = spin(
             fn () => $this->client->instances()->setDefault($instance->id),

--- a/app/Commands/ManagedQueueSetDefault.php
+++ b/app/Commands/ManagedQueueSetDefault.php
@@ -16,6 +16,8 @@ class ManagedQueueSetDefault extends BaseCommand
 
     protected $description = 'Set a managed queue as the default';
 
+    protected $aliases = ['queue:set-default'];
+
     public function handle()
     {
         $this->ensureClient();

--- a/app/Dto/EnvironmentInstance.php
+++ b/app/Dto/EnvironmentInstance.php
@@ -20,6 +20,11 @@ class EnvironmentInstance extends Data
         public readonly bool $usesScheduler,
         public readonly ?int $scalingCpuThresholdPercentage = null,
         public readonly ?int $scalingMemoryThresholdPercentage = null,
+        public readonly ?string $queueStatus = null,
+        public readonly ?bool $paused = null,
+        public readonly ?bool $isDefault = null,
+        public readonly ?int $visibilityTimeout = null,
+        public readonly ?int $pollingInterval = null,
         #[WithCast(DateTimeInterfaceCast::class, type: CarbonImmutable::class)]
         public readonly ?CarbonImmutable $createdAt = null,
         #[WithCast(DateTimeInterfaceCast::class, type: CarbonImmutable::class)]
@@ -48,6 +53,11 @@ class EnvironmentInstance extends Data
             'usesScheduler' => $attributes['uses_scheduler'],
             'scalingCpuThresholdPercentage' => $attributes['scaling_cpu_threshold_percentage'] ?? null,
             'scalingMemoryThresholdPercentage' => $attributes['scaling_memory_threshold_percentage'] ?? null,
+            'queueStatus' => $attributes['queue_status'] ?? null,
+            'paused' => isset($attributes['paused']) ? filter_var($attributes['paused'], FILTER_VALIDATE_BOOLEAN) : null,
+            'isDefault' => isset($attributes['is_default']) ? filter_var($attributes['is_default'], FILTER_VALIDATE_BOOLEAN) : null,
+            'visibilityTimeout' => isset($attributes['visibility_timeout']) ? (int) $attributes['visibility_timeout'] : null,
+            'pollingInterval' => isset($attributes['polling_interval']) ? (int) $attributes['polling_interval'] : null,
             'createdAt' => $attributes['created_at'] ?? null,
             'updatedAt' => $attributes['updated_at'] ?? null,
             'environment' => ($relationships['environment']['data'] ?? null) ? Environment::createFromResponse(['data' => collect($included)->firstWhere('type', 'environments')]) : null,

--- a/app/Dto/ManagedQueueFailedJob.php
+++ b/app/Dto/ManagedQueueFailedJob.php
@@ -11,16 +11,17 @@ class ManagedQueueFailedJob extends Data
 {
     public function __construct(
         public readonly string $id,
+        public readonly string $name,
         public readonly string $queue,
         public readonly int $attempts,
         public readonly ?string $exception = null,
-        #[WithCast(DateTimeInterfaceCast::class, type: CarbonImmutable::class, format: 'Y-m-d H:i:s.u')]
+        #[WithCast(DateTimeInterfaceCast::class, type: CarbonImmutable::class)]
         public readonly ?CarbonImmutable $failedAt = null,
-        #[WithCast(DateTimeInterfaceCast::class, type: CarbonImmutable::class, format: 'Y-m-d H:i:s.u')]
+        #[WithCast(DateTimeInterfaceCast::class, type: CarbonImmutable::class)]
         public readonly ?CarbonImmutable $startedAt = null,
-        #[WithCast(DateTimeInterfaceCast::class, type: CarbonImmutable::class, format: 'Y-m-d H:i:s.u')]
+        #[WithCast(DateTimeInterfaceCast::class, type: CarbonImmutable::class)]
         public readonly ?CarbonImmutable $retriedAt = null,
-        #[WithCast(DateTimeInterfaceCast::class, type: CarbonImmutable::class, format: 'Y-m-d H:i:s.u')]
+        #[WithCast(DateTimeInterfaceCast::class, type: CarbonImmutable::class)]
         public readonly ?CarbonImmutable $retryReservedUntil = null,
     ) {
         //
@@ -33,6 +34,7 @@ class ManagedQueueFailedJob extends Data
 
         return self::from([
             'id' => $data['id'],
+            'name' => $attributes['name'] ?? $data['id'],
             'queue' => $attributes['queue'],
             'attempts' => (int) ($attributes['attempts'] ?? 0),
             'exception' => $attributes['exception'] ?: null,

--- a/app/Dto/ManagedQueueFailedJob.php
+++ b/app/Dto/ManagedQueueFailedJob.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Dto;
+
+use Carbon\CarbonImmutable;
+use Spatie\LaravelData\Attributes\WithCast;
+use Spatie\LaravelData\Casts\DateTimeInterfaceCast;
+use Spatie\LaravelData\Data;
+
+class ManagedQueueFailedJob extends Data
+{
+    public function __construct(
+        public readonly string $id,
+        public readonly string $queue,
+        public readonly int $attempts,
+        public readonly ?string $exception = null,
+        #[WithCast(DateTimeInterfaceCast::class, type: CarbonImmutable::class, format: 'Y-m-d H:i:s.u')]
+        public readonly ?CarbonImmutable $failedAt = null,
+        #[WithCast(DateTimeInterfaceCast::class, type: CarbonImmutable::class, format: 'Y-m-d H:i:s.u')]
+        public readonly ?CarbonImmutable $startedAt = null,
+        #[WithCast(DateTimeInterfaceCast::class, type: CarbonImmutable::class, format: 'Y-m-d H:i:s.u')]
+        public readonly ?CarbonImmutable $retriedAt = null,
+        #[WithCast(DateTimeInterfaceCast::class, type: CarbonImmutable::class, format: 'Y-m-d H:i:s.u')]
+        public readonly ?CarbonImmutable $retryReservedUntil = null,
+    ) {
+        //
+    }
+
+    public static function createFromResponse(array $response): self
+    {
+        $data = $response['data'] ?? $response;
+        $attributes = $data['attributes'] ?? [];
+
+        return self::from([
+            'id' => $data['id'],
+            'queue' => $attributes['queue'],
+            'attempts' => (int) ($attributes['attempts'] ?? 0),
+            'exception' => $attributes['exception'] ?: null,
+            'failedAt' => $attributes['failed_at'] ?: null,
+            'startedAt' => $attributes['started_at'] ?: null,
+            'retriedAt' => $attributes['retried_at'] ?: null,
+            'retryReservedUntil' => $attributes['retry_reserved_until'] ?: null,
+        ]);
+    }
+}

--- a/app/Enums/InstanceScalingType.php
+++ b/app/Enums/InstanceScalingType.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Enums;
+
+enum InstanceScalingType: string
+{
+    case NONE = 'none';
+    case CUSTOM = 'custom';
+    case AUTO = 'auto';
+}

--- a/app/Enums/InstanceType.php
+++ b/app/Enums/InstanceType.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enums;
+
+enum InstanceType: string
+{
+    case SERVICE = 'service';
+    case MANAGED_QUEUE = 'managed_queue';
+}

--- a/app/Resolvers/InstanceResolver.php
+++ b/app/Resolvers/InstanceResolver.php
@@ -36,6 +36,10 @@ class InstanceResolver extends Resolver
             $this->failAndExit('Unable to resolve instance: '.($idOrName ?? 'Provide a valid instance ID or name.').'. Run `cloud instance:list --json` to see available instances.');
         }
 
+        if ($this->instanceType && $instance->type !== $this->instanceType) {
+            $this->failAndExit("Instance '{$instance->name}' is not of type {$this->instanceType}.");
+        }
+
         $this->displayResolved('Instance', $instance->name, $instance->id);
 
         return $instance;

--- a/app/Resolvers/InstanceResolver.php
+++ b/app/Resolvers/InstanceResolver.php
@@ -12,9 +12,18 @@ class InstanceResolver extends Resolver
 {
     use HasAnApplication;
 
+    protected ?string $instanceType = null;
+
     public function resolve(): ?EnvironmentInstance
     {
         return $this->from();
+    }
+
+    public function ofType(string $type): self
+    {
+        $this->instanceType = $type;
+
+        return $this;
     }
 
     public function from(?string $idOrName = null): ?EnvironmentInstance
@@ -23,7 +32,7 @@ class InstanceResolver extends Resolver
             ?? $this->fromInput();
 
         if (! $instance) {
-            $this->failAndExit('Unable to resolve instance: '.($idOrName ?? 'Provide a valid instance ID or name.').'. Run `cloud instance:list --json` to see available instances.');
+            $this->failAndExit('Unable to resolve instance: ' . ($idOrName ?? 'Provide a valid instance ID or name.') . '. Run `cloud instance:list --json` to see available instances.');
         }
 
         $this->displayResolved('Instance', $instance->name, $instance->id);
@@ -35,8 +44,8 @@ class InstanceResolver extends Resolver
     {
         return $this->resolveFromIdentifier(
             $identifier,
-            fn () => spin(
-                fn () => $this->client->instances()->include('environment')->get($identifier),
+            fn() => spin(
+                fn() => $this->client->instances()->include('environment')->get($identifier),
                 'Fetching instance...',
             ),
         );
@@ -49,19 +58,21 @@ class InstanceResolver extends Resolver
             ->withApplication($this->application())
             ->include('instances')
             ->resolve();
-        $instances = $this->client->instances()->include('environment')->list($environment->id)->collect();
+        $instances = $this->client->instances()
+            ->include('environment')
+            ->list($environment->id)
+            ->collect()
+            ->filter(fn($instance) => $this->instanceType ? $instance->type === $this->instanceType : true);
 
         if ($instances->isEmpty()) {
-            $this->failAndExit('No instances found for environment '.$environment->name);
+            $this->failAndExit('No instances found for environment ' . $environment->name);
         }
 
         if ($instances->hasSole()) {
-            answered(label: 'Instance', answer: $instances->first()->name);
-
             return $instances->first();
         }
 
-        $options = $instances->mapWithKeys(fn ($instance) => [
+        $options = $instances->mapWithKeys(fn($instance) => [
             $instance->id => $instance->name,
         ])->toArray();
 

--- a/app/Resolvers/InstanceResolver.php
+++ b/app/Resolvers/InstanceResolver.php
@@ -3,6 +3,7 @@
 namespace App\Resolvers;
 
 use App\Dto\EnvironmentInstance;
+use App\Enums\InstanceType;
 use App\Resolvers\Concerns\HasAnApplication;
 
 use function Laravel\Prompts\select;
@@ -19,9 +20,9 @@ class InstanceResolver extends Resolver
         return $this->from();
     }
 
-    public function ofType(string $type): self
+    public function ofType(InstanceType $type): self
     {
-        $this->instanceType = $type;
+        $this->instanceType = $type->value;
 
         return $this;
     }
@@ -32,7 +33,7 @@ class InstanceResolver extends Resolver
             ?? $this->fromInput();
 
         if (! $instance) {
-            $this->failAndExit('Unable to resolve instance: ' . ($idOrName ?? 'Provide a valid instance ID or name.') . '. Run `cloud instance:list --json` to see available instances.');
+            $this->failAndExit('Unable to resolve instance: '.($idOrName ?? 'Provide a valid instance ID or name.').'. Run `cloud instance:list --json` to see available instances.');
         }
 
         $this->displayResolved('Instance', $instance->name, $instance->id);
@@ -44,8 +45,8 @@ class InstanceResolver extends Resolver
     {
         return $this->resolveFromIdentifier(
             $identifier,
-            fn() => spin(
-                fn() => $this->client->instances()->include('environment')->get($identifier),
+            fn () => spin(
+                fn () => $this->client->instances()->include('environment')->get($identifier),
                 'Fetching instance...',
             ),
         );
@@ -62,17 +63,17 @@ class InstanceResolver extends Resolver
             ->include('environment')
             ->list($environment->id)
             ->collect()
-            ->filter(fn($instance) => $this->instanceType ? $instance->type === $this->instanceType : true);
+            ->filter(fn ($instance) => $this->instanceType ? $instance->type === $this->instanceType : true);
 
         if ($instances->isEmpty()) {
-            $this->failAndExit('No instances found for environment ' . $environment->name);
+            $this->failAndExit('No instances found for environment '.$environment->name);
         }
 
         if ($instances->hasSole()) {
             return $instances->first();
         }
 
-        $options = $instances->mapWithKeys(fn($instance) => [
+        $options = $instances->mapWithKeys(fn ($instance) => [
             $instance->id => $instance->name,
         ])->toArray();
 


### PR DESCRIPTION
Adds a full suite of `managed-queue:*` commands: `create`, `pause`, `resume`, `purge`, `set-default`, `failed-jobs`, `retry-failed-job`, and `delete-failed-job`. Also extends `CreateInstanceRequestData` and `UpdateInstanceRequestData` with the queue-specific fields (`visibility_timeout`, `polling_interval`, `shutdown_timeout`), adds a `ManagedQueueFailedJob` DTO, and expands `EnvironmentInstance` with queue-specific attributes. The instance resolver gains an `ofType()` filter so managed queue commands only resolve managed queue instances.
