### PR TITLE
Fix instance:create scaling type handling

### DIFF
--- a/app/Commands/InstanceCreate.php
+++ b/app/Commands/InstanceCreate.php
@@ -6,6 +6,7 @@ use App\Client\Requests\CreateInstanceRequestData;
 use App\Dto\EnvironmentInstance;
 use App\Enums\InstanceScalingType;
 use App\Enums\InstanceType;
+use App\Exceptions\CommandExitException;
 
 use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\intro;
@@ -86,10 +87,12 @@ class InstanceCreate extends BaseCommand
                 ->fromInput(
                     fn ($value) => $value ?? (confirm('Enable autoscaling?', default: true) ? InstanceScalingType::CUSTOM : InstanceScalingType::NONE),
                 )
-                ->nonInteractively(fn () => 'none'),
+                ->nonInteractively(fn () => InstanceScalingType::NONE),
         );
 
-        $isCustom = $this->form()->get('scaling_type') === InstanceScalingType::CUSTOM;
+        $scalingType = $this->resolveScalingType($this->form()->get('scaling_type'));
+
+        $isCustom = $scalingType === InstanceScalingType::CUSTOM;
 
         $this->form()->prompt(
             'min_replicas',
@@ -164,7 +167,7 @@ class InstanceCreate extends BaseCommand
                     name: $this->form()->get('name'),
                     type: InstanceType::SERVICE,
                     size: $this->form()->get('size'),
-                    scalingType: $this->form()->get('scaling_type'),
+                    scalingType: $scalingType,
                     minReplicas: $this->form()->integer('min_replicas'),
                     maxReplicas: $this->form()->integer('max_replicas'),
                     usesScheduler: $this->form()->boolean('uses_scheduler'),
@@ -174,5 +177,24 @@ class InstanceCreate extends BaseCommand
             ),
             'Creating instance...',
         );
+    }
+
+    protected function resolveScalingType(mixed $value): InstanceScalingType
+    {
+        if ($value instanceof InstanceScalingType) {
+            return $value;
+        }
+
+        $scalingType = InstanceScalingType::tryFrom(strtolower(trim((string) $value)));
+
+        if ($scalingType === null) {
+            $valid = implode(', ', array_column(InstanceScalingType::cases(), 'value'));
+
+            $this->outputErrorOrThrow('Invalid --scaling-type value "'.$value.'". Must be one of: '.$valid);
+
+            throw new CommandExitException(self::FAILURE);
+        }
+
+        return $scalingType;
     }
 }

--- a/app/Support/ValueResolver.php
+++ b/app/Support/ValueResolver.php
@@ -112,8 +112,13 @@ class ValueResolver
             return null;
         }
 
