### PR TITLE
Scope form fields per resource, and stop retrying requests that cannot succeed

### DIFF
--- a/app/Commands/DatabaseClusterDelete.php
+++ b/app/Commands/DatabaseClusterDelete.php
@@ -55,6 +55,7 @@ class DatabaseClusterDelete extends BaseCommand
                             'Deleting schema '.$schema->name.'...',
                         );
                     },
+                    shouldRetry: fn ($errors) => $errors->messageContains('global', 'please wait'),
                 );
             }
 
@@ -70,6 +71,7 @@ class DatabaseClusterDelete extends BaseCommand
                         'Deleting database cluster...',
                     );
                 },
+                shouldRetry: fn ($errors) => $errors->messageContains('global', 'please wait'),
             );
 
             $this->outputJsonIfWanted('Database cluster deleted.');

--- a/app/Commands/Ship.php
+++ b/app/Commands/Ship.php
@@ -435,6 +435,7 @@ class Ship extends BaseCommand
 
                     return false;
                 },
+                shouldRetry: fn ($errors) => $errors->messageContains('global', 'wait a few seconds'),
             );
         }
     }
@@ -641,7 +642,8 @@ class Ship extends BaseCommand
             return $applications->firstWhere('id', $application);
         }
 
-        return $this->loopUntilValid(
+        return $this->createInScope(
+            'websocket_application',
             fn () => $this->createWebSocketApplication($cluster, []),
         );
     }
@@ -657,8 +659,9 @@ class Ship extends BaseCommand
             $createWebsocketCluster = confirm('Do you want to create a new websocket cluster?');
 
             if ($createWebsocketCluster) {
-                return $this->loopUntilValid(
-                    fn () => $this->createWebSocketCluster(),
+                return $this->createInScope(
+                    'websocket_cluster',
+                    fn () => $this->createWebSocketCluster($this->getWebSocketClusterDefaults()),
                 );
             }
 
@@ -679,7 +682,8 @@ class Ship extends BaseCommand
             return $clusters->firstWhere('id', $cluster);
         }
 
-        return $this->loopUntilValid(
+        return $this->createInScope(
+            'websocket_cluster',
             fn () => $this->createWebSocketCluster($this->getWebSocketClusterDefaults()),
         );
     }
@@ -708,7 +712,8 @@ class Ship extends BaseCommand
             return collect($database->schemas)->firstWhere('id', $schema);
         }
 
-        return $this->loopUntilValid(
+        return $this->createInScope(
+            'database',
             fn () => $this->createDatabase($database),
         );
     }
@@ -724,7 +729,8 @@ class Ship extends BaseCommand
             $createDatabase = confirm('Do you want to create a new database?');
 
             if ($createDatabase) {
-                return $this->loopUntilValid(
+                return $this->createInScope(
+                    'database_cluster',
                     fn () => $this->createDatabaseCluster($this->databaseClusterDefaults()),
                 );
             }
@@ -746,8 +752,21 @@ class Ship extends BaseCommand
             return $databases->firstWhere('id', $database);
         }
 
-        return $this->loopUntilValid(
+        return $this->createInScope(
+            'database_cluster',
             fn () => $this->createDatabaseCluster($this->databaseClusterDefaults()),
+        );
+    }
+
+    /**
+     * Shipping creates several resources in one run, so each one prompts in its own form scope.
+     * Sharing the form means the application's `name` and `region` answers would be reused as
+     * the database cluster's, which the API then rejects.
+     */
+    protected function createInScope(string $scope, callable $callback): mixed
+    {
+        return $this->loopUntilValid(
+            fn () => $this->form()->withScope($scope, $callback),
         );
     }
 

--- a/app/Concerns/Validates.php
+++ b/app/Concerns/Validates.php
@@ -21,10 +21,11 @@ trait Validates
      * @param  callable(ValidationErrors): TReturn  $callback
      * @return TReturn
      */
