### PR TITLE
Read the API token from LARAVEL_CLOUD_TOKEN and make auth:token scriptable

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,43 @@ Before using most commands, authenticate with Laravel Cloud:
 cloud auth
 ```
 
-This opens a browser for OAuth. API tokens are stored in `~/.config/cloud/config.json`. To manage tokens (e.g. for CI):
+This opens a browser for OAuth. API tokens are stored in `~/.config/cloud/config.json`. To manage those tokens interactively:
 
 ```sh
 cloud auth:token
 ```
+
+### CI and other non-interactive use
+
+Browser OAuth needs a browser, so set the token in the environment instead. `LARAVEL_CLOUD_TOKEN` takes precedence over anything saved in `~/.config/cloud/config.json`, and nothing is written to disk:
+
+```sh
+export LARAVEL_CLOUD_TOKEN=your-api-token
+cloud application:list -n
+```
+
+Create a token at https://cloud.laravel.com/docs/api/authentication#create-an-api-token.
+
+An empty value counts as unset, so you can bypass it for a single command without unsetting it:
+
+```sh
+LARAVEL_CLOUD_TOKEN= cloud application:list -n
+```
+
+To save a token to the config file instead — on a machine you come back to, or when you need tokens for several organizations — pass it or pipe it:
+
+```sh
+cloud auth:token --add --token=your-api-token -n
+echo "$YOUR_API_TOKEN" | cloud auth:token --add -n
+```
+
+Prefer the pipe where the process list is visible to others. `--remove` takes `--token=` the same way, and `--list` names the source of each token:
+
+```sh
+cloud auth:token --list -n
+```
+
+The token carries its own organization, so `--organization` becomes a check rather than a choice: when `LARAVEL_CLOUD_TOKEN` is set and you name an organization the token doesn't belong to, the command fails instead of using the wrong one.
 
 ## Repository configuration
 

--- a/app/Cloud.php
+++ b/app/Cloud.php
@@ -4,6 +4,10 @@ namespace App;
 
 class Cloud
 {
+    public const API_TOKEN_ENV_VAR = 'LARAVEL_CLOUD_TOKEN';
+
+    public const DEFAULT_URL = 'https://cloud.laravel.com';
+
     public static function baseUrl(): string
     {
         $baseUrl = config('cloud.base_url');
@@ -13,5 +17,16 @@ class Cloud
         }
 
         return 'https://'.$baseUrl;
+    }
+
+    public static function apiTokenFromEnvironment(): ?string
+    {
+        $token = config('cloud.api_token');
+
+        if (! is_string($token) || trim($token) === '') {
+            return null;
+        }
+
+        return trim($token);
     }
 }

--- a/app/Commands/Auth.php
+++ b/app/Commands/Auth.php
@@ -3,6 +3,7 @@
 namespace App\Commands;
 
 use App\Client\Connector;
+use App\Cloud;
 use App\ConfigRepository;
 use App\Contracts\NoAuthRequired;
 use Saloon\Exceptions\Request\RequestException as SaloonRequestException;
@@ -13,6 +14,7 @@ use function Laravel\Prompts\info;
 use function Laravel\Prompts\intro;
 use function Laravel\Prompts\outro;
 use function Laravel\Prompts\spin;
+use function Laravel\Prompts\warning;
 
 class Auth extends BaseCommand implements NoAuthRequired
 {
@@ -135,6 +137,10 @@ class Auth extends BaseCommand implements NoAuthRequired
 
         foreach ($tokens as $tokenData) {
             success("Authenticated with <comment>{$tokenData['organization_name']}</comment>");
+        }
+
+        if (Cloud::apiTokenFromEnvironment()) {
+            warning(Cloud::API_TOKEN_ENV_VAR.' is set in your environment and takes precedence over these tokens. Unset it to use them.');
         }
 
         outro('Authentication successful! Tokens saved to '.$this->config->path());

--- a/app/Commands/AuthToken.php
+++ b/app/Commands/AuthToken.php
@@ -3,9 +3,11 @@
 namespace App\Commands;
 
 use App\Client\Connector;
+use App\Cloud;
 use App\ConfigRepository;
 use App\Contracts\NoAuthRequired;
 use App\Exceptions\CommandExitException;
+use App\Support\Stdin;
 use Illuminate\Support\Collection;
 
 use function Laravel\Prompts\info;
@@ -22,6 +24,7 @@ class AuthToken extends BaseCommand implements NoAuthRequired
     protected $signature = 'auth:token
                             {--add : Add a new API token}
                             {--remove : Remove an API token}
+                            {--token= : The API token to add or remove, for non-interactive use (may also be piped to STDIN)}
                             {--reveal : Reveal the config file in Finder}
                             {--list : List API tokens}';
 
@@ -62,6 +65,10 @@ class AuthToken extends BaseCommand implements NoAuthRequired
             return self::SUCCESS;
         }
 
+        if (! $this->isInteractive()) {
+            $this->failAndExit('Choose an action: --add, --remove, or --list.');
+        }
+
         $action = select(
             label: 'What would you like to do?',
             options: [
@@ -84,63 +91,131 @@ class AuthToken extends BaseCommand implements NoAuthRequired
      */
     protected function addToken(Collection $existingTokens): void
     {
-        info('Learn how to create an API token: https://cloud.laravel.com/docs/api/authentication#create-an-api-token');
+        $newToken = $this->tokenFromInput();
 
-        $newToken = password(
-            label: 'Laravel Cloud API token',
-            required: true,
-        );
+        if ($newToken === null) {
+            if (! $this->isInteractive()) {
+                $this->failAndExit('No API token given. Pass --token=<token> or pipe the token to STDIN.');
+            }
 
-        $this->config->addApiToken($newToken);
+            info('Learn how to create an API token: https://cloud.laravel.com/docs/api/authentication#create-an-api-token');
 
-        outro('API token saved to '.$this->config->path());
+            $newToken = password(
+                label: 'Laravel Cloud API token',
+                required: true,
+            );
+        }
+
+        if ($existingTokens->contains($newToken)) {
+            $message = 'API token already saved in '.$this->config->path();
+        } else {
+            $this->config->addApiToken($newToken);
+
+            $message = 'API token saved to '.$this->config->path();
+        }
+
+        $this->warnAboutEnvironmentToken();
+
+        $this->writeJsonIfWanted($message);
+
+        outro($message);
     }
 
     protected function removeToken(Collection $existingTokens): void
     {
         if ($existingTokens->isEmpty()) {
-            warning('No API tokens to remove.');
+            $this->outputErrorOrThrow('No API tokens to remove.');
 
             throw new CommandExitException(self::FAILURE);
         }
 
-        $token = select(
-            label: 'Select a token to remove',
-            options: $existingTokens,
-        );
+        $token = $this->tokenFromInput();
+
+        if ($token !== null && ! $existingTokens->contains($token)) {
+            $this->failAndExit('Provided API token is not saved in '.$this->config->path().'.');
+        }
+
+        if ($token === null) {
+            if (! $this->isInteractive()) {
+                $this->failAndExit('No API token given. Pass --token=<token> or pipe the token to STDIN.');
+            }
+
+            $token = select(
+                label: 'Select a token to remove',
+                options: $existingTokens,
+            );
+        }
 
         $this->config->removeApiToken($token);
+
+        $this->writeJsonIfWanted('API token removed');
 
         outro('API token removed');
     }
 
     protected function listTokens(Collection $existingTokens): void
     {
+        $sources = $existingTokens
+            ->map(fn ($token) => ['token' => $token, 'source' => $this->config->path()])
+            ->when(
+                Cloud::apiTokenFromEnvironment(),
+                fn ($tokens, $envToken) => $tokens->prepend(['token' => $envToken, 'source' => Cloud::API_TOKEN_ENV_VAR]),
+            );
+
+        if ($sources->isEmpty()) {
+            $this->outputErrorOrThrow('No API tokens found.');
+
+            throw new CommandExitException(self::FAILURE);
+        }
+
         $orgs = spin(
-            function () use ($existingTokens) {
-                return $existingTokens->map(function ($token) {
-                    $client = new Connector($token);
+            function () use ($sources) {
+                return $sources->map(function ($entry) {
+                    $organization = (new Connector($entry['token']))->meta()->organization();
 
-                    $organization = $client->meta()->organization();
-
-                    return [
-                        'token' => $token,
-                        'organization' => $organization->name,
-                    ];
+                    return [...$entry, 'organization' => $organization->name];
                 });
             },
             'Fetching token details',
         );
 
-        if ($orgs->isEmpty()) {
-            warning('No API tokens found.');
-
-            throw new CommandExitException(self::FAILURE);
-        }
+        $this->outputJsonIfWanted($orgs->values());
 
         table(
-            headers: ['Organization', 'API Token'],
-            rows: $orgs->map(fn ($org) => [$org['organization'], $org['token']]),
+            headers: ['Organization', 'API Token', 'Source'],
+            rows: $orgs->map(fn ($org) => [$org['organization'], $org['token'], $org['source']]),
         );
+    }
+
+    protected function tokenFromInput(): ?string
+    {
+        $token = $this->option('token') ?: app(Stdin::class)->read();
+
+        if ($token === null || trim($token) === '') {
+            return null;
+        }
+
+        return trim($token);
+    }
+
+    /**
+     * A saved token is dead weight while the environment variable is set, so say so
+     * rather than let the next command look like it ignored the token we just stored.
+     */
+    protected function warnAboutEnvironmentToken(): void
+    {
+        if (! Cloud::apiTokenFromEnvironment()) {
+            return;
+        }
+
+        $message = Cloud::API_TOKEN_ENV_VAR.' is set in your environment and takes precedence over saved tokens. Unset it to use the tokens in '.$this->config->path().'.';
+
+        if ($this->wantsJson()) {
+            fwrite(STDERR, json_encode(['warning' => true, 'message' => $message]).PHP_EOL);
+
+            return;
+        }
+
+        warning($message);
     }
 }

--- a/app/Concerns/HasAClient.php
+++ b/app/Concerns/HasAClient.php
@@ -3,6 +3,7 @@
 namespace App\Concerns;
 
 use App\Client\Connector;
+use App\Cloud;
 use App\Commands\Auth;
 use App\ConfigRepository;
 use App\LocalConfig;
@@ -30,6 +31,10 @@ trait HasAClient
 
     protected function ensureApiTokenExists(): void
     {
+        if (Cloud::apiTokenFromEnvironment()) {
+            return;
+        }
+
         $config = app(ConfigRepository::class);
         $apiTokens = $config->apiTokens();
 
@@ -42,6 +47,14 @@ trait HasAClient
 
     protected function resolveApiToken(bool $ignoreLocalConfig = false, ?string $organization = null): string
     {
+        if ($envToken = Cloud::apiTokenFromEnvironment()) {
+            if ($organization) {
+                $this->assertEnvironmentTokenBelongsTo($envToken, $organization);
+            }
+
+            return $envToken;
+        }
+
         $config = app(ConfigRepository::class);
         $apiTokens = $config->apiTokens();
 
@@ -118,11 +131,37 @@ trait HasAClient
         }
 
         if (! stream_isatty(STDIN) && ! $this->isAgentEnvironment()) {
-            throw new RuntimeException('Not authenticated. Run `cloud auth` or `cloud auth:token --add` to add an API token.');
+            throw new RuntimeException('Not authenticated. Run `cloud auth`, set '.Cloud::API_TOKEN_ENV_VAR.' in your environment, or run `cloud auth:token --add --token=<token>` to save one.');
         }
 
         Artisan::call(Auth::class);
 
         return $this->resolveApiToken($ignoreLocalConfig);
+    }
+
+    /**
+     * An explicitly named organization is an assertion, not a selector: the environment
+     * holds one token, so a mismatch means the wrong credential, not the wrong choice.
+     */
+    protected function assertEnvironmentTokenBelongsTo(string $token, string $organization): void
+    {
+        $config = app(ConfigRepository::class);
+
+        try {
+            $org = spin(
+                fn () => (new Connector($token))->meta()->organization(),
+                'Verifying organization',
+            );
+        } catch (RequestException $e) {
+            if ($e->getResponse()->status() === 401) {
+                throw new RuntimeException('The API token in '.Cloud::API_TOKEN_ENV_VAR.' was rejected. Check that variable, or unset it to use the tokens in '.$config->path().'.');
+            }
+
+            throw $e;
+        }
+
+        if (! in_array($organization, [$org->id, $org->name, $org->slug], true)) {
+            throw new RuntimeException('The API token in '.Cloud::API_TOKEN_ENV_VAR." belongs to [{$org->name}], not [{$organization}]. Unset that variable to use the tokens in ".$config->path().'.');
+        }
     }
 }

--- a/app/Support/Stdin.php
+++ b/app/Support/Stdin.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Support;
+
+class Stdin
+{
+    /**
+     * Read piped input, or null when STDIN is a terminal or carries nothing.
+     */
+    public function read(): ?string
+    {
+        if (stream_isatty(STDIN)) {
+            return null;
+        }
+
+        $contents = stream_get_contents(STDIN);
+
+        if ($contents === false || trim($contents) === '') {
+            return null;
+        }
+
+        return trim($contents);
+    }
+}

--- a/config/cloud.php
+++ b/config/cloud.php
@@ -12,12 +12,14 @@
 |
 */
 
-$defaultUrl = 'https://cloud.laravel.com';
+use App\Cloud;
 
 return [
 
-    'default_url' => $defaultUrl,
+    'default_url' => Cloud::DEFAULT_URL,
 
-    'base_url' => rtrim(env('CLOUD_BASE_URL') ?: $defaultUrl, '/'),
+    'base_url' => rtrim(env('CLOUD_BASE_URL') ?: Cloud::DEFAULT_URL, '/'),
+
+    'api_token' => env(Cloud::API_TOKEN_ENV_VAR),
 
 ];

--- a/skills/deploying-laravel-cloud/SKILL.md
+++ b/skills/deploying-laravel-cloud/SKILL.md
@@ -11,6 +11,8 @@ composer global require laravel/cloud-cli
 cloud auth -n
 ```
 
