### PR TITLE
Include database, cache and websocket relationships when fetching environments

### DIFF
--- a/app/Client/Resources/EnvironmentsResource.php
+++ b/app/Client/Resources/EnvironmentsResource.php
@@ -94,4 +94,19 @@ class EnvironmentsResource extends Resource
     {
         $this->send(new StopEnvironmentRequest(new StopEnvironmentRequestData($environmentId)));
     }
+
+    public function withDefaultIncludes(): static
+    {
+        return $this->include(
+            'application',
+            'branch',
+            'deployments',
+            'currentDeployment',
+            'primaryDomain',
+            'instances',
+            'database',
+            'cache',
+            'websocketApplication',
+        );
+    }
 }

--- a/app/Commands/Dashboard.php
+++ b/app/Commands/Dashboard.php
@@ -23,7 +23,7 @@ class Dashboard extends BaseCommand
         $this->ensureClient();
         $this->ensureRemoteGitRepo();
 
-        $environment = $this->resolvers()->environment()->include('application')->resolve();
+        $environment = $this->resolvers()->environment()->resolve();
         $application = $this->client->applications()->get($environment->application->id);
 
         $url = $application->url($environment);

--- a/app/Commands/DomainCreate.php
+++ b/app/Commands/DomainCreate.php
@@ -30,7 +30,7 @@ class DomainCreate extends BaseCommand
 
         intro('Creating Domain');
 
-        $environment = $this->resolvers()->environment()->include('application')->from($this->argument('environment'));
+        $environment = $this->resolvers()->environment()->from($this->argument('environment'));
 
         $domain = $this->loopUntilValid(fn () => $this->createDomain($environment->id));
 

--- a/app/Commands/EnvironmentGet.php
+++ b/app/Commands/EnvironmentGet.php
@@ -22,7 +22,7 @@ class EnvironmentGet extends BaseCommand
 
         intro('Environment Details');
 
-        $environment = $this->resolvers()->environment()->include('application')->from($this->argument('environment'));
+        $environment = $this->resolvers()->environment()->from($this->argument('environment'));
         $application = $this->client->applications()->get($environment->application->id);
 
         $this->outputJsonIfWanted($environment);

--- a/app/Commands/Tinker.php
+++ b/app/Commands/Tinker.php
@@ -51,7 +51,7 @@ class Tinker extends BaseCommand
 
         intro('Tinker');
 