-    protected function loopUntilValid(callable $callback, int $maxAttempts = 20, bool|callable $suppressOutput = false, ?callable $handleNonInteractiveErrors = null): mixed
+    protected function loopUntilValid(callable $callback, int $maxAttempts = 20, bool|callable $suppressOutput = false, ?callable $handleNonInteractiveErrors = null, ?callable $shouldRetry = null): mixed
     {
         $this->errors ??= new ValidationErrors;
         $attempts = 0;
+        $previousFailure = null;
         $this->form()->errors($this->errors);
 
         while (true) { // @phpstan-ignore while.alwaysTrue
@@ -37,7 +38,12 @@ trait Validates
             $attempts++;
 
             try {
-                return $callback($this->errors);
+                $result = $callback($this->errors);
+
+                // Errors from an earlier attempt would otherwise follow us into the next loop.
+                $this->errors->clear();
+
+                return $result;
             } catch (RequestException $e) {
                 $this->errors->clear();
 
@@ -50,16 +56,55 @@ trait Validates
 
                             $this->errors->add($field, implode(', ', $messages));
                         }
+
+                        $failure = (string) json_encode($this->errors->all());
                     } else {
                         $message = $e->getResponse()->json('message', 'Unknown validation error');
 
                         $this->displayValidationError($message, $suppressOutput);
+
+                        $failure = $message;
                     }
                 } else {
                     $this->displayValidationError($e->getMessage(), $suppressOutput);
+
+                    $failure = $e->getMessage();
                 }
+
+                $this->breakValidationLoopIfStuck($failure, $previousFailure, $shouldRetry, $suppressOutput);
+
+                $previousFailure = $failure;
             }
         }
+    }
+
+    /**
+     * Stop retrying when the same failure comes back and there is nothing for the user to change.
+     *
+     * Errors the API does not tie to a field (a plan restriction, say) have no prompt to send the
+     * user back to, so retrying replays the same request until the attempt limit runs out.
+     */
+    protected function breakValidationLoopIfStuck(string $failure, ?string $previousFailure, ?callable $shouldRetry, bool|callable $suppressOutput): void
+    {
+        if (! $this->isInteractive()) {
+            return;
+        }
+
+        if ($shouldRetry !== null && $shouldRetry($this->errors)) {
+            return;
+        }
+
+        if ($this->form()->canPromptForAnyOf($this->errors)) {
+            return;
+        }
+
+        if ($failure !== $previousFailure) {
+            return;
+        }
+
+        $this->displayValidationError('Fix the error above, then run again.', $suppressOutput);
+
+        throw new CommandExitException(BaseCommand::FAILURE);
     }
 
     protected function displayValidationError(string $message, bool|callable $suppressOutput): void

--- a/app/Support/Form.php
+++ b/app/Support/Form.php
@@ -21,6 +21,27 @@ class Form
 
     protected array $prompted = [];
 
+    protected ?string $scope = null;
+
+    /**
+     * Run the callback with every field it defines namespaced under $scope.
+     *
+     * A command that creates more than one resource (shipping an app also creates a
+     * database cluster) would otherwise reuse one `name` field for all of them, so the
+     * first prompt defined wins and every later resource is sent the wrong value.
+     */
+    public function withScope(string $scope, callable $callback): mixed
+    {
+        $previous = $this->scope;
+        $this->scope = $previous === null ? $scope : $previous.'.'.$scope;
+
+        try {
+            return $callback();
+        } finally {
+            $this->scope = $previous;
+        }
+    }
+
     /**
      * @param  callable(ValueResolver): ValueResolver  $callback
      */
@@ -29,6 +50,8 @@ class Form
         if ($callback) {
             $this->define($key, $callback, $optionOrArgKey);
         }