+`cloud auth` opens a browser. Where that isn't possible, set `LARAVEL_CLOUD_TOKEN` in the environment — it overrides any saved token and writes nothing to disk. To save a token instead: `cloud auth:token --add --token=<token> -n`, or pipe it: `echo "$TOKEN" | cloud auth:token --add -n`.
+
 ## Commands
 
 Commands follow a CRUD pattern: `resource:list`, `resource:get`, `resource:create`, `resource:update`, `resource:delete`.
@@ -156,13 +158,16 @@ Delegate `--detailed --json` to a subagent — the payload includes every databa
 
 ## Config
 
-1. Global: `~/.config/cloud/config.json` — auth tokens and preferences
-2. Repo-local: `.cloud/config.json` — app and environment defaults (set by `cloud repo:config {application} -n`)
-3. CLI arguments override both
+1. Environment: `LARAVEL_CLOUD_TOKEN` — an API token, taking precedence over any saved one (empty counts as unset)
+2. Global: `~/.config/cloud/config.json` — auth tokens and preferences
+3. Repo-local: `.cloud/config.json` — app and environment defaults (set by `cloud repo:config {application} -n`)
+4. CLI arguments override both config files
 
 Pass the application to `repo:config` — without it the command has to ask, and under `-n` it fails when the organization has more than one application. Deploy commands don't need these defaults; pass the application and environment to them directly.
 
 Multiple organizations means multiple stored API tokens. Every command reads `organization_id` from `.cloud/config.json` to pick one; if it isn't set, they fail. Set it with `cloud repo:config {application} --organization=<id|name|slug> -n`.