-        if ($this->nonInteractivelyCallback && $result = ($this->nonInteractivelyCallback)($this->value)) {
-            return $result;
+        if ($this->nonInteractivelyCallback) {
+            // Only null means "no default"; false and 0 are real defaults, so don't test truthiness.
+            $result = ($this->nonInteractivelyCallback)($this->value);
+
+            if ($result !== null) {
+                return $result;
+            }
         }
 
         $message = match ($this->resolveFromType) {

--- a/tests/Feature/InstanceCreateTest.php
+++ b/tests/Feature/InstanceCreateTest.php
@@ -1,0 +1,179 @@
+<?php
+
+use App\Client\Resources\Environments\GetEnvironmentRequest;
+use App\Client\Resources\Instances\CreateInstanceRequest;
+use App\Client\Resources\Instances\ListInstanceSizesRequest;
+use App\Client\Resources\Meta\GetOrganizationRequest;
+use App\ConfigRepository;
+use Illuminate\Support\Sleep;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+use Saloon\Http\PendingRequest;
+
+beforeEach(function () {
+    Sleep::fake();
+
+    $this->mockConfig = Mockery::mock(ConfigRepository::class);
+    $this->mockConfig->shouldReceive('apiTokens')->andReturn(collect(['test-api-token']));
+    $this->app->instance(ConfigRepository::class, $this->mockConfig);
+});
+
+afterEach(function () {
+    MockClient::destroyGlobal();
+});
+
+function instanceSizesResponse(): array
+{
+    return [
+        'data' => [
+            'service' => [
+                [
+                    'name' => 'standard-1',
+                    'label' => 'Standard 1',
+                    'description' => '1 vCPU / 2GB',
+                    'cpu_type' => 'shared',
+                    'compute_class' => 'standard',
+                    'cpu_count' => 1,
+                    'memory_mib' => 2048,
+                ],
+            ],
+        ],
+    ];
+}
+
+function createdInstanceResponse(array $attributes = []): array
+{
+    return [
+        'data' => [
+            'id' => 'instance-1',
+            'type' => 'instances',
+            'attributes' => array_merge([
+                'name' => 'analytics',
+                'type' => 'service',
+                'size' => 'standard-1',
+                'scaling_type' => 'none',
+                'min_replicas' => 1,
+                'max_replicas' => 1,
+                'uses_scheduler' => false,
+            ], $attributes),
+        ],
+    ];
+}
+
+function setupInstanceCreateMocks(): Closure
+{
+    $sentBody = new stdClass;
+
+    MockClient::global([
+        GetOrganizationRequest::class => MockResponse::make(organizationResponse(), 200),
+        GetEnvironmentRequest::class => MockResponse::make(['data' => createEnvironmentResponse()], 200),
+        ListInstanceSizesRequest::class => MockResponse::make(instanceSizesResponse(), 200),
+        CreateInstanceRequest::class => function (PendingRequest $request) use ($sentBody) {
+            $sentBody->value = $request->body()->all();
+
+            return MockResponse::make(createdInstanceResponse(), 201);
+        },
+    ]);
+
+    return fn () => $sentBody->value ?? null;
+}
+
+it('creates an instance non-interactively without a scaling type', function () {
+    $sentBody = setupInstanceCreateMocks();
+
+    $this->artisan('instance:create', [
+        'environment' => 'env-1',
+        '--name' => 'analytics',
+        '--size' => 'standard-1',
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+
+    expect($sentBody())->toMatchArray([
+        'name' => 'analytics',
+        'size' => 'standard-1',
+        'scaling_type' => 'none',
+        'min_replicas' => 1,
+        'max_replicas' => 1,
+        'uses_scheduler' => false,
+    ]);
+});
+
+it('creates an instance non-interactively with an explicit scaling type', function (string $scalingType) {
+    $sentBody = setupInstanceCreateMocks();
+
+    $this->artisan('instance:create', [
+        'environment' => 'env-1',
+        '--name' => 'analytics',
+        '--size' => 'standard-1',
+        '--scaling-type' => $scalingType,
+        '--uses-scheduler' => 'false',
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+
+    expect($sentBody()['scaling_type'])->toBe($scalingType);
+})->with(['none', 'custom', 'auto']);
+
+it('accepts a scaling type in any case', function () {
+    $sentBody = setupInstanceCreateMocks();
+
+    $this->artisan('instance:create', [
+        'environment' => 'env-1',
+        '--name' => 'analytics',
+        '--size' => 'standard-1',
+        '--scaling-type' => 'CUSTOM',
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+
+    expect($sentBody()['scaling_type'])->toBe('custom');
+});
+
+it('sends scaling thresholds when the scaling type is custom', function () {
+    $sentBody = setupInstanceCreateMocks();
+
+    $this->artisan('instance:create', [
+        'environment' => 'env-1',
+        '--name' => 'analytics',
+        '--size' => 'standard-1',
+        '--scaling-type' => 'custom',
+        '--min-replicas' => '2',
+        '--max-replicas' => '6',
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+
+    expect($sentBody())->toMatchArray([
+        'scaling_type' => 'custom',
+        'min_replicas' => 2,
+        'max_replicas' => 6,
+        'scaling_cpu_threshold_percentage' => 50,
+        'scaling_memory_threshold_percentage' => 50,
+    ]);
+});
+
+it('does not send scaling thresholds when the scaling type is none', function () {
+    $sentBody = setupInstanceCreateMocks();
+
+    $this->artisan('instance:create', [
+        'environment' => 'env-1',
+        '--name' => 'analytics',
+        '--size' => 'standard-1',
+        '--scaling-type' => 'none',
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+
+    expect($sentBody())->not->toHaveKey('scaling_cpu_threshold_percentage');
+    expect($sentBody())->not->toHaveKey('scaling_memory_threshold_percentage');
+});
+
+it('fails with a readable message on an invalid scaling type', function () {
+    $sentBody = setupInstanceCreateMocks();
+
+    $this->artisan('instance:create', [
+        'environment' => 'env-1',
+        '--name' => 'analytics',
+        '--size' => 'standard-1',
+        '--scaling-type' => 'bogus',
+        '--no-interaction' => true,
+    ])->assertFailed();
+
+    expect($sentBody())->toBeNull();
+});

--- a/tests/Unit/FormTest.php
+++ b/tests/Unit/FormTest.php
@@ -39,6 +39,27 @@ it('returns null for a boolean that was never provided', function () {
     expect($form->boolean('is_public'))->toBeNull();
 });
 
+it('uses a falsy non-interactive default rather than treating it as missing', function (mixed $default) {
+    $form = (new Form)
+        ->isInteractive(false)
+        ->options([])
+        ->arguments([]);
+
+    $form->prompt('uses_scheduler', fn ($resolver) => $resolver->nonInteractively(fn () => $default));
+
+    expect($form->get('uses_scheduler'))->toBe($default);
+})->with([false, 0, '']);
+
+it('requires a value when the non-interactive default is null', function () {
+    $form = (new Form)
+        ->isInteractive(false)
+        ->options(['type' => null])
+        ->arguments([]);
+
+    expect(fn () => $form->prompt('type', fn ($resolver) => $resolver->nonInteractively(fn () => null)))
+        ->toThrow(RuntimeException::class, 'type is required. Provide --type option.');
+});
+
 it('keeps errors passed in before prompting', function () {
     $errors = new ValidationErrors;
     $errors->add('name', 'Name has already been taken.');


### PR DESCRIPTION
`instance:create` passed the `--scaling-type` option straight into `CreateInstanceRequestData`, which types it as an `InstanceScalingType` enum. The option arrives as a raw string and the non-interactive default was the string `'none'`, so every non-interactive run crashed with a TypeError before reaching the API. Only the interactive `confirm()` ever produced an enum, which is why this shipped.

Now the value gets converted once, case-insensitively, with a clear error listing the valid values when it isn't one of them.

The same block also compared a string to an enum case with `===` when deciding whether custom scaling was on, so that check was always false and `--scaling-type=custom` silently skipped the replica and threshold prompts. It compares the converted value now.

Separately, `ValueResolver` tested the truthiness of a non-interactive default, so a default of `false` or `0` looked like no default at all. Omitting `--uses-scheduler` failed with "uses-scheduler is required" even though the command defines a default of false. Only `null` falls through to that error now, which is what `CacheCreate` and `ApplicationCreate` rely on.

Closes #177
