### PR TITLE
Mask API tokens in auth:token --list

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ Prefer the pipe where the process list is visible to others. `--remove` takes `-
 cloud auth:token --list -n
 ```
 
+Listed tokens are masked down to their last four characters. Pass `--show-sensitive` to print them in full.
+
 The token carries its own organization, so `--organization` becomes a check rather than a choice: when `LARAVEL_CLOUD_TOKEN` is set and you name an organization the token doesn't belong to, the command fails instead of using the wrong one.
 
 ## Repository configuration

--- a/app/Commands/AuthToken.php
+++ b/app/Commands/AuthToken.php
@@ -6,7 +6,9 @@ use App\Client\Connector;
 use App\Cloud;
 use App\ConfigRepository;
 use App\Contracts\NoAuthRequired;
+use App\Dto\ApiToken;
 use App\Exceptions\CommandExitException;
+use App\Support\SensitiveValues;
 use App\Support\Stdin;
 use Illuminate\Support\Collection;
 
@@ -155,6 +157,8 @@ class AuthToken extends BaseCommand implements NoAuthRequired
 
     protected function listTokens(Collection $existingTokens): void
     {
+        SensitiveValues::$reveal = (bool) $this->option('show-sensitive');
+
         $sources = $existingTokens
             ->map(fn ($token) => ['token' => $token, 'source' => $this->config->path()])
             ->when(
@@ -173,7 +177,11 @@ class AuthToken extends BaseCommand implements NoAuthRequired
                 return $sources->map(function ($entry) {
                     $organization = (new Connector($entry['token']))->meta()->organization();
 
-                    return [...$entry, 'organization' => $organization->name];
+                    return new ApiToken(
+                        organization: $organization->name,
+                        token: $entry['token'],
+                        source: $entry['source'],
+                    );
                 });
             },
             'Fetching token details',
@@ -183,7 +191,11 @@ class AuthToken extends BaseCommand implements NoAuthRequired
 
         table(
             headers: ['Organization', 'API Token', 'Source'],
-            rows: $orgs->map(fn ($org) => [$org['organization'], $org['token'], $org['source']]),
+            rows: $orgs->map(fn (ApiToken $entry) => [
+                $entry->organization,
+                SensitiveValues::maskWithSuffix($entry->token),
+                $entry->source,
+            ]),
         );
     }
 

--- a/app/Dto/ApiToken.php
+++ b/app/Dto/ApiToken.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Dto;
+
+use App\Dto\Transformers\MaskSensitiveSuffix;
+use Spatie\LaravelData\Attributes\WithTransformer;
+use Spatie\LaravelData\Data;
+
+class ApiToken extends Data
+{
+    public function __construct(
+        public readonly string $organization,
+        #[WithTransformer(MaskSensitiveSuffix::class)]
+        public readonly string $token,
+        public readonly string $source,
+    ) {
+        //
+    }
+}

--- a/app/Dto/Transformers/MaskSensitiveSuffix.php
+++ b/app/Dto/Transformers/MaskSensitiveSuffix.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Dto\Transformers;
+
+use App\Support\SensitiveValues;
+use Spatie\LaravelData\Support\DataProperty;
+use Spatie\LaravelData\Support\Transformation\TransformationContext;
+use Spatie\LaravelData\Transformers\Transformer;
+
+class MaskSensitiveSuffix implements Transformer
+{
+    public function transform(DataProperty $property, mixed $value, TransformationContext $context): mixed
+    {
+        if (! is_string($value)) {
+            return $value;
+        }
+
+        return SensitiveValues::maskWithSuffix($value);
+    }
+}

--- a/app/Support/SensitiveValues.php
+++ b/app/Support/SensitiveValues.php
@@ -12,4 +12,18 @@ class SensitiveValues
     {
         return (bool) preg_match('/pass|secret|token|credential|private|dsn|url|uri/i', $key);
     }
+
+    /** Keeps the last few characters so tokens sharing an organization stay tellable apart. */
+    public static function maskWithSuffix(string $value, int $suffix = 4): string
+    {
+        if (static::$reveal) {
+            return $value;
+        }
+
+        if (mb_strlen($value) <= $suffix) {
+            return static::MASK;
+        }
+
+        return static::MASK.mb_substr($value, -$suffix);
+    }
 }

