### PR TITLE
Fail with a readable error when the API sends back something that is not JSON

### DIFF
--- a/app/Client/Connector.php
+++ b/app/Client/Connector.php
@@ -24,10 +24,12 @@ use App\Client\Resources\UsageResource;
 use App\Client\Resources\WebSocketApplicationsResource;
 use App\Client\Resources\WebSocketClustersResource;
 use App\Cloud;
+use App\Exceptions\UnreadableResponseException;
 use App\Support\ContextDetector;
 use Illuminate\Support\Facades\Cache;
 use Saloon\CachePlugin\Contracts\Driver;
 use Saloon\CachePlugin\Drivers\LaravelCacheDriver;
+use Saloon\Enums\PipeOrder;
 use Saloon\Http\Auth\TokenAuthenticator;
 use Saloon\Http\Connector as SaloonConnector;
 use Saloon\Http\PendingRequest;
@@ -67,6 +69,25 @@ class Connector extends SaloonConnector implements HasPagination
 
     public function boot(PendingRequest $pendingRequest): void
     {
+        $pendingRequest->middleware()->onResponse(
+            callable: static function (Response $response) {
+                // A failed response is already on its way to becoming a RequestException.
+                if ($response->failed()) {
+                    return;
+                }
+
+                $body = trim($response->body());
+
+                if ($body === '' || json_validate($body)) {
+                    return;
+                }
+
+                throw UnreadableResponseException::for($response);
+            },
+            name: 'failOnUnreadableBody',
+            order: PipeOrder::LAST,
+        );
+
         if (! method_exists($pendingRequest->getRequest(), 'getInclude')) {
             return;
         }

--- a/app/Commands/BaseCommand.php
+++ b/app/Commands/BaseCommand.php
@@ -5,6 +5,7 @@ namespace App\Commands;
 use App\Concerns\HasAClient;
 use App\Concerns\Validates;
 use App\Exceptions\CommandExitException;
+use App\Exceptions\UnreadableResponseException;
 use App\Prompts\Renderer;
 use App\Prompts\SelectWithContextPrompt;
 use App\Prompts\SuppressedOutput;
@@ -187,6 +188,10 @@ abstract class BaseCommand extends Command
             return parent::run($input, $output);
         } catch (CommandExitException $e) {
             return $e->getExitCode();
+        } catch (UnreadableResponseException $e) {
+            $this->outputError($e->getMessage());
+
+            return self::FAILURE;
         } catch (RuntimeException $e) {
             if ($this->wantsJson()) {
                 $this->outputError($e->getMessage());

--- a/app/Exceptions/UnreadableResponseException.php
+++ b/app/Exceptions/UnreadableResponseException.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+use Saloon\Http\Response;
+
+class UnreadableResponseException extends Exception
+{
+    public static function for(Response $response): self
+    {
+        $request = $response->getPendingRequest();
+
+        return new self(sprintf(
+            'Laravel Cloud sent back a response we could not read: HTTP %d from %s %s. The body started with: %s',
+            $response->status(),
+            $request->getMethod()->value,
+            $request->getUrl(),
+            str($response->body())->squish()->limit(80)->toString(),
+        ));
+    }
+}

--- a/tests/Feature/UnreadableResponseTest.php
+++ b/tests/Feature/UnreadableResponseTest.php
@@ -1,0 +1,56 @@
+<?php
+
+use App\Client\Resources\Applications\CreateApplicationRequest;
+use App\Client\Resources\Meta\GetOrganizationRequest;
+use App\Client\Resources\Meta\ListRegionsRequest;
+use App\ConfigRepository;
+use App\Git;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+
+beforeEach(function () {
+    $this->mockGit = Mockery::mock(Git::class);
+    $this->mockGit->shouldReceive('isRepo')->andReturn(true)->byDefault();
+    $this->mockGit->shouldReceive('getRoot')->andReturn('/tmp/test-repo')->byDefault();
+    $this->mockGit->shouldReceive('hasGitHubRemote')->andReturn(true)->byDefault();
+    $this->mockGit->shouldReceive('remoteRepo')->andReturn('laravel/cloud-cli')->byDefault();
+    $this->app->instance(Git::class, $this->mockGit);
+
+    $this->mockConfig = Mockery::mock(ConfigRepository::class);
+    $this->mockConfig->shouldReceive('apiTokens')->andReturn(collect(['test-api-token']));
+    $this->app->instance(ConfigRepository::class, $this->mockConfig);
+});
+
+afterEach(function () {
+    MockClient::destroyGlobal();
+});
+
+it('fails cleanly when the API answers a successful request with something other than JSON', function () {
+    MockClient::global([
+        GetOrganizationRequest::class => MockResponse::make(organizationResponse(), 200),
+        ListRegionsRequest::class => MockResponse::make(regionsResponse(), 200),
+        CreateApplicationRequest::class => MockResponse::make('<!DOCTYPE html><html><body>Something went wrong</body></html>', 200),
+    ]);
+
+    $this->artisan('application:create', [
+        '--name' => 'my-app',
+        '--repository' => 'laravel/cloud-cli',
+        '--region' => 'us-east-2',
+        '--no-interaction' => true,
+    ])->assertFailed();
+});
+
+it('still reports a failed response as a request error rather than an unreadable one', function () {
+    MockClient::global([
+        GetOrganizationRequest::class => MockResponse::make(organizationResponse(), 200),
+        ListRegionsRequest::class => MockResponse::make(regionsResponse(), 200),
+        CreateApplicationRequest::class => MockResponse::make('<!DOCTYPE html><html><body>Server Error</body></html>', 500),
+    ]);
+
+    $this->artisan('application:create', [
+        '--name' => 'my-app',
+        '--repository' => 'laravel/cloud-cli',
+        '--region' => 'us-east-2',
+        '--no-interaction' => true,
+    ])->assertFailed();
+});


### PR DESCRIPTION
Successful responses are now checked for a parseable body before anything tries to decode them. If the body is not JSON, the command exits with the status, the endpoint, and the start of what came back, instead of an unhandled JsonException and a stack trace.

Responses the API already treats as failures are left alone, so 4xx and 5xx handling is unchanged.

Fixes #162
