### PR TITLE
Fix database-restore:create fataling on every invocation

### DIFF
--- a/app/Commands/DatabaseRestoreCreate.php
+++ b/app/Commands/DatabaseRestoreCreate.php
@@ -33,18 +33,24 @@ class DatabaseRestoreCreate extends BaseCommand
 
         $cluster = $this->resolvers()->databaseCluster()->from($this->argument('cluster'));
 
+        [$snapshotId, $pointInTime] = $this->resolveRestoreSource($cluster);
+
+        $restored = $this->loopUntilValid(
+            fn () => $this->createRestore($cluster, $snapshotId, $pointInTime),
+        );
+
+        $this->outputJsonIfWanted($restored);
+
+        success("Database restore created: {$restored->name}");
+    }
+
+    /**
+     * @return array{0: ?string, 1: ?string}
+     */
+    protected function resolveRestoreSource(DatabaseCluster $cluster): array
+    {
         $snapshotId = $this->option('snapshot');
         $pointInTime = $this->option('point-in-time');
-
-        $this->form()->prompt(
-            'name',
-            fn ($resolver) => $resolver->fromInput(
-                fn (?string $value) => text(
-                    label: 'Name',
-                    default: $value ?? '',
-                ),
-            ),
-        );
 
         if (! $snapshotId && ! $pointInTime && $this->isInteractive()) {
             $snapshots = spin(
@@ -89,7 +95,23 @@ class DatabaseRestoreCreate extends BaseCommand
             throw new CommandExitException(self::FAILURE);
         }
 
-        $restored = spin(
+        return [$snapshotId, $pointInTime];
+    }
+
+    protected function createRestore(DatabaseCluster $cluster, ?string $snapshotId, ?string $pointInTime): DatabaseCluster
+    {
+        $this->form()->prompt(
+            'name',
+            fn ($resolver) => $resolver->fromInput(
+                fn (?string $value) => text(
+                    label: 'Name',
+                    default: $value ?? '',
+                    required: true,
+                ),
+            ),
+        );
+
+        return spin(
             fn () => $this->client->databaseRestores()->create(
                 new CreateDatabaseRestoreRequestData(
                     name: $this->form()->get('name'),
@@ -100,9 +122,5 @@ class DatabaseRestoreCreate extends BaseCommand
             ),
             'Creating restore...',
         );
-
-        $this->outputJsonIfWanted($restored);
-
-        success("Database restore created: {$restored->name}");
     }
 }

--- a/app/Support/Form.php
+++ b/app/Support/Form.php
@@ -15,7 +15,7 @@ class Form
 
     protected array $arguments = [];
 
-    protected ValidationErrors $errors;
+    protected ?ValidationErrors $errors = null;
 
     protected bool $isInteractive;
 
@@ -33,6 +33,8 @@ class Form
         if (! in_array($key, $this->prompted)) {
             $this->prompted[] = $key;
         }
+
+        $this->errors ??= new ValidationErrors;
 
         $result = ($this->fields[$key]['callback'])($this->fields[$key]['resolver'])->errors($this->errors);
         $result->retrieve();

--- a/tests/Feature/DatabaseRestoreCreateTest.php
+++ b/tests/Feature/DatabaseRestoreCreateTest.php
@@ -1,0 +1,84 @@
+<?php
+
+use App\Client\Resources\DatabaseClusters\GetDatabaseClusterRequest;
+use App\Client\Resources\DatabaseRestores\CreateDatabaseRestoreRequest;
+use App\Client\Resources\Meta\GetOrganizationRequest;
+use App\ConfigRepository;
+use Illuminate\Support\Sleep;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+
+beforeEach(function () {
+    Sleep::fake();
+
+    $this->mockConfig = Mockery::mock(ConfigRepository::class);
+    $this->mockConfig->shouldReceive('apiTokens')->andReturn(collect(['test-api-token']));
+    $this->app->instance(ConfigRepository::class, $this->mockConfig);
+});
+
+afterEach(function () {
+    MockClient::destroyGlobal();
+});
+
+function setupDatabaseRestoreMocks(int $createStatus = 200, ?array $createBody = null): void
+{
+    MockClient::global([
+        GetOrganizationRequest::class => MockResponse::make(organizationResponse(), 200),
+        GetDatabaseClusterRequest::class => MockResponse::make(databaseClusterResponse(), 200),
+        CreateDatabaseRestoreRequest::class => MockResponse::make(
+            $createBody ?? databaseClusterResponse([
+                'id' => 'db-456',
+                'attributes' => ['name' => 'my-restore'],
+            ]),
+            $createStatus,
+        ),
+    ]);
+}
+
+it('creates a restore from a snapshot non-interactively', function () {
+    setupDatabaseRestoreMocks();
+
+    $this->artisan('database-restore:create', [
+        'cluster' => 'db-123',
+        'name' => 'my-restore',
+        '--snapshot' => 'snap-1',
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+});
+
+it('creates a restore from a point-in-time non-interactively', function () {
+    setupDatabaseRestoreMocks();
+
+    $this->artisan('database-restore:create', [
+        'cluster' => 'db-123',
+        'name' => 'my-restore',
+        '--point-in-time' => '2024-01-15T12:00:00Z',
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+});
+
+it('fails when neither snapshot nor point-in-time is given non-interactively', function () {
+    setupDatabaseRestoreMocks();
+
+    $this->artisan('database-restore:create', [
+        'cluster' => 'db-123',
+        'name' => 'my-restore',
+        '--no-interaction' => true,
+    ])->assertFailed();
+});
+
+it('fails with JSON validation errors when the API returns 422', function () {
+    setupDatabaseRestoreMocks(422, [
+        'message' => 'Validation failed',
+        'errors' => ['name' => ['Name has already been taken.']],
+    ]);
+
+    $result = $this->artisan('database-restore:create', [
+        'cluster' => 'db-123',
+        'name' => 'taken',
+        '--snapshot' => 'snap-1',
+        '--json' => true,
+    ]);
+
+    $result->assertFailed();
+});

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -103,6 +103,25 @@ function setupApplicationListMocks(?array $applications = null, int $status = 20
     ]);
 }
 
+function databaseClusterResponse(array $overrides = []): array
+{
+    return [
+        'data' => [
+            'id' => $overrides['id'] ?? 'db-123',
+            'type' => 'databaseClusters',
+            'attributes' => array_merge([
+                'name' => 'my-cluster',
+                'type' => 'laravel-mysql',
+                'status' => 'available',
+                'region' => 'us-east-1',
+                'config' => [],
+                'connection' => [],
+            ], $overrides['attributes'] ?? []),
+        ],
+        'included' => [],
+    ];
+}
+
 function usageResponse(array $overrides = []): array
 {
     $base = [

--- a/tests/Unit/FormTest.php
+++ b/tests/Unit/FormTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use App\Dto\ValidationErrors;
+use App\Support\Form;
+
+it('prompts without errors having been set', function () {
+    $form = (new Form)
+        ->isInteractive(false)
+        ->options([])
+        ->arguments(['name' => 'my-restore']);
+
+    $form->prompt('name', fn ($resolver) => $resolver);
+
+    expect($form->get('name'))->toBe('my-restore');
+});
+
+it('keeps errors passed in before prompting', function () {
+    $errors = new ValidationErrors;
+    $errors->add('name', 'Name has already been taken.');
+
+    $form = (new Form)
+        ->isInteractive(false)
+        ->options([])
+        ->arguments(['name' => 'taken'])
+        ->errors($errors);
+
+    $resolver = $form->prompt('name', fn ($resolver) => $resolver);
+
+    expect($resolver->value())->toBe('taken');
+});


### PR DESCRIPTION
`database-restore:create` has been broken for everyone: interactive or not, with `--snapshot` or `--point-in-time`, it dies with "Typed property App\Support\Form::$errors must not be accessed before initialization".

`Form::$errors` is a typed property with no default, and `Form::prompt()` reads it unconditionally. The only thing that ever set it was `Validates::loopUntilValid()`, so any command that calls `form()->prompt()` outside that path fatals on the first prompt. `DatabaseRestoreCreate` was the only one shaped that way.

This makes `$errors` nullable and lazy-inits it in `prompt()`, which is what `ValueResolver` already does. That fixes the crash and stops the next direct caller tripping over the same thing.

It also wraps the create call in `loopUntilValid()` like the `DatabaseSnapshotCreate` sibling, so the command picks up the 422 retry and JSON error handling the rest of the CLI has, and marks the name prompt required. The restore source is now resolved before the name is prompted, so a 422 retry only re-asks for the name.

Fixes #183
