### PR TITLE
Respect CLOUD_BASE_URL in built binaries

### DIFF
--- a/app/Client/Connector.php
+++ b/app/Client/Connector.php
@@ -77,7 +77,7 @@ class Connector extends SaloonConnector implements HasPagination
 
     public function resolveBaseUrl(): string
     {
-        return config('app.base_url').'/api';
+        return config('cloud.base_url').'/api';
     }
 
     protected function defaultAuth(): TokenAuthenticator

--- a/app/Client/Connector.php
+++ b/app/Client/Connector.php
@@ -23,6 +23,7 @@ use App\Client\Resources\ObjectStorageBucketsResource;
 use App\Client\Resources\UsageResource;
 use App\Client\Resources\WebSocketApplicationsResource;
 use App\Client\Resources\WebSocketClustersResource;
+use App\Cloud;
 use App\Support\ContextDetector;
 use Illuminate\Support\Facades\Cache;
 use Saloon\CachePlugin\Contracts\Driver;
@@ -77,7 +78,7 @@ class Connector extends SaloonConnector implements HasPagination
 
     public function resolveBaseUrl(): string
     {
-        return config('cloud.base_url').'/api';
+        return Cloud::baseUrl().'/api';
     }
 
     protected function defaultAuth(): TokenAuthenticator

--- a/app/Cloud.php
+++ b/app/Cloud.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App;
+
+class Cloud
+{
+    public static function baseUrl(): string
+    {
+        $baseUrl = config('cloud.base_url');
+
+        if (str_starts_with($baseUrl, 'https://') || str_starts_with($baseUrl, 'http://')) {
+            return $baseUrl;
+        }
+
+        return 'https://'.$baseUrl;
+    }
+}

