### PR TITLE
Mask credentials in JSON output, not just environment variables

### DIFF
--- a/app/Commands/BaseCommand.php
+++ b/app/Commands/BaseCommand.php
@@ -52,7 +52,7 @@ abstract class BaseCommand extends Command
 
         $this->addOption('json', null, InputOption::VALUE_NONE, 'Output as JSON');
         $this->addOption('fields', null, InputOption::VALUE_REQUIRED, 'Filter JSON output to specific fields (comma-separated, supports dot notation for nested fields)');
-        $this->addOption('show-sensitive', null, InputOption::VALUE_NONE, 'Reveal sensitive values (e.g. environment variables) in JSON output (masked by default)');
+        $this->addOption('show-sensitive', null, InputOption::VALUE_NONE, 'Reveal sensitive values (e.g. environment variables, connection credentials) in JSON output (masked by default)');
 
         if ($this->jsonDataClass) {
             $fields = $this->describeJsonFields($this->jsonDataClass);
@@ -229,6 +229,8 @@ abstract class BaseCommand extends Command
         if (! $this->wantsJson()) {
             return;
         }
+
+        SensitiveValues::$reveal = (bool) $this->option('show-sensitive');
 
         $this->line($this->toJson($data));
     }

--- a/app/Dto/BucketKey.php
+++ b/app/Dto/BucketKey.php
@@ -2,8 +2,10 @@
 
 namespace App\Dto;
 
+use App\Dto\Transformers\MaskSensitiveValue;
 use Carbon\CarbonImmutable;
 use Spatie\LaravelData\Attributes\WithCast;
+use Spatie\LaravelData\Attributes\WithTransformer;
 use Spatie\LaravelData\Casts\DateTimeInterfaceCast;
 use Spatie\LaravelData\Data;
 
@@ -16,6 +18,7 @@ class BucketKey extends Data
         #[WithCast(DateTimeInterfaceCast::class, type: CarbonImmutable::class)]
         public readonly ?CarbonImmutable $createdAt = null,
         public readonly ?string $accessKeyId = null,
