### PR TITLE
Fix self-update 404

### DIFF
--- a/config/updater.php
+++ b/config/updater.php
@@ -1,6 +1,6 @@
 <?php
 
-use LaravelZero\Framework\Components\Updater\Strategy\GithubReleasesStrategy;
+use LaravelZero\Framework\Components\Updater\Strategy\GithubStrategy;
 
 return [
 
@@ -15,6 +15,6 @@ return [
     |
     */
 
-    'strategy' => GithubReleasesStrategy::class,
+    'strategy' => GithubStrategy::class,
 
 ];

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -1,7 +1,24 @@
 <?php
 
+use Humbug\SelfUpdate\Strategy\GithubStrategy;
+
 it('keeps env() out of config/app.php', function () {
     // `app:build` evaluates config/app.php and bakes the resulting array into the phar, so any
     // env() call there is frozen at build time and ignored by the binary. Put it elsewhere.
     expect(file_get_contents(base_path('config/app.php')))->not->toContain('env(');
+});
+
+it('points self-update at a strategy that names the file to download', function () {
+    // GithubReleasesStrategy builds `releases/download/{version}/{pharName}`, and nothing ever
+    // calls setPharName(), so the URL loses its filename and 404s. GithubStrategy appends the
+    // running binary's own name to the tagged `builds/` path instead.
+    $strategy = app(config('updater.strategy'));
+
+    (new ReflectionProperty(GithubStrategy::class, 'remoteVersion'))
+        ->setValue($strategy, 'v9.9.9');
+
+    $url = (new ReflectionMethod($strategy, 'getDownloadUrl'))
+        ->invoke($strategy, ['source' => ['url' => 'https://github.com/laravel/cloud-cli.git']]);
+
+    expect($url)->toMatch('#^https://github\\.com/laravel/cloud-cli/raw/v9\\.9\\.9/+builds/#');
 });


### PR DESCRIPTION
`cloud self-update` always failed with a 404. We configured the updater to use `GithubReleasesStrategy`, which builds its download URL as `releases/download/{version}/{pharName}`, but nothing ever calls `setPharName()`, so the URL had no filename on the end.

Switched to Laravel Zero's default `GithubStrategy`, which downloads `builds/cloud` from the tagged commit and fills in the filename itself. `release.sh` already commits the binary before tagging, so every tag has it.

Verified by building a phar stamped v0.5.0 and running `self-update` against it, which correctly pulled down v0.5.1.

Note that anyone on v0.5.1 or earlier still cannot self-update to the release carrying this fix, since the broken updater is the one doing the work. They will need to reinstall once.

Closes #196
