### PR TITLE
Register prompt fallbacks for our custom prompts so they work on Windows

### DIFF
--- a/app/Commands/BaseCommand.php
+++ b/app/Commands/BaseCommand.php
@@ -6,14 +6,18 @@ use App\Concerns\HasAClient;
 use App\Concerns\Validates;
 use App\Exceptions\CommandExitException;
 use App\Prompts\Renderer;
+use App\Prompts\SelectWithContextPrompt;
 use App\Prompts\SuppressedOutput;
 use App\Resolvers\Resolvers;
 use App\Support\DetectsNonInteractiveEnvironments;
 use App\Support\Form;
 use App\Support\SensitiveValues;
 use App\Support\ValueResolver;
+use Closure;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+use Laravel\Prompts\AutoCompletePrompt;
 use Laravel\Prompts\Concerns\Colors;
 use Laravel\Prompts\Prompt;
 use LaravelZero\Framework\Commands\Command;
@@ -125,9 +129,37 @@ abstract class BaseCommand extends Command
     {
         parent::configurePrompts($input);
 
+        $this->configureAdditionalPromptFallbacks();
+
         if (Renderer::$suppressOutput) {
             Prompt::setOutput(new SuppressedOutput);
         }
+    }
+
+    /**
+     * Laravel Prompts keys fallbacks by exact class name, and Illuminate only registers
+     * them for the prompts it ships with. Without these, our own prompt subclasses have
+     * no fallback and throw on terminals that can't render prompts (native Windows).
+     */
+    protected function configureAdditionalPromptFallbacks(): void
+    {
+        SelectWithContextPrompt::fallbackUsing(fn (SelectWithContextPrompt $prompt) => $this->promptUntilValid(
+            fn () => $this->components->choice($prompt->label, $prompt->options, $prompt->default),
+            false,
+            $prompt->validate,
+        ));
+
+        AutoCompletePrompt::fallbackUsing(fn (AutoCompletePrompt $prompt) => $this->promptUntilValid(
+            fn () => $this->components->askWithCompletion(
+                $prompt->label,
+                $prompt->options instanceof Closure
+                    ? fn (string $typed) => Collection::wrap(($prompt->options)($typed))->all()
+                    : $prompt->options,
+                $prompt->default ?: null,
+            ) ?? '',
+            $prompt->required,
+            $prompt->validate,
+        ));
     }
 
     protected function failAndExit(string $message): void

--- a/tests/Feature/PromptFallbackTest.php
+++ b/tests/Feature/PromptFallbackTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Support\Facades\Artisan;
+use Laravel\Prompts\Prompt;
+use Tests\Fixtures\PromptFallbackTestCommand;
+
+/**
+ * Stand in for `windows_os()`, which is what puts prompts into fallback mode on a
+ * terminal that can't render them.
+ */
+function forcePromptFallback(bool $condition): void
+{
+    (new ReflectionProperty(Prompt::class, 'shouldFallback'))->setValue(null, $condition);
+}
+
+beforeEach(function () {
+    Artisan::registerCommand(new PromptFallbackTestCommand);
+
+    forcePromptFallback(true);
+});
+
+afterEach(function () {
+    forcePromptFallback(false);
+});
+
+it('falls back to console questions for prompts Illuminate does not register', function () {
+    $this->artisan('test:prompt-fallback')
+        ->expectsChoice('Application', 'app-2', ['app-1' => 'First app', 'app-2' => 'Second app'])
+        ->expectsQuestion('Command', 'php artisan migrate')
+        ->expectsOutputToContain('selected:app-2')
+        ->expectsOutputToContain('typed:php artisan migrate')
+        ->assertSuccessful();
+});

--- a/tests/Fixtures/PromptFallbackTestCommand.php
+++ b/tests/Fixtures/PromptFallbackTestCommand.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Fixtures;
+
+use App\Commands\BaseCommand;
+
+use function Laravel\Prompts\autocomplete;
+
+class PromptFallbackTestCommand extends BaseCommand
+{
+    protected $signature = 'test:prompt-fallback';
+
+    public function handle(): void
+    {
+        $application = selectWithContext(
+            label: 'Application',
+            options: ['app-1' => 'First app', 'app-2' => 'Second app'],
+        );
+
+        $command = autocomplete(
+            label: 'Command',
+            options: ['php artisan migrate', 'php artisan queue:work'],
+        );
+
+        $this->line('selected:'.$application);
+        $this->line('typed:'.$command);
+    }
+}


### PR DESCRIPTION
Laravel Prompts keys fallbacks by exact class name, and Illuminate's `ConfiguresPrompts` only registers them for the prompts it ships with. That leaves two we use without a fallback, so on native Windows (no WSL) they hit `Prompt::checkEnvironment()` and throw `Prompts is not currently supported on Windows`:

- `App\Prompts\SelectWithContextPrompt`, which extends `SelectPrompt` but doesn't inherit its fallback. It's behind the `selectWithContext()` helper used by every resolver, so this broke basically any interactive command.
- `Laravel\Prompts\AutoCompletePrompt`, used by `command:run`.

`BaseCommand::configurePrompts()` now registers both, routed through Illuminate's `promptUntilValid()` so `required` and `validate` behave the same as on a supported terminal. `SelectWithContextPrompt` maps to `choice()` and `AutoCompletePrompt` to `askWithCompletion()`, with its closure form wrapped so Symfony's autocompleter gets a plain array.

The other custom prompts (`DataTable`, `MonitorCommand`, `SlideIn`, and friends) are fine as is. They go through `display()` rather than `prompt()`, so they never reach the environment check, and they already catch the `setTty()` failure and degrade to static output.

Closes #173
