### PR TITLE
Rename hibernation to scale to zero across user-facing output

### DIFF
--- a/app/Commands/DatabaseClusterUpdate.php
+++ b/app/Commands/DatabaseClusterUpdate.php
@@ -28,7 +28,7 @@ class DatabaseClusterUpdate extends BaseCommand
                             {--uses-scheduled-snapshots= : Whether scheduled backups are enabled}
                             {--cu-min= : Minimum compute units (Neon)}
                             {--cu-max= : Maximum compute units (Neon)}
-                            {--suspend-seconds= : Seconds before hibernation (Neon)}
+                            {--suspend-seconds= : Seconds before scale to zero (Neon)}
                             {--uses-pitr= : Whether point-in-time recovery is enabled}
                             {--maintenance-window= : UTC maintenance window}
                             {--deployment-option= : single-az or multi-az}

--- a/app/Commands/EnvironmentGet.php
+++ b/app/Commands/EnvironmentGet.php
@@ -31,7 +31,7 @@ class EnvironmentGet extends BaseCommand
             'ID' => $environment->id,
             'Name' => $environment->name,
             'Branch' => $environment->branch ?? 'N/A',
-            'Status' => $environment->status,
+            'Status' => $environment->statusEnum->label(),
             'Web URL' => $environment->url,
             'Dashboard URL' => $application->url($environment),
             'PHP Version' => $environment->phpMajorVersion,

--- a/app/Commands/EnvironmentList.php
+++ b/app/Commands/EnvironmentList.php
@@ -53,7 +53,7 @@ class EnvironmentList extends BaseCommand
                 $env->id,
                 $env->name,
                 $env->branch ?? '—',
-                $env->status ?? '—',
+                $env->status ? $env->statusEnum->label() : '—',
             ])->toArray(),
             actions: [
                 Key::ENTER => [

--- a/app/Commands/InstanceUpdate.php
+++ b/app/Commands/InstanceUpdate.php
@@ -28,11 +28,34 @@ class InstanceUpdate extends BaseCommand
                             {--scaling-memory-threshold-percentage= : Scaling memory threshold percentage}
                             {--uses-octane= : Uses Octane}
                             {--uses-inertia-ssr= : Uses Inertia SSR}
-                            {--hibernation= : Uses hibernation}
-                            {--hibernation-timeout= : Hibernation timeout}
+                            {--scale-to-zero= : Uses scale to zero}
+                            {--scale-to-zero-timeout= : Scale to zero timeout}
+                            {--hibernation= : Deprecated alias for --scale-to-zero}
+                            {--hibernation-timeout= : Deprecated alias for --scale-to-zero-timeout}
                             {--force : Force update without confirmation}';
 
     protected $description = 'Update an instance';
+
+    /**
+     * @var array<string, string>
+     */
+    protected array $deprecatedOptions = [
+        'hibernation' => 'scale-to-zero',
+        'hibernation-timeout' => 'scale-to-zero-timeout',
+    ];
+
+    public function options()
+    {
+        $options = parent::options();
+
+        foreach ($this->deprecatedOptions as $deprecated => $current) {
+            if (($options[$deprecated] ?? null) !== null && ($options[$current] ?? null) === null) {
+                $options[$current] = $options[$deprecated];
+            }
+        }
+
+        return $options;
+    }
 
     public function handle()
     {
@@ -209,25 +232,25 @@ class InstanceUpdate extends BaseCommand
             'uses_sleep_mode',
             fn ($resolver) => $resolver->fromInput(
                 fn ($value) => confirm(
-                    label: 'Use sleep mode?',
+                    label: 'Use scale to zero?',
                     default: $value ?? $instance->environment->usesHibernation ?? true,
                 ),
             ),
-            'hibernation',
-        )->setPreviousValue($instance->environment->usesHibernation)->setLabel('Hibernation');
+            'scale-to-zero',
+        )->setPreviousValue($instance->environment->usesHibernation)->setLabel('Scale to zero');
 
         $this->form()->define(
             'sleep_timeout',
             fn ($resolver) => $resolver->fromInput(
                 fn ($value) => number(
-                    label: 'Sleep timeout',
+                    label: 'Scale to zero timeout',
                     default: (string) ($value ?? ''),
                     min: 1,
                     max: 60,
                 ),
             ),
-            'hibernation-timeout',
-        )->setLabel('Hibernation timeout');
+            'scale-to-zero-timeout',
+        )->setLabel('Scale to zero timeout');
     }
 
     protected function collectDataAndUpdate(EnvironmentInstance $instance): EnvironmentInstance

--- a/app/Commands/Ship.php
+++ b/app/Commands/Ship.php
@@ -314,7 +314,7 @@ class Ship extends BaseCommand
 
         $enableOptions = [
             'scheduler' => 'Laravel Scheduler',
-            'hibernation' => 'Hibernation',
+            'scale_to_zero' => 'Scale to Zero',
             'database_cluster' => 'Database Cluster',
         ];
 
@@ -346,7 +346,7 @@ class Ship extends BaseCommand
             'scheduler' => 'uses_scheduler',
             'octane' => 'uses_octane',
             'inertia_ssr' => 'uses_inertia_ssr',
