### PR TITLE
Fix database-cluster:update ignoring every option

### DIFF
--- a/app/Commands/DatabaseClusterUpdate.php
+++ b/app/Commands/DatabaseClusterUpdate.php
@@ -80,7 +80,7 @@ class DatabaseClusterUpdate extends BaseCommand
         foreach ($type->configSchema as $schemaField) {
             $schema = is_array($schemaField) ? $schemaField : $schemaField->toArray();
             $name = $schema['name'];
-            $value = $this->form()->get($name);
+            $value = $this->form()->get('config.'.$name);
 
             if ($value !== null) {
                 $config[$name] = $this->coerceConfigValue($name, $value, $type);
@@ -91,12 +91,7 @@ class DatabaseClusterUpdate extends BaseCommand
             fn () => $this->client->databaseClusters()->update(
                 new UpdateDatabaseClusterRequestData(
                     clusterId: $cluster->id,
-                    config: collect($config)
-                        ->filter(fn ($value, $key) => str_starts_with($key, 'config.'))
-                        ->mapWithKeys(fn ($value, $key) => [
-                            str_replace('config.', '', $key) => $value,
-                        ])
-                        ->toArray(),
+                    config: $config,
                 ),
             ),
             'Updating database cluster...',
@@ -109,7 +104,8 @@ class DatabaseClusterUpdate extends BaseCommand
     {
         foreach ($type->configSchema as $field) {
             $schema = is_array($field) ? $field : $field->toArray();
-            $name = 'config.'.$schema['name'];
+            $name = $schema['name'];
+            $key = 'config.'.$name;
             $optionName = str_replace('_', '-', $name);
             $current = $cluster->config[$name] ?? $schema['example'] ?? null;
             $fieldType = $schema['type'] ?? 'string';
@@ -128,7 +124,7 @@ class DatabaseClusterUpdate extends BaseCommand
                 $options = is_array($enum) ? array_combine($enum, $enum) : $enum;
 
                 $this->form()->define(
-                    $name,
+                    $key,
                     fn ($resolver) => $resolver->fromInput(
                         fn ($value) => select(
                             label: $label,
@@ -138,10 +134,10 @@ class DatabaseClusterUpdate extends BaseCommand
                         ),
                     ),
                     $optionName,
-                )->setPreviousValue($current !== null ? (string) $current : '');
+                )->setLabel($label)->setPreviousValue($current !== null ? (string) $current : '');
             } elseif ($fieldType === 'boolean') {
                 $this->form()->define(
-                    $name,
+                    $key,
                     fn ($resolver) => $resolver->fromInput(
                         fn ($value) => confirm(
                             label: $label,
@@ -150,10 +146,10 @@ class DatabaseClusterUpdate extends BaseCommand
                         ),
                     ),
                     $optionName,
-                )->setPreviousValue($current !== null ? ($current ? 'true' : 'false') : '');
+                )->setLabel($label)->setPreviousValue($current !== null ? ($current ? 'true' : 'false') : '');
             } elseif ($fieldType === 'integer') {
                 $this->form()->define(
-                    $name,
+                    $key,
                     fn ($resolver) => $resolver->fromInput(
                         fn ($value) => (int) number(
                             label: $label,
@@ -165,10 +161,10 @@ class DatabaseClusterUpdate extends BaseCommand
                         ),
                     ),
                     $optionName,
-                )->setPreviousValue($current !== null ? (string) $current : '');
+                )->setLabel($label)->setPreviousValue($current !== null ? (string) $current : '');
             } elseif ($fieldType === 'number') {
                 $this->form()->define(
-                    $name,
+                    $key,
                     fn ($resolver) => $resolver->fromInput(
                         fn ($value) => (float) number(
                             label: $label,
@@ -180,10 +176,10 @@ class DatabaseClusterUpdate extends BaseCommand
                         ),
                     ),
                     $optionName,
-                )->setPreviousValue($current !== null ? (string) $current : '');
+                )->setLabel($label)->setPreviousValue($current !== null ? (string) $current : '');
             } else {
                 $this->form()->define(
-                    $name,
+                    $key,
                     fn ($resolver) => $resolver->fromInput(
                         fn ($value) => text(
                             label: $label,
@@ -193,7 +189,7 @@ class DatabaseClusterUpdate extends BaseCommand
                         ),
                     ),
                     $optionName,
-                )->setPreviousValue($current !== null ? (string) $current : '');
+                )->setLabel($label)->setPreviousValue($current !== null ? (string) $current : '');
             }
         }
     }