--- a/tests/Feature/AuthTokenTest.php
+++ b/tests/Feature/AuthTokenTest.php
@@ -5,6 +5,7 @@ use App\Client\Resources\Meta\GetOrganizationRequest;
 use App\Cloud;
 use App\Concerns\HasAClient;
 use App\ConfigRepository;
+use App\Support\SensitiveValues;
 use App\Support\Stdin;
 use Illuminate\Support\Facades\Artisan;
 use Saloon\Http\Faking\MockClient;
@@ -27,6 +28,7 @@ beforeEach(function () {
 
 afterEach(function () {
     MockClient::destroyGlobal();
+    SensitiveValues::$reveal = false;
 });
 
 function pipeToStdin(?string $value): void
@@ -227,8 +229,44 @@ it('lists the environment token alongside saved tokens and names each source', f
 
     $listed = collect(json_decode(Artisan::output(), true));
 
-    expect($listed->pluck('token')->all())->toBe(['env-token', 'config-token']);
     expect($listed->pluck('source')->all())->toBe(['LARAVEL_CLOUD_TOKEN', '/tmp/cloud-config.json']);
+    expect($listed->pluck('organization')->all())->toBe(['My Org', 'My Org']);
+});
+
+it('masks listed tokens down to their last four characters by default', function () {
+    config()->set('cloud.api_token', 'env-token');
+    recordSigningTokens();
+
+    Artisan::call('auth:token', ['--list' => true, '--no-interaction' => true]);
+
+    $output = Artisan::output();
+
+    expect($output)
+        ->not->toContain('env-token')
+        ->not->toContain('config-token');
+
+    expect(collect(json_decode($output, true))->pluck('token')->all())
+        ->toBe(['*****oken', '*****oken']);
+});
+
+it('reveals listed tokens when --show-sensitive is passed', function () {
+    config()->set('cloud.api_token', 'env-token');
+    recordSigningTokens();
+
+    Artisan::call('auth:token', ['--list' => true, '--no-interaction' => true, '--show-sensitive' => true]);
+
+    expect(collect(json_decode(Artisan::output(), true))->pluck('token')->all())
+        ->toBe(['env-token', 'config-token']);
+});
+
+it('masks a token too short to keep a suffix from', function () {
+    config()->set('cloud.api_token', null);
+    $this->mockConfig->shouldReceive('apiTokens')->andReturn(collect(['abcd']));
+    recordSigningTokens();
+
+    Artisan::call('auth:token', ['--list' => true, '--no-interaction' => true]);
+
+    expect(collect(json_decode(Artisan::output(), true))->pluck('token')->all())->toBe(['*****']);
 });
 
 it('names an action when none is given non-interactively', function () {

--- a/tests/Unit/MaskSensitiveValuesTest.php
+++ b/tests/Unit/MaskSensitiveValuesTest.php
@@ -85,3 +85,17 @@ it('handles empty environmentVariables arrays', function () {
 
     expect($env->toArray()['environmentVariables'])->toBe([]);
 });
+
+it('keeps the last four characters when masking with a suffix', function () {
+    expect(SensitiveValues::maskWithSuffix('cloud-token-abcdef'))->toBe('*****cdef');
+});
+
+it('masks a value entirely when it is no longer than the suffix', function (string $value) {
+    expect(SensitiveValues::maskWithSuffix($value))->toBe('*****');
+})->with(['', 'ab', 'abcd']);
+
+it('returns the whole value when revealing', function () {
+    SensitiveValues::$reveal = true;
+
+    expect(SensitiveValues::maskWithSuffix('cloud-token-abcdef'))->toBe('cloud-token-abcdef');
+});


### PR DESCRIPTION
`auth:token --list` printed saved API tokens in full, in the table and in the JSON. Every other secret in the CLI is masked by default, and this one is the most valuable of the lot: `--list` is documented with `-n`, which means JSON, so a live credential ends up in CI logs and agent transcripts from a command whose job is just to name the source of each token.

Tokens now show as `*****` plus their last four characters, which is enough to tell apart two tokens for the same organization. `--show-sensitive` prints them in full.

The masking elsewhere runs through DTO transformers, but this command built a raw array, so nothing applied. It now builds an `ApiToken` DTO, which also keeps `--show-sensitive` working.