-        $environment = $this->resolvers()->environment()->include('application')->from($this->argument('environment'));
+        $environment = $this->resolvers()->environment()->from($this->argument('environment'));
 
         if (! $this->isInteractive() || $this->option('code')) {
             return $this->handleNonInteractively($environment);

--- a/app/Resolvers/EnvironmentResolver.php
+++ b/app/Resolvers/EnvironmentResolver.php
@@ -23,8 +23,6 @@ class EnvironmentResolver extends Resolver
 
     public function from(?string $idOrName = null): ?Environment
     {
-        $this->include('application', 'branch', 'deployments', 'currentDeployment', 'primaryDomain', 'instances');
-
         $identifier = $idOrName ?? $this->localConfig->environmentId();
         $environment = ($identifier ? $this->fromIdentifier($identifier) : null) ?? $this->fromBranch() ?? $this->fromInput();
 

--- a/tests/Feature/EnvironmentRelationshipsTest.php
+++ b/tests/Feature/EnvironmentRelationshipsTest.php
@@ -1,0 +1,122 @@
+<?php
+
+use App\Client\Resources\Applications\GetApplicationRequest;
+use App\Client\Resources\Environments\GetEnvironmentRequest;
+use App\Client\Resources\Environments\UpdateEnvironmentRequest;
+use App\Client\Resources\Meta\GetOrganizationRequest;
+use App\ConfigRepository;
+use App\Git;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+use Saloon\Http\PendingRequest;
+
+beforeEach(function () {
+    $this->mockGit = Mockery::mock(Git::class);
+    $this->mockGit->shouldReceive('isRepo')->andReturn(true)->byDefault();
+    $this->mockGit->shouldReceive('getRoot')->andReturn('/tmp/test-repo')->byDefault();
+    $this->mockGit->shouldReceive('currentBranch')->andReturn('main')->byDefault();
+    $this->app->instance(Git::class, $this->mockGit);
+
+    $this->mockConfig = Mockery::mock(ConfigRepository::class);
+    $this->mockConfig->shouldReceive('apiTokens')->andReturn(collect(['test-api-token']));
+    $this->app->instance(ConfigRepository::class, $this->mockConfig);
+});
+
+afterEach(function () {
+    MockClient::destroyGlobal();
+});
+
+/**
+ * The API returns a relationship only when the request asked to include it, so
+ * the fake has to drop anything the caller did not request.
+ */
+function attachedEnvironmentResponse(?string $include): array
+{
+    $requested = explode(',', $include ?? '');
+
+    $relationships = array_filter([
+        'application' => ['data' => ['id' => 'app-123', 'type' => 'applications']],
+        'database' => ['data' => ['id' => '65634813', 'type' => 'databaseSchemas']],
+        'cache' => ['data' => null],
+        'websocketApplication' => ['data' => null],
+    ], fn ($key) => in_array($key, $requested, true), ARRAY_FILTER_USE_KEY);
+
+    return [
+        'data' => createEnvironmentResponse(['relationships' => $relationships]),
+        'included' => [createApplicationResponse()],
+    ];
+}
+
+function captureEnvironmentIncludes(): Closure
+{
+    $captured = new stdClass;
+
+    MockClient::global([
+        GetOrganizationRequest::class => MockResponse::make(organizationResponse(), 200),
+        GetApplicationRequest::class => MockResponse::make(['data' => createApplicationResponse()], 200),
+        GetEnvironmentRequest::class => function (PendingRequest $request) use ($captured) {
+            $captured->value = $request->query()->get('include');
+
+            return MockResponse::make(attachedEnvironmentResponse($captured->value), 200);
+        },
+        UpdateEnvironmentRequest::class => MockResponse::make(attachedEnvironmentResponse(null), 200),
+    ]);
+
+    return fn () => $captured->value ?? null;
+}
+
+it('requests the database, cache and websocket relationships when getting an environment', function () {
+    $includes = captureEnvironmentIncludes();
+
+    $this->artisan('environment:get', [
+        'environment' => 'env-1',
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+
+    expect(explode(',', $includes()))
+        ->toContain('database')
+        ->toContain('cache')
+        ->toContain('websocketApplication');
+});
+
+it('reads the attached database schema id from the environment relationships', function () {
+    captureEnvironmentIncludes();
+
+    $this->artisan('environment:get', [
+        'environment' => 'env-1',
+        '--json' => true,
+        '--fields' => 'databaseSchemaId',
+        '--no-interaction' => true,
+    ])->assertSuccessful()
+        ->expectsOutputToContain('"databaseSchemaId":"65634813"');
+});
+
+it('reports the attached database after updating an environment', function () {
+    $sentDatabaseSchemaId = new stdClass;
+
+    MockClient::global([
+        GetOrganizationRequest::class => MockResponse::make(organizationResponse(), 200),
+        GetApplicationRequest::class => MockResponse::make(['data' => createApplicationResponse()], 200),
+        GetEnvironmentRequest::class => fn (PendingRequest $request) => MockResponse::make(
+            attachedEnvironmentResponse($request->query()->get('include')),
+            200,
+        ),
+        UpdateEnvironmentRequest::class => function (PendingRequest $request) use ($sentDatabaseSchemaId) {
+            $sentDatabaseSchemaId->value = $request->body()->all()['database_schema_id'] ?? null;
+
+            return MockResponse::make(attachedEnvironmentResponse(null), 200);
+        },
+    ]);
+
+    $this->artisan('environment:update', [
+        'environment' => 'env-1',
+        '--database-id' => '65634813',
+        '--json' => true,
+        '--fields' => 'databaseSchemaId',
+        '--force' => true,
+        '--no-interaction' => true,
+    ])->assertSuccessful()
+        ->expectsOutputToContain('"databaseSchemaId":"65634813"');
+
+    expect($sentDatabaseSchemaId->value)->toBe('65634813');
+});

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -63,6 +63,10 @@ function createEnvironmentResponse(array $overrides = []): array
         $base['attributes'] = array_merge($base['attributes'], $overrides['attributes']);
     }
 
+    if (isset($overrides['relationships'])) {
+        $base['relationships'] = array_merge($base['relationships'] ?? [], $overrides['relationships']);
+    }
+
     return $base;
 }
 


### PR DESCRIPTION
The Cloud API only returns a relationship when the request asks for it. The environment resolver asked for six includes and left out `database`, `cache` and `websocketApplication`, so `databaseSchemaId`, `cacheId` and `websocketApplicationId` always read as null no matter what was attached. Bare `environments()->get()` calls, like the re-fetch after `environment:update`, asked for nothing at all.

That made `environment:update --database-id` look broken: the PATCH was fine, but the environment printed afterwards showed `databaseSchemaId: null`, so the attach appeared to have silently failed.

`EnvironmentsResource` now declares its default includes, and since the base `Resource` falls back to `withDefaultIncludes()` when none are set, the resolver can simply stop setting them. Also dropped the `->include('application')` calls in `Dashboard`, `DomainCreate`, `EnvironmentGet` and `Tinker`, which the resolver overwrote anyway.

Closes #174