--- a/app/Support/Form.php
+++ b/app/Support/Form.php
@@ -117,7 +117,8 @@ class Form
     {
         $result = $this->get($key, $default);
 
-        return ($result === null) ? null : (bool) $result;
+        // Options arrive as strings, so "false" and "0" must not cast to true.
+        return ($result === null) ? null : filter_var($result, FILTER_VALIDATE_BOOLEAN);
     }
 
     /**

--- a/tests/Feature/DatabaseClusterUpdateTest.php
+++ b/tests/Feature/DatabaseClusterUpdateTest.php
@@ -1,0 +1,128 @@
+<?php
+
+use App\Client\Resources\DatabaseClusters\GetDatabaseClusterRequest;
+use App\Client\Resources\DatabaseClusters\ListDatabaseTypesRequest;
+use App\Client\Resources\DatabaseClusters\UpdateDatabaseClusterRequest;
+use App\Client\Resources\Meta\GetOrganizationRequest;
+use App\ConfigRepository;
+use Illuminate\Support\Sleep;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+use Saloon\Http\PendingRequest;
+
+beforeEach(function () {
+    Sleep::fake();
+
+    $this->mockConfig = Mockery::mock(ConfigRepository::class);
+    $this->mockConfig->shouldReceive('apiTokens')->andReturn(collect(['test-api-token']));
+    $this->app->instance(ConfigRepository::class, $this->mockConfig);
+});
+
+afterEach(function () {
+    MockClient::destroyGlobal();
+});
+
+function databaseClusterTypesResponse(): array
+{
+    return [
+        'data' => [
+            [
+                'type' => 'laravel-mysql',
+                'label' => 'MySQL 8',
+                'regions' => ['us-east-1'],
+                'config_schema' => [
+                    ['name' => 'size', 'type' => 'string', 'required' => true, 'example' => 'db-flex.m-1vcpu-512mb'],
+                    ['name' => 'storage', 'type' => 'integer', 'required' => true, 'example' => '5'],
+                    ['name' => 'retention_days', 'type' => 'integer', 'required' => true, 'example' => '1'],
+                    ['name' => 'is_public', 'type' => 'boolean', 'required' => true, 'example' => 'false'],
+                ],
+            ],
+        ],
+    ];
+}
+
+function setupDatabaseClusterUpdateMocks(): Closure
+{
+    $sentConfig = new stdClass;
+
+    $cluster = databaseClusterResponse([
+        'attributes' => [
+            'config' => [
+                'size' => 'db-flex.m-1vcpu-512mb',
+                'storage' => 5,
+                'retention_days' => 1,
+                'is_public' => true,
+            ],
+        ],
+    ]);
+
+    MockClient::global([
+        GetOrganizationRequest::class => MockResponse::make(organizationResponse(), 200),
+        GetDatabaseClusterRequest::class => MockResponse::make($cluster, 200),
+        ListDatabaseTypesRequest::class => MockResponse::make(databaseClusterTypesResponse(), 200),
+        UpdateDatabaseClusterRequest::class => function (PendingRequest $request) use ($sentConfig, $cluster) {
+            $sentConfig->value = $request->body()->all()['config'];
+
+            return MockResponse::make($cluster, 200);
+        },
+    ]);
+
+    return fn () => $sentConfig->value ?? null;
+}
+
+it('applies a boolean option that was passed as false', function () {
+    $sentConfig = setupDatabaseClusterUpdateMocks();
+
+    $this->artisan('database-cluster:update', [
+        'cluster' => 'db-123',
+        '--is-public' => 'false',
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+
+    expect($sentConfig())->toBe([
+        'size' => 'db-flex.m-1vcpu-512mb',
+        'storage' => 5,
+        'retention_days' => 1,
+        'is_public' => false,
+    ]);
+});
+
+it('applies an integer option and leaves the rest of the config alone', function () {
+    $sentConfig = setupDatabaseClusterUpdateMocks();
+
+    $this->artisan('database-cluster:update', [
+        'cluster' => 'db-123',
+        '--storage' => '20',
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+
+    expect($sentConfig())->toBe([
+        'size' => 'db-flex.m-1vcpu-512mb',
+        'storage' => 20,
+        'retention_days' => 1,
+        'is_public' => true,
+    ]);
+});
+
+it('accepts an option set to the value the cluster already has', function () {
+    $sentConfig = setupDatabaseClusterUpdateMocks();
+
+    $this->artisan('database-cluster:update', [
+        'cluster' => 'db-123',
+        '--retention-days' => '1',
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+
+    expect($sentConfig()['retention_days'])->toBe(1);
+});
+
+it('fails when no options are given non-interactively', function () {
+    $sentConfig = setupDatabaseClusterUpdateMocks();
+
+    $this->artisan('database-cluster:update', [
+        'cluster' => 'db-123',
+        '--no-interaction' => true,
+    ])->assertFailed();
+
+    expect($sentConfig())->toBeNull();
+});

--- a/tests/Unit/FormTest.php
+++ b/tests/Unit/FormTest.php
@@ -14,6 +14,31 @@ it('prompts without errors having been set', function () {
     expect($form->get('name'))->toBe('my-restore');
 });
 
+it('reads booleans from string options', function (string $option, bool $expected) {
+    $form = (new Form)
+        ->isInteractive(false)
+        ->options(['is-public' => $option])
+        ->arguments([]);
+
+    $form->prompt('is_public', fn ($resolver) => $resolver);
+
+    expect($form->boolean('is_public'))->toBe($expected);
+})->with([
+    ['false', false],
+    ['0', false],
+    ['true', true],
+    ['1', true],
+]);
+
+it('returns null for a boolean that was never provided', function () {
+    $form = (new Form)
+        ->isInteractive(false)
+        ->options([])
+        ->arguments([]);
+
+    expect($form->boolean('is_public'))->toBeNull();
+});
+
 it('keeps errors passed in before prompting', function () {
     $errors = new ValidationErrors;
     $errors->add('name', 'Name has already been taken.');


### PR DESCRIPTION
`database-cluster:update` built its form keys as `config.is_public` and then derived the option name from that same string, so it looked for `--config.is-public` while the signature declared `--is-public`. Nothing ever matched, and every run bailed out with "No fields to update". The same prefix confusion meant current values were read with the wrong keys (so prompts showed schema examples instead of the cluster's real settings) and the PATCH body was filtered down to `{"config":{}}`, which broke interactive updates too, just silently. Labels rendered as "Config.is public" for the same reason.

Also fixed `Form::boolean()`, which cast with `(bool)`. Since options arrive as strings, `--is-public=false` came through as true. That is what made `cache:create --is-public=false` create a public cache. `instance:create --uses-scheduler` had it too. `CacheUpdate` was already working around it with `filter_var`, which is now what `boolean()` does.

Tests cover the actual PATCH payload for a boolean false option, an integer option, an option set to the value the cluster already has, and no options at all.

The credential leak in the same issue was already fixed by #186 and just needs a release.

Fixes #179
