### PR TITLE
Reduce built PHAR size by >70%

### DIFF
--- a/box.json
+++ b/box.json
@@ -14,6 +14,5 @@
     "compactors": [
         "KevinGH\\Box\\Compactor\\Php",
         "KevinGH\\Box\\Compactor\\Json"
-    ],
-    "exclude-dev-files": false
+    ]
 }

--- a/composer.json
+++ b/composer.json
@@ -20,24 +20,24 @@
         }
     ],
     "require": {
-        "php": "^8.2"
-    },
-    "require-dev": {
+        "php": "^8.2",
         "illuminate/http": "^12.17",
         "illuminate/translation": "^12.53",
         "illuminate/validation": "^12.53",
         "laravel-zero/framework": "^12.0.2",
         "laravel-zero/phar-updater": "^1.4",
-        "laravel/pint": "^1.25.1",
-        "mockery/mockery": "^1.6.12",
-        "pestphp/pest": "^3.8.4|^4.1.2",
-        "php-parallel-lint/php-console-highlighter": "^1.0",
-        "phpstan/phpstan": "^2.1",
         "saloonphp/cache-plugin": "^3.1",
         "saloonphp/pagination-plugin": "^2.3",
         "saloonphp/saloon": "^4.0",
         "shipfastlabs/agent-detector": "^1.0",
         "spatie/laravel-data": "^4.19"
+    },
+    "require-dev": {
+        "laravel/pint": "^1.25.1",
+        "mockery/mockery": "^1.6.12",
+        "pestphp/pest": "^3.8.4|^4.1.2",
+        "php-parallel-lint/php-console-highlighter": "^1.0",
+        "phpstan/phpstan": "^2.1"
     },
     "autoload": {
         "psr-4": {

--- a/release.sh
+++ b/release.sh
@@ -129,6 +129,7 @@ if [ -f ".env" ]; then
 fi
 
 info "Building binary..."
+composer install --no-dev
 php cloud app:build --build-version="$NEW_TAG"
 
 if [ -f ".env.bak" ]; then


### PR DESCRIPTION
Hey,

while working on something Cloud related for Herd, I noticed that the official CLI is pretty big (33.4 MB).
This comes from the fact that all dev dependencies are getting bundled into the PHAR (so pint, phpstan, pest, ...).

I modified the composer.json so that dev dependencies are now properly marked as dev dependencies and updated the release shell script to run a `composer install --no-dev` before building a new PHAR file.

This results in a CLI that is only 9.4 MB ✨ 