-            'hibernation' => 'uses_sleep_mode',
+            'scale_to_zero' => 'uses_sleep_mode',
         ];
 
         foreach ($mapping as $option => $param) {
@@ -356,16 +356,16 @@ class Ship extends BaseCommand
         }
 
         if ($instanceParams['uses_sleep_mode'] ?? false) {
-            $hibernateFor = number(
-                label: 'Hibernate after',
+            $scaleToZeroAfter = number(
+                label: 'Scale to zero after',
                 default: '5',
                 required: true,
-                hint: 'The number of minutes without HTTP requests received before your application hibernates (1-60)',
+                hint: 'The number of minutes without HTTP requests received before your application scales to zero (1-60)',
                 min: 1,
                 max: 60,
             );
 
-            $instanceParams['sleep_timeout'] = $hibernateFor;
+            $instanceParams['sleep_timeout'] = $scaleToZeroAfter;
         }
 
         if (in_array('database_cluster', $selectedOptions)) {

--- a/app/Enums/DatabaseClusterPreset.php
+++ b/app/Enums/DatabaseClusterPreset.php
@@ -100,13 +100,13 @@ enum DatabaseClusterPreset: string
             self::NeonServerlessPostgres18 => fn ($preset) => sprintf(
                 '%s vCPU units · %s · %s',
                 $preset['cu_min'] === $preset['cu_max'] ? $this->formatNumber($preset['cu_min']) : $this->formatNumber($preset['cu_min']).' – '.$this->formatNumber($preset['cu_max']),
-                $preset['suspend_seconds'] > 0 ? 'Hibernate after '.$preset['suspend_seconds'].' seconds' : 'No hibernation',
+                $preset['suspend_seconds'] > 0 ? 'Scale to zero after '.$preset['suspend_seconds'].' seconds' : 'No scale to zero',
                 $preset['retention_days'] === 0 ? 'No backups' : $preset['retention_days'].' days PITR',
             ),
             self::NeonServerlessPostgres17 => fn ($preset) => sprintf(
                 '%s vCPU units · %s · %s',
                 $preset['cu_min'] === $preset['cu_max'] ? $this->formatNumber($preset['cu_min']) : $this->formatNumber($preset['cu_min']).' – '.$this->formatNumber($preset['cu_max']),
-                $preset['suspend_seconds'] === 0 ? 'No hibernation' : 'Hibernate after '.$preset['suspend_seconds'].' seconds',
+                $preset['suspend_seconds'] === 0 ? 'No scale to zero' : 'Scale to zero after '.$preset['suspend_seconds'].' seconds',
                 $preset['retention_days'] === 0 ? 'No backups' : $preset['retention_days'].' days PITR',
             ),
         };

--- a/app/Enums/EnvironmentStatus.php
+++ b/app/Enums/EnvironmentStatus.php
@@ -8,4 +8,12 @@ enum EnvironmentStatus: string
     case RUNNING = 'running';
     case HIBERNATING = 'hibernating';
     case STOPPED = 'stopped';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::HIBERNATING => 'scaled to zero',
+            default => $this->value,
+        };
+    }
 }

--- a/tests/Unit/InstanceUpdateDeprecatedOptionsTest.php
+++ b/tests/Unit/InstanceUpdateDeprecatedOptionsTest.php
@@ -1,0 +1,50 @@
+<?php
+
+use App\Commands\InstanceUpdate;
+use Illuminate\Console\OutputStyle;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+function instanceUpdateOptions(array $input): array
+{
+    $command = app(InstanceUpdate::class);
+    $command->setApplication(new Application);
+
+    $input = new ArrayInput($input, $command->getDefinition());
+
+    // The command reads its options off the bound input, which is normally set by
+    // the console kernel when the command is actually run.
+    (fn () => $this->input = $input)->call($command);
+    (fn () => $this->output = new OutputStyle($input, new BufferedOutput))->call($command);
+
+    return $command->options();
+}
+
+it('maps the deprecated hibernation options onto the scale to zero options', function () {
+    $options = instanceUpdateOptions([
+        '--hibernation' => 'true',
+        '--hibernation-timeout' => '17',
+    ]);
+
+    expect($options['scale-to-zero'])->toBe('true')
+        ->and($options['scale-to-zero-timeout'])->toBe('17');
+});
+
+it('prefers the scale to zero options when both are passed', function () {
+    $options = instanceUpdateOptions([
+        '--hibernation' => 'true',
+        '--scale-to-zero' => 'false',
+    ]);
+
+    expect($options['scale-to-zero'])->toBe('false');
+});
+
+it('leaves the scale to zero options alone when no deprecated options are passed', function () {
+    $options = instanceUpdateOptions([
+        '--scale-to-zero' => 'true',
+    ]);
+
+    expect($options['scale-to-zero'])->toBe('true')
+        ->and($options['scale-to-zero-timeout'])->toBeNull();
+});


### PR DESCRIPTION
Swaps every user-facing mention of "hibernation" over to "scale to zero": prompt labels, option descriptions, the feature toggle in `ship`, and the Neon preset summaries. The Postgres 18 preset arm still said "Hibernate after", so it now matches the 17 arm.

`instance:update` gains `--scale-to-zero` and `--scale-to-zero-timeout`. The old `--hibernation` and `--hibernation-timeout` still work as deprecated aliases and fold into the new keys, so existing scripts keep running. If both are passed, the new one wins. Also renamed the two prompts that called this "sleep mode" internally, since it is the same feature.

Environment status now renders `hibernating` as "scaled to zero" via a new `label()` on the enum. Every other status renders exactly as before.

API request and response keys are untouched: `uses_sleep_mode`, `sleep_timeout`, `uses_hibernation`, and the `hibernating` status value all stay as they are. That includes the `usesHibernation` key in `--json` output, which would be a breaking change worth its own PR.