+
+`LARAVEL_CLOUD_TOKEN` holds one token, so it picks the organization on its own. Naming a different one with `--organization` fails rather than falling back to the token's organization.
 
 ## Documentation
 

--- a/tests/Feature/AuthTokenTest.php
+++ b/tests/Feature/AuthTokenTest.php
@@ -1,0 +1,238 @@
+<?php
+
+use App\Client\Resources\Applications\ListApplicationsRequest;
+use App\Client\Resources\Meta\GetOrganizationRequest;
+use App\Cloud;
+use App\Concerns\HasAClient;
+use App\ConfigRepository;
+use App\Support\Stdin;
+use Illuminate\Support\Facades\Artisan;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+use Saloon\Http\PendingRequest;
+
+beforeEach(function () {
+    $this->mockConfig = Mockery::mock(ConfigRepository::class);
+    $this->mockConfig->shouldReceive('apiTokens')->andReturn(collect(['config-token']))->byDefault();
+    $this->mockConfig->shouldReceive('path')->andReturn('/tmp/cloud-config.json')->byDefault();
+    $this->mockConfig->shouldReceive('addApiToken')->byDefault();
+    $this->mockConfig->shouldReceive('removeApiToken')->byDefault();
+    $this->mockConfig->shouldReceive('setApiTokens')->byDefault();
+    $this->app->instance(ConfigRepository::class, $this->mockConfig);
+
+    $this->mockStdin = Mockery::mock(Stdin::class);
+    $this->mockStdin->shouldReceive('read')->andReturn(null)->byDefault();
+    $this->app->instance(Stdin::class, $this->mockStdin);
+});
+
+afterEach(function () {
+    MockClient::destroyGlobal();
+});
+
+function pipeToStdin(?string $value): void
+{
+    test()->mockStdin->shouldReceive('read')->andReturn($value);
+}
+
+/** Resolves a token straight from the trait, where the organization check lives. */
+function resolveApiTokenFor(?string $organization = null): string
+{
+    return (new class
+    {
+        use HasAClient;
+
+        public function resolve(?string $organization): string
+        {
+            return $this->resolveApiToken(organization: $organization);
+        }
+    })->resolve($organization);
+}
+
+/** Records the bearer token every request was signed with. */
+function recordSigningTokens(string $organizationName = 'My Org'): Closure
+{
+    $seen = collect();
+
+    MockClient::global([
+        GetOrganizationRequest::class => function (PendingRequest $request) use ($seen, $organizationName) {
+            $seen->push(str_replace('Bearer ', '', $request->headers()->get('Authorization') ?? ''));
+
+            return MockResponse::make([
+                'data' => [
+                    'id' => 'org-1',
+                    'type' => 'organizations',
+                    'attributes' => ['name' => $organizationName, 'slug' => 'my-org'],
+                ],
+            ], 200);
+        },
+        ListApplicationsRequest::class => function (PendingRequest $request) use ($seen) {
+            $seen->push(str_replace('Bearer ', '', $request->headers()->get('Authorization') ?? ''));
+
+            return MockResponse::make([
+                'data' => [createApplicationResponse()],
+                'included' => [
+                    ['id' => 'org-1', 'type' => 'organizations', 'attributes' => ['name' => 'My Org', 'slug' => 'my-org']],
+                    ['id' => 'env-1', 'type' => 'environments', 'attributes' => ['name' => 'production', 'slug' => 'production', 'vanity_domain' => 'my-app.cloud.laravel.com', 'status' => 'running', 'php_major_version' => '8.3']],
+                ],
+                'links' => ['next' => null],
+            ], 200);
+        },
+    ]);
+
+    return fn () => $seen;
+}
+
+it('reads the api token from the environment', function () {
+    config()->set('cloud.api_token', 'env-token');
+
+    expect(Cloud::apiTokenFromEnvironment())->toBe('env-token');
+});
+
+it('treats a blank environment token as unset so it can be bypassed per command', function (?string $value) {
+    config()->set('cloud.api_token', $value);
+
+    expect(Cloud::apiTokenFromEnvironment())->toBeNull();
+})->with([null, '', '   ']);
+
+it('trims surrounding whitespace from the environment token', function () {
+    config()->set('cloud.api_token', "  env-token\n");
+
+    expect(Cloud::apiTokenFromEnvironment())->toBe('env-token');
+});
+
+it('signs requests with the environment token in preference to the saved token', function () {
+    config()->set('cloud.api_token', 'env-token');
+    $tokens = recordSigningTokens();
+
+    Artisan::call('application:list', ['--json' => true, '--no-interaction' => true]);
+
+    expect($tokens()->unique()->values()->all())->toBe(['env-token']);
+});
+
+it('falls back to the saved token when no environment token is set', function () {
+    config()->set('cloud.api_token', null);
+    $tokens = recordSigningTokens();
+
+    Artisan::call('application:list', ['--json' => true, '--no-interaction' => true]);
+
+    expect($tokens()->unique()->values()->all())->toBe(['config-token']);
+});
+
+it('authenticates from the environment when no token is saved', function () {
+    config()->set('cloud.api_token', 'env-token');
+    $this->mockConfig->shouldReceive('apiTokens')->andReturn(collect());
+    $tokens = recordSigningTokens();
+
+    Artisan::call('application:list', ['--json' => true, '--no-interaction' => true]);
+
+    expect($tokens()->unique()->values()->all())->toBe(['env-token']);
+});
+
+it('rejects an explicitly named organization the environment token does not belong to', function () {
+    config()->set('cloud.api_token', 'env-token');
+    recordSigningTokens(organizationName: 'Acme');
+
+    expect(fn () => resolveApiTokenFor('globex'))
+        ->toThrow(RuntimeException::class, 'The API token in LARAVEL_CLOUD_TOKEN belongs to [Acme], not [globex].');
+});
+
+it('accepts an explicitly named organization the environment token belongs to', function (string $organization) {
+    config()->set('cloud.api_token', 'env-token');
+    recordSigningTokens(organizationName: 'Acme');
+
+    expect(resolveApiTokenFor($organization))->toBe('env-token');
+})->with(['org-1', 'Acme', 'my-org']);
+
+it('does not check the organization when none is named', function () {
+    config()->set('cloud.api_token', 'env-token');
+    $tokens = recordSigningTokens();
+
+    expect(resolveApiTokenFor())->toBe('env-token');
+    expect($tokens()->all())->toBeEmpty();
+});
+
+it('reports a rejected environment token against the environment variable', function () {
+    config()->set('cloud.api_token', 'env-token');
+
+    MockClient::global([
+        GetOrganizationRequest::class => MockResponse::make(['message' => 'Unauthenticated.'], 401),
+    ]);
+
+    expect(fn () => resolveApiTokenFor('acme'))
+        ->toThrow(RuntimeException::class, 'The API token in LARAVEL_CLOUD_TOKEN was rejected.');
+});
+
+it('adds a token given with the token option', function () {
+    $this->mockConfig->shouldReceive('addApiToken')->once()->with('new-token');
+
+    Artisan::call('auth:token', ['--add' => true, '--token' => 'new-token', '--no-interaction' => true]);
+});
+
+it('adds a token piped to stdin', function () {
+    pipeToStdin("new-token\n");
+    $this->mockConfig->shouldReceive('addApiToken')->once()->with('new-token');
+
+    Artisan::call('auth:token', ['--add' => true, '--no-interaction' => true]);
+});
+
+it('prefers the token option over stdin', function () {
+    pipeToStdin('piped-token');
+    $this->mockConfig->shouldReceive('addApiToken')->once()->with('flag-token');
+
+    Artisan::call('auth:token', ['--add' => true, '--token' => 'flag-token', '--no-interaction' => true]);
+});
+
+it('does not save a token twice', function () {
+    $this->mockConfig->shouldReceive('addApiToken')->never();
+
+    Artisan::call('auth:token', ['--add' => true, '--token' => 'config-token', '--no-interaction' => true]);
+});
+
+it('explains how to supply a token when adding one non-interactively with no input', function () {
+    $this->mockConfig->shouldReceive('addApiToken')->never();
+
+    $exitCode = Artisan::call('auth:token', ['--add' => true, '--no-interaction' => true]);
+
+    expect($exitCode)->toBe(1);
+});
+
+it('still saves a token when the environment token is set', function () {
+    config()->set('cloud.api_token', 'env-token');
+    $this->mockConfig->shouldReceive('addApiToken')->once()->with('new-token');
+
+    $exitCode = Artisan::call('auth:token', ['--add' => true, '--token' => 'new-token', '--no-interaction' => true]);
+
+    expect($exitCode)->toBe(0);
+});
+
+it('removes a token given with the token option', function () {
+    $this->mockConfig->shouldReceive('removeApiToken')->once()->with('config-token');
+
+    Artisan::call('auth:token', ['--remove' => true, '--token' => 'config-token', '--no-interaction' => true]);
+});
+
+it('refuses to remove a token that is not saved', function () {
+    $this->mockConfig->shouldReceive('removeApiToken')->never();
+
+    $exitCode = Artisan::call('auth:token', ['--remove' => true, '--token' => 'unknown-token', '--no-interaction' => true]);
+
+    expect($exitCode)->toBe(1);
+});
+
+it('lists the environment token alongside saved tokens and names each source', function () {
+    config()->set('cloud.api_token', 'env-token');
+    recordSigningTokens();
+
+    Artisan::call('auth:token', ['--list' => true, '--no-interaction' => true]);
+
+    $listed = collect(json_decode(Artisan::output(), true));
+
+    expect($listed->pluck('token')->all())->toBe(['env-token', 'config-token']);
+    expect($listed->pluck('source')->all())->toBe(['LARAVEL_CLOUD_TOKEN', '/tmp/cloud-config.json']);
+});
+
+it('names an action when none is given non-interactively', function () {
+    $exitCode = Artisan::call('auth:token', ['--no-interaction' => true]);
+
+    expect($exitCode)->toBe(1);
+});