+        #[WithTransformer(MaskSensitiveValue::class)]
         public readonly ?string $secretAccessKey = null,
     ) {
         //

--- a/app/Dto/Cache.php
+++ b/app/Dto/Cache.php
@@ -2,8 +2,10 @@
 
 namespace App\Dto;
 
+use App\Dto\Transformers\MaskSensitiveKeys;
 use Carbon\CarbonImmutable;
 use Spatie\LaravelData\Attributes\WithCast;
+use Spatie\LaravelData\Attributes\WithTransformer;
 use Spatie\LaravelData\Casts\DateTimeInterfaceCast;
 use Spatie\LaravelData\Data;
 
@@ -20,6 +22,7 @@ class Cache extends Data
         public readonly bool $isPublic,
         #[WithCast(DateTimeInterfaceCast::class, type: CarbonImmutable::class)]
         public readonly ?CarbonImmutable $createdAt = null,
+        #[WithTransformer(MaskSensitiveKeys::class)]
         public readonly array $connection = [],
         public readonly array $environmentIds = [],
     ) {

--- a/app/Dto/DatabaseCluster.php
+++ b/app/Dto/DatabaseCluster.php
@@ -2,9 +2,11 @@
 
 namespace App\Dto;
 
+use App\Dto\Transformers\MaskSensitiveKeys;
 use Carbon\CarbonImmutable;
 use Spatie\LaravelData\Attributes\DataCollectionOf;
 use Spatie\LaravelData\Attributes\WithCast;
+use Spatie\LaravelData\Attributes\WithTransformer;
 use Spatie\LaravelData\Casts\DateTimeInterfaceCast;
 use Spatie\LaravelData\Data;
 
@@ -17,6 +19,7 @@ class DatabaseCluster extends Data
         public readonly string $status,
         public readonly string $region,
         public readonly array $config,
+        #[WithTransformer(MaskSensitiveKeys::class)]
         public readonly array $connection,
         #[WithCast(DateTimeInterfaceCast::class, type: CarbonImmutable::class)]
         public readonly ?CarbonImmutable $createdAt = null,

--- a/app/Dto/Transformers/MaskSensitiveKeys.php
+++ b/app/Dto/Transformers/MaskSensitiveKeys.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Dto\Transformers;
+
+use App\Support\SensitiveValues;
+use Spatie\LaravelData\Support\DataProperty;
+use Spatie\LaravelData\Support\Transformation\TransformationContext;
+use Spatie\LaravelData\Transformers\Transformer;
+
+class MaskSensitiveKeys implements Transformer
+{
+    public function transform(DataProperty $property, mixed $value, TransformationContext $context): mixed
+    {
+        if (SensitiveValues::$reveal || ! is_array($value)) {
+            return $value;
+        }
+
+        return $this->mask($value);
+    }
+
+    protected function mask(array $value): array
+    {
+        foreach ($value as $key => $item) {
+            if (is_array($item)) {
+                $value[$key] = $this->mask($item);
+
+                continue;
+            }
+
+            if ($item === null || ! is_string($key) || ! SensitiveValues::isSensitiveKey($key)) {
+                continue;
+            }
+
+            $value[$key] = SensitiveValues::MASK;
+        }
+
+        return $value;
+    }
+}

--- a/app/Dto/Transformers/MaskSensitiveValue.php
+++ b/app/Dto/Transformers/MaskSensitiveValue.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Dto\Transformers;
+
+use App\Support\SensitiveValues;
+use Spatie\LaravelData\Support\DataProperty;
+use Spatie\LaravelData\Support\Transformation\TransformationContext;
+use Spatie\LaravelData\Transformers\Transformer;
+
+class MaskSensitiveValue implements Transformer
+{
+    public function transform(DataProperty $property, mixed $value, TransformationContext $context): mixed
+    {
+        if (SensitiveValues::$reveal || $value === null) {
+            return $value;
+        }
+
+        return SensitiveValues::MASK;
+    }
+}

--- a/app/Dto/WebsocketApplication.php
+++ b/app/Dto/WebsocketApplication.php
@@ -2,8 +2,10 @@
 
 namespace App\Dto;
 
+use App\Dto\Transformers\MaskSensitiveValue;
 use Carbon\CarbonImmutable;
 use Spatie\LaravelData\Attributes\WithCast;
+use Spatie\LaravelData\Attributes\WithTransformer;
 use Spatie\LaravelData\Casts\DateTimeInterfaceCast;
 use Spatie\LaravelData\Data;
 
@@ -19,6 +21,7 @@ class WebsocketApplication extends Data
         public readonly int $maxMessageSize,
         public readonly int $maxConnections,
         public readonly string $key,
+        #[WithTransformer(MaskSensitiveValue::class)]
         public readonly string $secret,
         #[WithCast(DateTimeInterfaceCast::class, type: CarbonImmutable::class)]
         public readonly ?CarbonImmutable $createdAt = null,

--- a/app/Support/SensitiveValues.php
+++ b/app/Support/SensitiveValues.php
@@ -4,5 +4,12 @@ namespace App\Support;
 
 class SensitiveValues
 {
+    public const MASK = '*****';
+
     public static bool $reveal = false;
+
+    public static function isSensitiveKey(string $key): bool
+    {
+        return (bool) preg_match('/pass|secret|token|credential|private|dsn|url|uri/i', $key);
+    }
 }

--- a/tests/Feature/SensitiveJsonOutputTest.php
+++ b/tests/Feature/SensitiveJsonOutputTest.php
@@ -2,10 +2,12 @@
 
 use App\Support\SensitiveValues;
 use Illuminate\Support\Facades\Artisan;
+use Tests\Fixtures\SensitiveConnectionJsonTestCommand;
 use Tests\Fixtures\SensitiveJsonOutputTestCommand;
 
 beforeEach(function () {
     Artisan::registerCommand(new SensitiveJsonOutputTestCommand);
+    Artisan::registerCommand(new SensitiveConnectionJsonTestCommand);
 });
 
 afterEach(function () {
@@ -39,4 +41,60 @@ it('reveals environmentVariables when --show-sensitive is passed', function () {
         ['key' => 'APP_KEY', 'value' => 'base64:secret'],
         ['key' => 'STRIPE_SECRET', 'value' => 'sk_live_xyz'],
     ]);
+});
+
+it('masks connection credentials and secrets in JSON output by default', function () {
+    $exitCode = Artisan::call('test:sensitive-connection-json', ['--no-interaction' => true]);
+
+    expect($exitCode)->toBe(0);
+
+    $output = Artisan::output();
+
+    expect($output)
+        ->not->toContain('cache-password')
+        ->not->toContain('db-password')
+        ->not->toContain('bucket-secret')
+        ->not->toContain('ws-secret');
+
+    $payload = json_decode($output, true);
+
+    expect($payload['cache']['connection'])->toEqual([
+        'hostname' => 'cache.example.com',
+        'port' => 6379,
+        'protocol' => 'redis',
+        'username' => 'default',
+        'password' => '*****',
+        'url' => '*****',
+    ]);
+
+    expect($payload['databaseCluster']['connection'])->toEqual([
+        'host' => 'db.example.com',
+        'port' => 5432,
+        'username' => 'forge',
+        'password' => '*****',
+        'dsn' => '*****',
+    ]);
+
+    expect($payload['bucketKey']['accessKeyId'])->toBe('AKIAEXAMPLE');
+    expect($payload['bucketKey']['secretAccessKey'])->toBe('*****');
+
+    expect($payload['websocketApplication']['key'])->toBe('ws-key');
+    expect($payload['websocketApplication']['secret'])->toBe('*****');
+});
+
+it('reveals connection credentials and secrets when --show-sensitive is passed', function () {
+    $exitCode = Artisan::call('test:sensitive-connection-json', [
+        '--no-interaction' => true,
+        '--show-sensitive' => true,
+    ]);
+
+    expect($exitCode)->toBe(0);
+
+    $payload = json_decode(Artisan::output(), true);
+
+    expect($payload['cache']['connection']['password'])->toBe('cache-password');
+    expect($payload['cache']['connection']['url'])->toBe('rediss://default:cache-password@cache.example.com:6379');
+    expect($payload['databaseCluster']['connection']['password'])->toBe('db-password');
+    expect($payload['bucketKey']['secretAccessKey'])->toBe('bucket-secret');
+    expect($payload['websocketApplication']['secret'])->toBe('ws-secret');
 });

--- a/tests/Fixtures/SensitiveConnectionJsonTestCommand.php
+++ b/tests/Fixtures/SensitiveConnectionJsonTestCommand.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Fixtures;
+
+use App\Commands\BaseCommand;
+use App\Dto\BucketKey;
+use App\Dto\Cache;
+use App\Dto\DatabaseCluster;
+use App\Dto\WebsocketApplication;
+
+class SensitiveConnectionJsonTestCommand extends BaseCommand
+{
+    protected $signature = 'test:sensitive-connection-json';
+
+    public function handle(): void
+    {
+        $cache = Cache::from([
+            'id' => 'cache-1',
+            'type' => 'valkey',
+            'name' => 'main',
+            'status' => 'running',
+            'region' => 'us-east-1',
+            'size' => 'small',
+            'autoUpgradeEnabled' => false,
+            'isPublic' => false,
+            'connection' => [
+                'hostname' => 'cache.example.com',
+                'port' => 6379,
+                'protocol' => 'redis',
+                'username' => 'default',
+                'password' => 'cache-password',
+                'url' => 'rediss://default:cache-password@cache.example.com:6379',
+            ],
+        ]);
+
+        $cluster = DatabaseCluster::from([
+            'id' => 'db-1',
+            'name' => 'primary',
+            'type' => 'postgres',
+            'status' => 'running',
+            'region' => 'us-east-1',
+            'config' => [],
+            'connection' => [
+                'host' => 'db.example.com',
+                'port' => 5432,
+                'username' => 'forge',
+                'password' => 'db-password',
+                'dsn' => 'postgres://forge:db-password@db.example.com:5432/forge',
+            ],
+        ]);
+
+        $bucketKey = BucketKey::from([
+            'id' => 'key-1',
+            'name' => 'deploys',
+            'permission' => 'read_write',
+            'accessKeyId' => 'AKIAEXAMPLE',
+            'secretAccessKey' => 'bucket-secret',
+        ]);
+
+        $websocketApplication = WebsocketApplication::from([
+            'id' => 'ws-1',
+            'name' => 'app',
+            'appId' => '12345',
+            'allowedOrigins' => ['*'],
+            'pingInterval' => 30,
+            'activityTimeout' => 30,
+            'maxMessageSize' => 1024,
+            'maxConnections' => 100,
+            'key' => 'ws-key',
+            'secret' => 'ws-secret',
+        ]);
+
+        $this->outputJsonIfWanted([
+            'cache' => $cache,
+            'databaseCluster' => $cluster,
+            'bucketKey' => $bucketKey,
+            'websocketApplication' => $websocketApplication,
+        ]);
+    }
+}


### PR DESCRIPTION
`cache:list --json` printed the cache password in full, even without `--show-sensitive`. Masking only ever covered `Environment::$environmentVariables`, so every other DTO carrying credentials leaked them.

Adds two transformers: `MaskSensitiveKeys` walks an array and masks values under sensitive-looking keys (password, secret, token, credential, private, dsn, url, uri), and `MaskSensitiveValue` masks a whole scalar. They now cover `Cache::$connection`, `DatabaseCluster::$connection`, `BucketKey::$secretAccessKey` and `WebsocketApplication::$secret`. `accessKeyId` and the websocket `key` stay visible since they are public identifiers, like a username.

`writeJsonIfWanted()` also sets the reveal flag now, so `--show-sensitive` works on the deploy, tinker and command:run paths.