+
+        $key = $this->scopedKey($key);
 
         if (! in_array($key, $this->prompted)) {
             $this->prompted[] = $key;
@@ -47,11 +70,17 @@ class Form
      */
     public function define(string $key, callable $callback, ?string $optionOrArgKey = null): ValueResolver
     {
+        $scopedKey = $this->scopedKey($key);
         $optionOrArgKey = $optionOrArgKey ?? str($key)->replace('_', '-')->toString();
-        $argOrOptionValue = $this->options[$optionOrArgKey] ?? $this->arguments[$optionOrArgKey] ?? null;
+
+        // A scoped field belongs to a nested resource, so the command's own options are not its input.
+        $argOrOptionValue = $this->scope === null
+            ? $this->options[$optionOrArgKey] ?? $this->arguments[$optionOrArgKey] ?? null
+            : null;
+
         $resolutionType = array_key_exists($optionOrArgKey, $this->options) ? 'option' : 'argument';
 
-        $this->fields[$key] ??= [
+        $this->fields[$scopedKey] ??= [
             'resolver' => new ValueResolver(
                 $key,
                 $optionOrArgKey,
@@ -62,11 +91,16 @@ class Form
             'callback' => $callback,
         ];
 
-        if ($argOrOptionValue !== null && ! in_array($key, $this->prompted)) {
-            $this->prompted[] = $key;
+        if ($argOrOptionValue !== null && ! in_array($scopedKey, $this->prompted)) {
+            $this->prompted[] = $scopedKey;
         }
 
-        return $this->fields[$key]['resolver'];
+        return $this->fields[$scopedKey]['resolver'];
+    }
+
+    protected function scopedKey(string $key): string
+    {
+        return $this->scope === null ? $key : $this->scope.'.'.$key;
     }
 
     public function isInteractive(bool $isInteractive): self
@@ -99,11 +133,27 @@ class Form
 
     public function get(string $key, mixed $default = null): mixed
     {
+        $key = $this->scopedKey($key);
+
         if (! array_key_exists($key, $this->fields)) {
             return $default;
         }
 
         return $this->fields[$key]['resolver']->value();
+    }
+
+    /**
+     * Whether any of these errors belongs to a field the user can be prompted for again.
+     */
+    public function canPromptForAnyOf(ValidationErrors $errors): bool
+    {
+        foreach ($this->fields as $field) {
+            if ($errors->has($field['resolver']->key) && $field['resolver']->canPromptForInput()) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public function integer(string $key, ?int $default = null): ?int

--- a/app/Support/ValueResolver.php
+++ b/app/Support/ValueResolver.php
@@ -81,6 +81,11 @@ class ValueResolver
         return $this->value;
     }
 
+    public function canPromptForInput(): bool
+    {
+        return $this->isInteractive && $this->fromInputCallback !== null;
+    }
+
     public function retrieve(): mixed
     {
         return $this->value = $this->retrieveValue();

--- a/tests/Unit/FormTest.php
+++ b/tests/Unit/FormTest.php
@@ -60,6 +60,60 @@ it('requires a value when the non-interactive default is null', function () {
         ->toThrow(RuntimeException::class, 'type is required. Provide --type option.');
 });
 
+it('keeps a scoped field separate from the field of the same name outside the scope', function () {
+    $form = (new Form)
+        ->isInteractive(true)
+        ->options([])
+        ->arguments([]);
+
+    $form->prompt('name', fn ($resolver) => $resolver->fromInput(fn () => 'My App'));
+
+    $form->withScope('database_cluster', fn () => $form->prompt(
+        'name',
+        fn ($resolver) => $resolver->fromInput(fn () => 'my_app'),
+    ));
+
+    expect($form->get('name'))->toBe('My App');
+    expect($form->withScope('database_cluster', fn () => $form->get('name')))->toBe('my_app');
+});
+
+it('does not read the command options for a scoped field', function () {
+    $form = (new Form)
+        ->isInteractive(true)
+        ->options(['name' => 'my-app'])
+        ->arguments([]);
+
+    $form->withScope('database_cluster', fn () => $form->prompt(
+        'name',
+        fn ($resolver) => $resolver->fromInput(fn ($value) => $value ?? 'prompted'),
+    ));
+
+    expect($form->withScope('database_cluster', fn () => $form->get('name')))->toBe('prompted');
+});
+
+it('matches errors to a scoped field by the field name the API returned', function () {
+    $errors = new ValidationErrors;
+    $errors->add('name', 'The cluster name may only contain lowercase letters.');
+
+    $form = (new Form)
+        ->isInteractive(true)
+        ->options([])
+        ->arguments([])
+        ->errors($errors);
+
+    $form->withScope('database_cluster', fn () => $form->prompt(
+        'name',
+        fn ($resolver) => $resolver->fromInput(fn ($value) => $value === null ? 'TimeKeeper' : 'timekeeper'),
+    ));
+
+    expect($form->canPromptForAnyOf($errors))->toBeTrue();
+
+    // The error is still there, so prompting again asks the user for a new value.
+    $form->withScope('database_cluster', fn () => $form->prompt('name'));
+
+    expect($form->withScope('database_cluster', fn () => $form->get('name')))->toBe('timekeeper');
+});
+
 it('keeps errors passed in before prompting', function () {
     $errors = new ValidationErrors;
     $errors->add('name', 'Name has already been taken.');

--- a/tests/Unit/ValidatesTest.php
+++ b/tests/Unit/ValidatesTest.php
@@ -1,0 +1,102 @@
+<?php
+
+use App\Concerns\Validates;
+use App\Dto\ValidationErrors;
+use App\Exceptions\CommandExitException;
+use App\Support\Form;
+use Saloon\Exceptions\Request\RequestException;
+use Saloon\Http\Response;
+
+class ValidatesHost
+{
+    use Validates;
+
+    public int $attempts = 0;
+
+    public function __construct(protected Form $form, protected bool $interactive = true) {}
+
+    public function run(callable $callback, ?callable $shouldRetry = null): mixed
+    {
+        return $this->loopUntilValid($callback, suppressOutput: true, shouldRetry: $shouldRetry);
+    }
+
+    public function form(): Form
+    {
+        return $this->form;
+    }
+
+    protected function isInteractive(): bool
+    {
+        return $this->interactive;
+    }
+
+    protected function wantsJson(): bool
+    {
+        return false;
+    }
+}
+
+function validationException(array $errors): RequestException
+{
+    $response = Mockery::mock(Response::class);
+    $response->shouldReceive('status')->andReturn(422);
+    $response->shouldReceive('json')->with('errors', [])->andReturn($errors);
+
+    return new RequestException($response, 'Unprocessable Content');
+}
+
+function validatesHost(bool $interactive = true): ValidatesHost
+{
+    return new ValidatesHost(
+        (new Form)->isInteractive($interactive)->options([])->arguments([]),
+        $interactive,
+    );
+}
+
+it('stops retrying when the same error comes back and no field can be prompted for again', function () {
+    $host = validatesHost();
+
+    expect(fn () => $host->run(function () use ($host) {
+        $host->attempts++;
+
+        throw validationException(['global' => ['The selected type is not available on your plan.']]);
+    }))->toThrow(CommandExitException::class);
+
+    expect($host->attempts)->toBe(2);
+});
+
+it('keeps retrying while the callback says the error is worth waiting out', function () {
+    $host = validatesHost();
+
+    $host->run(
+        function () use ($host) {
+            $host->attempts++;
+
+            if ($host->attempts < 4) {
+                throw validationException(['global' => ['Please wait a few seconds.']]);
+            }
+
+            return 'done';
+        },
+        fn (ValidationErrors $errors) => $errors->messageContains('global', 'Please wait'),
+    );
+
+    expect($host->attempts)->toBe(4);
+});
+
+it('keeps retrying while the user can be prompted for the field that failed', function () {
+    $host = validatesHost();
+    $host->form()->prompt('name', fn ($resolver) => $resolver->fromInput(fn ($value) => $value ?? 'taken'));
+
+    $host->run(function () use ($host) {
+        $host->attempts++;
+
+        if ($host->attempts < 4) {
+            throw validationException(['name' => ['The name has already been taken.']]);
+        }
+
+        return 'done';
+    });
+
+    expect($host->attempts)->toBe(4);
+});


### PR DESCRIPTION
Adds scoping to Form. Fields defined inside withScope() are namespaced, and ship now creates each nested resource (database cluster, schema, websocket cluster, websocket app) in its own scope. The resolver keeps the unscoped field name so API errors still map back to the right prompt, and scoped fields no longer read the command's own options. Unscoped fields are unchanged, so the other 20 commands behave exactly as before.

loopUntilValid also gives up now when the same failure repeats and no error field has a prompt behind it, printing "Fix the error above, then run again." An error the API does not tie to a field, like "The selected type is not available on your plan", used to replay the same request 20 times before dying on "Maximum attempts reached". Loops that wait out a transient error opt out through a new shouldRetry argument: ship's environment update and both database-cluster:delete loops. Errors are cleared after a successful attempt too, so a failure early in a run no longer leaks into the next loop.
