### PR TITLE
Fix missing corners on header-less tables

### DIFF
--- a/app/Prompts/DataTableRenderer.php
+++ b/app/Prompts/DataTableRenderer.php
@@ -96,7 +96,10 @@ class DataTableRenderer extends Renderer
         }
 
         if (empty($headers)) {
-            $tableStyle->setCrossingChars('┼', '', '', '', '┤', '┘</>', '┴', '└', '├', '<fg=gray>╭', '┬', '╮');
+            // A header-less table draws its first separator with the "top" crossings on
+            // symfony/console 7.4.15 and 8.1.2 and above, and with the "top bottom"
+            // ones before that, so the corners are given to both...
+            $tableStyle->setCrossingChars('┼', '<fg=gray>╭', '┬', '╮', '┤', '┘</>', '┴', '└', '├', '<fg=gray>╭', '┬', '╮');
         } else {
             $tableStyle->setCrossingChars('┼', '<fg=gray>╭', '┬', '╮', '┤', '╯</>', '┴', '╰', '├');
         }

--- a/app/Prompts/TableRenderer.php
+++ b/app/Prompts/TableRenderer.php
@@ -21,7 +21,10 @@ class TableRenderer extends Renderer
             ->setCellRowFormat('<fg=default>%s</>');
 
         if (empty($table->headers)) {
-            $tableStyle->setCrossingChars('┼', '', '', '', '┤', '┘</>', '┴', '└', '├', '<fg=gray>╭', '┬', '╮');
+            // A header-less table draws its first separator with the "top" crossings on
+            // symfony/console 7.4.15 and 8.1.2 and above, and with the "top bottom"
+            // ones before that, so the corners are given to both...
+            $tableStyle->setCrossingChars('┼', '<fg=gray>╭', '┬', '╮', '┤', '┘</>', '┴', '└', '├', '<fg=gray>╭', '┬', '╮');
         } else {
             $tableStyle->setCrossingChars('┼', '<fg=gray>╭', '┬', '╮', '┤', '╯</>', '┴', '╰', '├');
         }


### PR DESCRIPTION
The header-less table style passes empty strings for the top crossings and supplies the corners only in the top bottom slots:

```php
$tableStyle->setCrossingChars('┼', '', '', '', '┤', '┘</>', '┴', '└', '├', '<fg=gray>╭', '┬', '╮');
//                                 ↑   ↑   ↑  top left / mid / right
```

symfony/console took symfony/symfony#64843, "Fix table borders around colspan cells and header-less tables", which changed the first separator of a header-less table to be drawn with the *top* crossings rather than the *top bottom* ones:

```php
$horizontal || !array_filter($this->headers) ? self::SEPARATOR_TOP : self::SEPARATOR_TOP_BOTTOM,
```

That shipped in **v7.4.15** and **v8.1.2**, so the corners disappear as soon as the lock file moves past v7.4.14. Rendering the same rows either side of `composer update symfony/console`:

```
symfony/console v7.4.8            symfony/console v7.4.15
╭─────────┬─────────╮             ──────────────────
│ app-one │ running │             │ app-one │ running │
│ app-two │ stopped │             │ app-two │ stopped │
└─────────┴─────────┘             └─────────┴─────────┘
```

`composer.lock` currently pins v7.4.8, so nothing is broken today — this only surfaces on the next dependency bump.

This gives the corners to both sets, so the same border is drawn whichever separator symfony/console picks, on old and new versions alike. `DataTableRenderer` carries the same style, so it is fixed too. The header-ed branch is untouched.

The identical defect was fixed upstream in laravel/prompts#260.

Verified by rendering through the style on symfony/console v7.4.8 and v7.4.15 — both produce the bordered table above. `pint` is clean and the suite is unchanged (the four `SensitiveJsonOutputTest` / `UsageCommandTest` failures are present on `main` too).
