### PR TITLE
Make repo:config work non-interactively

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,17 @@ Link the current Git repo to a Laravel Cloud application and set defaults (appli
 cloud repo:config
 ```
 
-Run this from your project root after `cloud auth`.
+Run this from your project root after `cloud auth`. Pass the application to skip the prompt, which is required when running non-interactively with more than one application:
+
+```sh
+cloud repo:config my-app -n
+```
+
+If you have tokens for more than one organization, name the one you want with `--organization` (its ID, name, or slug):
+
+```sh
+cloud repo:config my-app --organization=acme -n
+```
 
 ## Quick start
 

--- a/app/Commands/BaseCommand.php
+++ b/app/Commands/BaseCommand.php
@@ -162,7 +162,7 @@ abstract class BaseCommand extends Command
         ));
     }
 
-    protected function failAndExit(string $message): void
+    protected function failAndExit(string $message): never
     {
         $this->outputError($message);
 

--- a/app/Commands/RepoConfig.php
+++ b/app/Commands/RepoConfig.php
@@ -7,16 +7,16 @@ use App\Dto\Organization;
 use App\Git;
 use App\LocalConfig;
 
-use function Laravel\Prompts\error;
 use function Laravel\Prompts\intro;
 use function Laravel\Prompts\outro;
 use function Laravel\Prompts\select;
 use function Laravel\Prompts\spin;
-use function Laravel\Prompts\warning;
 
 class RepoConfig extends BaseCommand
 {
-    protected $signature = 'repo:config';
+    protected $signature = 'repo:config
+                            {application? : The application ID or name to use as the default}
+                            {--organization= : The organization ID, name, or slug to use as the default}';
 
     protected $description = 'Configure Laravel Cloud defaults for the current repository';
 
@@ -25,28 +25,20 @@ class RepoConfig extends BaseCommand
         intro('Configure Repository Defaults');
 
         if (! $git->isRepo()) {
-            error('This directory is not a Git repository.');
-
-            return self::FAILURE;
+            $this->failAndExit('This directory is not a Git repository.');
         }
 
         $gitRoot = $git->getRoot();
 
         if (! $gitRoot) {
-            error('Could not determine Git repository root.');
-
-            return self::FAILURE;
+            $this->failAndExit('Could not determine Git repository root.');
         }
 
-        $this->ensureClient(ignoreLocalConfig: true);
+        $this->ensureClient(ignoreLocalConfig: true, organization: $this->option('organization'));
 
         $organization = $this->resolveOrganization();
 
         $application = $this->selectApplication($localConfig->get('application_id'));
-
-        if ($application === null) {
-            return self::FAILURE;
-        }
 
         $newValues = ['organization_id' => $organization->id];
 
@@ -61,13 +53,23 @@ class RepoConfig extends BaseCommand
 
     protected function resolveOrganization(): Organization
     {
-        return spin(
+        $organization = spin(
             fn () => $this->client->meta()->organization(),
             'Fetching organization...',
         );
+
+        // With a single API token there is nothing to choose between, so --organization
+        // has been ignored up to this point. Check it against what the token belongs to.
+        $requested = $this->option('organization');
+
+        if ($requested && ! in_array($requested, [$organization->id, $organization->name, $organization->slug], true)) {
+            $this->failAndExit("Unable to resolve organization [{$requested}]. This API token belongs to {$organization->name}. Run `cloud auth:token --list` to see your tokens.");
+        }
+
+        return $organization;
     }
 
-    protected function selectApplication($currentApplicationId): ?Application
+    protected function selectApplication($currentApplicationId): Application
     {
         $applications = spin(
             fn () => $this->client->applications()->withDefaultIncludes()->list()->collect(),
@@ -75,9 +77,19 @@ class RepoConfig extends BaseCommand
         );
 
         if ($applications->isEmpty()) {
-            warning('No applications found for this organization');
+            $this->failAndExit('No applications found for this organization.');
+        }
 
-            return null;
+        if ($identifier = $this->argument('application')) {
+            $app = $applications->firstWhere('id', $identifier) ?? $applications->firstWhere('name', $identifier);
+
+            if (! $app) {
+                $this->failAndExit("Unable to resolve application [{$identifier}]. Run `cloud application:list --json -n` to see available applications.");
+            }
+
+            answered(label: 'Application', answer: $app->name);
+
+            return $app;
         }
 
         if ($applications->hasSole()) {
@@ -86,6 +98,10 @@ class RepoConfig extends BaseCommand
             answered(label: 'Application', answer: $app->name);
 
             return $app;
+        }
+
+        if (! $this->isInteractive()) {
+            $this->failAndExit('Multiple applications found. Provide an application ID or name: `cloud repo:config {application} -n`.');
         }
 
         $defaultApplicationId = $applications->firstWhere('id', $currentApplicationId)?->id;

--- a/app/Commands/Usage.php
+++ b/app/Commands/Usage.php
@@ -329,10 +329,8 @@ class Usage extends BaseCommand
 
         return match ($input) {
             'current' => 0,
-            'previous', '1' => 1,
-            '2' => 2,
-            '3' => 3,
-            default => 0,
+            'previous' => 1,
+            default => (int) $input,
         };
     }
 

--- a/app/Concerns/HasAClient.php
+++ b/app/Concerns/HasAClient.php
@@ -21,9 +21,9 @@ trait HasAClient
 
     protected Connector $client;
 
-    protected function ensureClient(bool $ignoreLocalConfig = false)
+    protected function ensureClient(bool $ignoreLocalConfig = false, ?string $organization = null)
     {
-        $apiToken = $this->resolveApiToken($ignoreLocalConfig);
+        $apiToken = $this->resolveApiToken($ignoreLocalConfig, $organization);
 
         $this->client = new Connector($apiToken);
     }
@@ -40,7 +40,7 @@ trait HasAClient
         $this->resolveApiToken();
     }
 
-    protected function resolveApiToken(bool $ignoreLocalConfig = false): string
+    protected function resolveApiToken(bool $ignoreLocalConfig = false, ?string $organization = null): string
     {
         $config = app(ConfigRepository::class);
         $apiTokens = $config->apiTokens();
@@ -85,16 +85,26 @@ trait HasAClient
                 return $orgs->keys()->first();
             }
 
+            if ($organization) {
+                foreach ($orgs as $token => $org) {
+                    if (in_array($organization, [$org->id, $org->name, $org->slug], true)) {
+                        return $token;
+                    }
+                }
+
+                throw new RuntimeException("Unable to resolve organization [{$organization}]. Available organizations: ".$orgs->map(fn ($org) => $org->name)->join(', ').'.');
+            }
+
             if (! $ignoreLocalConfig && $defaultOrganizationId = app(LocalConfig::class)->get('organization_id')) {
-                foreach ($orgs as $token => $organization) {
-                    if ($organization->id === $defaultOrganizationId) {
+                foreach ($orgs as $token => $org) {
+                    if ($org->id === $defaultOrganizationId) {
                         return $token;
                     }
                 }
             }
 
             if (! stream_isatty(STDIN) || $this->isNonInteractiveEnvironment()) {
-                throw new RuntimeException('Multiple API tokens found. Set organization_id in .cloud/config.json or use `cloud auth:token` to manage tokens.');
+                throw new RuntimeException('Multiple API tokens found. Run `cloud repo:config --organization=<id|name|slug>` to set a default for this repository, or use `cloud auth:token` to manage tokens.');
             }
 
             $apiToken = select(

--- a/skills/deploying-laravel-cloud/SKILL.md
+++ b/skills/deploying-laravel-cloud/SKILL.md
@@ -42,7 +42,6 @@ First deploy? → `cloud ship -n` (discover options via `cloud ship -h`)
 
 Existing app? →
 ```sh
-cloud repo:config
 cloud deploy {app_name} {environment} -n --open
 cloud deploy:monitor -n
 ```
@@ -158,8 +157,12 @@ Delegate `--detailed --json` to a subagent — the payload includes every databa
 ## Config
 
 1. Global: `~/.config/cloud/config.json` — auth tokens and preferences
-2. Repo-local: `.cloud/config.json` — app and environment defaults (set by `cloud repo:config`)
+2. Repo-local: `.cloud/config.json` — app and environment defaults (set by `cloud repo:config {application} -n`)
 3. CLI arguments override both
+
+Pass the application to `repo:config` — without it the command has to ask, and under `-n` it fails when the organization has more than one application. Deploy commands don't need these defaults; pass the application and environment to them directly.
+
+Multiple organizations means multiple stored API tokens. Every command reads `organization_id` from `.cloud/config.json` to pick one; if it isn't set, they fail. Set it with `cloud repo:config {application} --organization=<id|name|slug> -n`.
 
 ## Documentation
 

--- a/tests/Feature/RepoConfigTest.php
+++ b/tests/Feature/RepoConfigTest.php
@@ -1,0 +1,190 @@
+<?php
+
+use App\Client\Resources\Applications\ListApplicationsRequest;
+use App\Client\Resources\Meta\GetOrganizationRequest;
+use App\ConfigRepository;
+use App\Git;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+use Saloon\Http\PendingRequest;
+
+beforeEach(function () {
+    $this->repoRoot = sys_get_temp_dir().'/cloud-cli-repo-config-'.uniqid();
+    File::ensureDirectoryExists($this->repoRoot);
+
+    $this->mockGit = Mockery::mock(Git::class);
+    $this->mockGit->shouldReceive('isRepo')->andReturn(true)->byDefault();
+    $this->mockGit->shouldReceive('getRoot')->andReturn($this->repoRoot)->byDefault();
+    $this->app->instance(Git::class, $this->mockGit);
+
+    $this->mockConfig = Mockery::mock(ConfigRepository::class);
+    $this->mockConfig->shouldReceive('apiTokens')->andReturn(collect(['test-api-token']))->byDefault();
+    $this->mockConfig->shouldReceive('setApiTokens')->byDefault();
+    $this->app->instance(ConfigRepository::class, $this->mockConfig);
+});
+
+/**
+ * Two tokens, one per organization — which is what having multiple organizations means
+ * to the CLI. Both the organization and the applications a request sees depend on the
+ * token it was signed with, exactly as the API scopes them.
+ */
+function fakeTwoOrganizations(): void
+{
+    test()->mockConfig->shouldReceive('apiTokens')->andReturn(collect(['token-acme', 'token-globex']));
+
+    $signedWithAcme = fn (PendingRequest $request) => str_contains($request->headers()->get('Authorization') ?? '', 'token-acme');
+
+    MockClient::global([
+        GetOrganizationRequest::class => function (PendingRequest $request) use ($signedWithAcme) {
+            $isAcme = $signedWithAcme($request);
+
+            return MockResponse::make([
+                'data' => [
+                    'id' => $isAcme ? 'org-acme' : 'org-globex',
+                    'type' => 'organizations',
+                    'attributes' => [
+                        'name' => $isAcme ? 'Acme' : 'Globex',
+                        'slug' => $isAcme ? 'acme' : 'globex',
+                    ],
+                ],
+            ], 200);
+        },
+        ListApplicationsRequest::class => function (PendingRequest $request) use ($signedWithAcme) {
+            $isAcme = $signedWithAcme($request);
+            $organizationId = $isAcme ? 'org-acme' : 'org-globex';
+
+            return MockResponse::make([
+                'data' => [
+                    createApplicationResponse([
+                        'id' => $isAcme ? 'app-acme' : 'app-globex',
+                        'attributes' => ['name' => $isAcme ? 'Acme App' : 'Globex App'],
+                        'relationships' => [
+                            'organization' => ['data' => ['id' => $organizationId, 'type' => 'organizations']],
+                        ],
+                    ]),
+                ],
+                'included' => [
+                    ['id' => $organizationId, 'type' => 'organizations', 'attributes' => ['name' => $isAcme ? 'Acme' : 'Globex', 'slug' => $isAcme ? 'acme' : 'globex']],
+                    ['id' => 'env-1', 'type' => 'environments', 'attributes' => ['name' => 'production', 'slug' => 'production', 'vanity_domain' => 'my-app.cloud.laravel.com', 'status' => 'running', 'php_major_version' => '8.3']],
+                ],
+                'links' => ['next' => null],
+            ], 200);
+        },
+    ]);
+}
+
+afterEach(function () {
+    File::deleteDirectory($this->repoRoot);
+
+    MockClient::destroyGlobal();
+});
+
+it('saves the repository defaults for the application named in the argument', function () {
+    setupApplicationListMocks([
+        createApplicationResponse(['id' => 'app-123', 'attributes' => ['name' => 'My App']]),
+        createApplicationResponse(['id' => 'app-456', 'attributes' => ['name' => 'Other App']]),
+    ]);
+
+    $exitCode = Artisan::call('repo:config', ['application' => 'Other App', '--no-interaction' => true]);
+
+    expect($exitCode)->toBe(0);
+    expect(File::json($this->repoRoot.'/.cloud/config.json'))->toMatchArray([
+        'organization_id' => 'org-1',
+        'application_id' => 'app-456',
+    ]);
+});
+
+it('saves the repository defaults without an argument when the organization has one application', function () {
+    setupApplicationListMocks();
+
+    $exitCode = Artisan::call('repo:config', ['--no-interaction' => true]);
+
+    expect($exitCode)->toBe(0);
+    expect(File::json($this->repoRoot.'/.cloud/config.json'))->toMatchArray([
+        'application_id' => 'app-123',
+    ]);
+});
+
+it('fails non-interactively when multiple applications exist and no argument is given', function () {
+    setupApplicationListMocks([
+        createApplicationResponse(['id' => 'app-123', 'attributes' => ['name' => 'My App']]),
+        createApplicationResponse(['id' => 'app-456', 'attributes' => ['name' => 'Other App']]),
+    ]);
+
+    $exitCode = Artisan::call('repo:config', ['--no-interaction' => true]);
+
+    expect($exitCode)->toBe(1);
+    expect(File::exists($this->repoRoot.'/.cloud/config.json'))->toBeFalse();
+});
+
+it('fails when the application argument matches nothing', function () {
+    setupApplicationListMocks();
+
+    $exitCode = Artisan::call('repo:config', ['application' => 'nonexistent', '--no-interaction' => true]);
+
+    expect($exitCode)->toBe(1);
+    expect(File::exists($this->repoRoot.'/.cloud/config.json'))->toBeFalse();
+});
+
+it('fails when there are no applications', function () {
+    setupApplicationListMocks([]);
+
+    $exitCode = Artisan::call('repo:config', ['--no-interaction' => true]);
+
+    expect($exitCode)->toBe(1);
+    expect(File::exists($this->repoRoot.'/.cloud/config.json'))->toBeFalse();
+});
+
+it('picks the organization named in --organization, and an application from it', function (string $identifier) {
+    fakeTwoOrganizations();
+
+    $exitCode = Artisan::call('repo:config', ['--organization' => $identifier, '--no-interaction' => true]);
+
+    expect($exitCode)->toBe(0);
+    expect(File::json($this->repoRoot.'/.cloud/config.json'))->toMatchArray([
+        'organization_id' => 'org-globex',
+        'application_id' => 'app-globex',
+    ]);
+})->with(['Globex', 'globex', 'org-globex']);
+
+it('will not save an application belonging to another organization', function () {
+    fakeTwoOrganizations();
+
+    $exitCode = Artisan::call('repo:config', [
+        'application' => 'Acme App',
+        '--organization' => 'Globex',
+        '--no-interaction' => true,
+    ]);
+
+    expect($exitCode)->toBe(1);
+    expect(File::exists($this->repoRoot.'/.cloud/config.json'))->toBeFalse();
+});
+
+it('fails when --organization matches none of the organizations', function () {
+    fakeTwoOrganizations();
+
+    $exitCode = Artisan::call('repo:config', ['--organization' => 'Initech', '--no-interaction' => true]);
+
+    expect($exitCode)->toBe(1);
+    expect(File::exists($this->repoRoot.'/.cloud/config.json'))->toBeFalse();
+});
+
+it('fails non-interactively with multiple organizations and no --organization', function () {
+    fakeTwoOrganizations();
+
+    $exitCode = Artisan::call('repo:config', ['--no-interaction' => true]);
+
+    expect($exitCode)->toBe(1);
+    expect(File::exists($this->repoRoot.'/.cloud/config.json'))->toBeFalse();
+});
+
+it('fails when --organization does not match the only token', function () {
+    setupApplicationListMocks();
+
+    $exitCode = Artisan::call('repo:config', ['--organization' => 'Initech', '--no-interaction' => true]);
+
+    expect($exitCode)->toBe(1);
+    expect(File::exists($this->repoRoot.'/.cloud/config.json'))->toBeFalse();
+});


### PR DESCRIPTION
`repo:config` could only pick an application through a prompt. Run it with `-n`
(or from any agent environment, which the CLI already treats as non-interactive)
and the prompt returned its default of null, so the command exited 1 without
printing anything.

It now takes the application as an argument, resolved by ID or name. When it
still can't choose one it says why instead of failing silently.

Multiple organizations had the same problem from the other direction. An
organization means a stored API token, and `repo:config` deliberately ignores
`.cloud/config.json` because it's the command that writes it, so with two tokens
it always failed, even when `organization_id` was already set. There was no way
to name the one you wanted. Added `--organization`, matching on ID, name, or
slug, and pointed the "multiple API tokens found" error at it.

The skill's deployment workflow dropped its bare `cloud repo:config` line. The
`cloud deploy` call directly below it already passes the application and
environment, so the defaults weren't buying anything there.

Fixes #168