--- a/tests/Feature/RepoConfigTest.php
+++ b/tests/Feature/RepoConfigTest.php
@@ -22,6 +22,7 @@ beforeEach(function () {
     $this->mockConfig = Mockery::mock(ConfigRepository::class);
     $this->mockConfig->shouldReceive('apiTokens')->andReturn(collect(['test-api-token']))->byDefault();
     $this->mockConfig->shouldReceive('setApiTokens')->byDefault();
+    $this->mockConfig->shouldReceive('path')->andReturn(sys_get_temp_dir().'/cloud-config.json')->byDefault();
     $this->app->instance(ConfigRepository::class, $this->mockConfig);
 });
 
@@ -184,6 +185,31 @@ it('fails when --organization does not match the only token', function () {
     setupApplicationListMocks();
 
     $exitCode = Artisan::call('repo:config', ['--organization' => 'Initech', '--no-interaction' => true]);
+
+    expect($exitCode)->toBe(1);
+    expect(File::exists($this->repoRoot.'/.cloud/config.json'))->toBeFalse();
+});
+
+it('configures the repository from a token in the environment', function () {
+    config()->set('cloud.api_token', 'env-token');
+    $this->mockConfig->shouldReceive('apiTokens')->andReturn(collect());
+    setupApplicationListMocks();
+
+    $exitCode = Artisan::call('repo:config', ['application' => 'My App', '--organization' => 'my-org', '--no-interaction' => true]);
+
+    expect($exitCode)->toBe(0);
+    expect(File::json($this->repoRoot.'/.cloud/config.json'))->toMatchArray([
+        'organization_id' => 'org-1',
+        'application_id' => 'app-123',
+    ]);
+});
+
+it('refuses to configure the repository for an organization the environment token does not belong to', function () {
+    config()->set('cloud.api_token', 'env-token');
+    $this->mockConfig->shouldReceive('apiTokens')->andReturn(collect());
+    setupApplicationListMocks();
+
+    $exitCode = Artisan::call('repo:config', ['application' => 'My App', '--organization' => 'globex', '--no-interaction' => true]);
 
     expect($exitCode)->toBe(1);
     expect(File::exists($this->repoRoot.'/.cloud/config.json'))->toBeFalse();


### PR DESCRIPTION
There was no way to give the CLI a token without a TTY. `cloud auth` needs a browser and `auth:token --add` always prompted, so the only option in CI was hand-writing `~/.config/cloud/config.json` at a path that changes with `CLOUD_BASE_URL`.

The CLI now reads `LARAVEL_CLOUD_TOKEN` from the environment. It takes precedence over saved tokens and writes nothing to disk. An empty value counts as unset, so you can bypass it for a single command.

`auth:token --add` and `--remove` accept `--token=` or the token piped to stdin, and report the result as JSON when run non-interactively.

The environment holds one token, so it picks its own organization. Naming a different one with `--organization` now fails rather than quietly using the token's. `auth` and `auth:token --add` warn when a token you just saved is being overridden by the environment, and `auth:token --list` names where each token came from.

This also clears up a few non-interactive dead ends that returned a bare "Required.": adding with no token, removing a token that isn't saved, and running `auth:token` with no action flag.