--- a/app/ConfigRepository.php
+++ b/app/ConfigRepository.php
@@ -16,8 +16,8 @@ class ConfigRepository
     {
         $filename = 'config.json';
 
-        if (config('app.has_custom_base_url')) {
-            $filename = str_replace('.', '-', parse_url(config('app.base_url'))['host']).'-config.json';
+        if (config('cloud.has_custom_base_url')) {
+            $filename = str_replace('.', '-', parse_url(config('cloud.base_url'))['host']).'-config.json';
         }
 
         $this->configPath = join_paths($this->getConfigDirectory(), $filename);

--- a/app/ConfigRepository.php
+++ b/app/ConfigRepository.php
@@ -15,9 +15,10 @@ class ConfigRepository
     public function __construct()
     {
         $filename = 'config.json';
+        $baseUrl = Cloud::baseUrl();
 
-        if (config('cloud.has_custom_base_url')) {
-            $filename = str_replace('.', '-', parse_url(config('cloud.base_url'))['host']).'-config.json';
+        if ($baseUrl !== config('cloud.default_url')) {
+            $filename = str_replace('.', '-', parse_url($baseUrl)['host']).'-config.json';
         }
 
         $this->configPath = join_paths($this->getConfigDirectory(), $filename);

--- a/app/Dto/Application.php
+++ b/app/Dto/Application.php
@@ -2,6 +2,7 @@
 
 namespace App\Dto;
 
+use App\Cloud;
 use Carbon\CarbonImmutable;
 use Spatie\LaravelData\Attributes\DataCollectionOf;
 use Spatie\LaravelData\Attributes\WithCast;
@@ -94,7 +95,7 @@ class Application extends Data
         $environment ??= collect($this->environments)->firstWhere('id', $this->defaultEnvironmentId);
 
         $parts = [
-            config('cloud.base_url'),
+            Cloud::baseUrl(),
             $this->organization->slug,
             $this->slug,
         ];

--- a/app/Dto/Application.php
+++ b/app/Dto/Application.php
@@ -94,7 +94,7 @@ class Application extends Data
         $environment ??= collect($this->environments)->firstWhere('id', $this->defaultEnvironmentId);
 
         $parts = [
-            config('app.base_url'),
+            config('cloud.base_url'),
             $this->organization->slug,
             $this->slug,
         ];

--- a/config/app.php
+++ b/config/app.php
@@ -63,8 +63,4 @@ return [
         TranslationServiceProvider::class,
     ],
 
-    'base_url' => rtrim(env('CLOUD_BASE_URL', 'https://cloud.laravel.com'), '/'),
-
-    'has_custom_base_url' => env('CLOUD_BASE_URL') !== null,
-
 ];

--- a/config/cloud.php
+++ b/config/cloud.php
@@ -18,6 +18,6 @@ return [
 
     'default_url' => $defaultUrl,
 
-    'base_url' => trim(env('CLOUD_BASE_URL') ?: $defaultUrl, '/'),
+    'base_url' => rtrim(env('CLOUD_BASE_URL') ?: $defaultUrl, '/'),
 
 ];

--- a/config/cloud.php
+++ b/config/cloud.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Laravel Cloud API Location
+|--------------------------------------------------------------------------
+|
+| These values must NOT live in config/app.php: the `app:build` command
+| evaluates config/app.php (and only that file) at build time and bakes
+| the resulting array into the phar, which would freeze the env() calls
+| below. In this file they are evaluated at runtime in built binaries.
+|
+*/
+
+return [
+
+    'base_url' => rtrim(env('CLOUD_BASE_URL', 'https://cloud.laravel.com'), '/'),
+
+    'has_custom_base_url' => env('CLOUD_BASE_URL') !== null,
+
+];

--- a/config/cloud.php
+++ b/config/cloud.php
@@ -12,10 +12,12 @@
 |
 */
 
+$defaultUrl = 'https://cloud.laravel.com';
+
 return [
 
-    'base_url' => rtrim(env('CLOUD_BASE_URL', 'https://cloud.laravel.com'), '/'),
+    'default_url' => $defaultUrl,
 
-    'has_custom_base_url' => env('CLOUD_BASE_URL') !== null,
+    'base_url' => trim(env('CLOUD_BASE_URL') ?: $defaultUrl, '/'),
 
 ];

--- a/tests/Unit/CloudTest.php
+++ b/tests/Unit/CloudTest.php
@@ -1,0 +1,15 @@
+<?php
+
+use App\Cloud;
+
+it('adds a scheme to the base URL when one is missing', function (string $baseUrl, string $expected) {
+    config(['cloud.base_url' => $baseUrl]);
+
+    expect(Cloud::baseUrl())->toBe($expected);
+})->with([
+    'no scheme' => ['cloud.laravel.test', 'https://cloud.laravel.test'],
+    'https' => ['https://cloud.laravel.test', 'https://cloud.laravel.test'],
+    'http' => ['http://cloud.laravel.test', 'http://cloud.laravel.test'],
+    'no scheme with port' => ['cloud.laravel.test:8080', 'https://cloud.laravel.test:8080'],
+    'default' => ['https://cloud.laravel.com', 'https://cloud.laravel.com'],
+]);

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -1,0 +1,7 @@
+<?php
+
+it('keeps env() out of config/app.php', function () {
+    // `app:build` evaluates config/app.php and bakes the resulting array into the phar, so any
+    // env() call there is frozen at build time and ignored by the binary. Put it elsewhere.
+    expect(file_get_contents(base_path('config/app.php')))->not->toContain('env(');
+});


### PR DESCRIPTION
## Problem

Setting `CLOUD_BASE_URL` had no effect when using the built `cloud` binary. The build step evaluates `config/app.php` ahead of time and stores the result inside the binary, so the environment variable was read once at build time and locked to `https://cloud.laravel.com`.

## Solution

Move `base_url` and `has_custom_base_url` to a new `config/cloud.php`, which is not pre-evaluated during the build. The built binary now reads `CLOUD_BASE_URL` when it runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (with a semi-human @fideloper looking at/testing its work)