### PR TITLE
fix database API compatibility

### DIFF
--- a/app/Client/Resources/DatabaseRestores/CreateDatabaseRestoreRequest.php
+++ b/app/Client/Resources/DatabaseRestores/CreateDatabaseRestoreRequest.php
@@ -24,7 +24,7 @@ class CreateDatabaseRestoreRequest extends Request implements HasBody
 
     public function resolveEndpoint(): string
     {
-        return "/databases/clusters/{$this->data->clusterId}/restores";
+        return "/databases/clusters/{$this->data->clusterId}/restore";
     }
 
     protected function defaultBody(): array

--- a/app/Commands/DatabaseClusterDelete.php
+++ b/app/Commands/DatabaseClusterDelete.php
@@ -26,7 +26,7 @@ class DatabaseClusterDelete extends BaseCommand
 
         $database = $this->resolvers()->databaseCluster()->from($this->argument('database'));
         $schemas = spin(
-            fn () => $this->client->databaseClusters()->include('schemas')->get($database->id)->schemas,
+            fn () => $this->client->databaseClusters()->include('databases')->get($database->id)->schemas,
             'Fetching database cluster schemas...',
         );
 

--- a/app/Commands/DatabaseClusterList.php
+++ b/app/Commands/DatabaseClusterList.php
@@ -28,7 +28,7 @@ class DatabaseClusterList extends BaseCommand
         intro('Database Clusters');
 
         $databases = spin(
-            fn () => $this->client->databaseClusters()->include('schemas')->list(),
+            fn () => $this->client->databaseClusters()->include('databases')->list(),
             'Fetching databases...',
         );
 

--- a/app/Commands/EnvironmentUpdate.php
+++ b/app/Commands/EnvironmentUpdate.php
@@ -145,7 +145,7 @@ class EnvironmentUpdate extends BaseCommand
     protected function selectDatabase(?string $value, ?string $currentId): string
     {
         $clusters = spin(
-            fn () => $this->client->databaseClusters()->include('schemas')->list()->collect(),
+            fn () => $this->client->databaseClusters()->include('databases')->list()->collect(),
             'Fetching databases...',
         );
 

--- a/app/Commands/Ship.php
+++ b/app/Commands/Ship.php
@@ -373,7 +373,7 @@ class Ship extends BaseCommand
             $cluster = $this->getDatabaseCluster();
 
             if ($cluster) {
-                $cluster = $this->client->databaseClusters()->include('schemas')->get($cluster->id);
+                $cluster = $this->client->databaseClusters()->include('databases')->get($cluster->id);
                 $database = $this->getDatabase($cluster);
                 $environmentParams['database_schema_id'] = $database->id;
             }
@@ -587,7 +587,7 @@ class Ship extends BaseCommand
 
         if (! $cluster) {
             $cluster = $this->createDatabaseClusterWithOptions($type->type, $preset, $name, $region);
-            $cluster = $this->client->databaseClusters()->include('schemas')->get($cluster->id);
+            $cluster = $this->client->databaseClusters()->include('databases')->get($cluster->id);
         }
 
         return $this->loopUntilValid(
@@ -721,7 +721,7 @@ class Ship extends BaseCommand
 
     protected function getDatabaseCluster(): ?DatabaseCluster
     {
-        $databasesPaginator = $this->client->databaseClusters()->include('schemas')->list();
+        $databasesPaginator = $this->client->databaseClusters()->include('databases')->list();
         $databases = $databasesPaginator->collect();
 
         if ($databases->isEmpty()) {

--- a/app/Dto/DatabaseCluster.php
+++ b/app/Dto/DatabaseCluster.php
@@ -49,11 +49,20 @@ class DatabaseCluster extends Data
             'updatedAt' => $attributes['updated_at'] ?? null,
         ];
 
-        $schemaData = collect($included)
-            ->filter(fn ($item) => $item['type'] === 'databaseSchemas')
+        $schemas = collect($included)->filter(fn ($item) => $item['type'] === 'databaseSchemas');
+
+        // List responses share one `included` array across every cluster, so the
+        // relationship is the only thing tying a schema to its own cluster.
+        if (isset($data['relationships']['databases']['data'])) {
+            $schemaIds = collect($data['relationships']['databases']['data'])->pluck('id');
+
+            $schemas = $schemas->filter(fn ($item) => $schemaIds->contains($item['id']));
+        }
+
+        $transformed['schemas'] = $schemas
+            ->map(fn ($item) => Database::createFromResponse(['data' => $item, 'included' => $included])->toArray())
             ->values()
             ->toArray();
-        $transformed['schemas'] = collect($schemaData)->map(fn ($item) => Database::createFromResponse(['data' => $item, 'included' => $included])->toArray())->toArray();
 
         return self::from($transformed);
     }

--- a/app/Resolvers/DatabaseClusterResolver.php
+++ b/app/Resolvers/DatabaseClusterResolver.php
@@ -34,7 +34,7 @@ class DatabaseClusterResolver extends Resolver
         return $this->resolveFromIdentifier(
             $identifier,
             fn () => spin(
-                fn () => $this->client->databaseClusters()->include('schemas')->get($identifier),
+                fn () => $this->client->databaseClusters()->include('databases')->get($identifier),
                 'Fetching database...',
             ),
             fn () => $this->fetchAndFind($identifier),
@@ -82,7 +82,7 @@ class DatabaseClusterResolver extends Resolver
     protected function fetchAll(): Collection
     {
         return collect(spin(
-            fn () => $this->client->databaseClusters()->include('schemas')->list()->items(),
+            fn () => $this->client->databaseClusters()->include('databases')->list()->items(),
             'Fetching databases...',
         ));
     }

--- a/tests/Feature/DatabaseClusterDeleteTest.php
+++ b/tests/Feature/DatabaseClusterDeleteTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use App\Client\Resources\DatabaseClusters\DeleteDatabaseClusterRequest;
+use App\Client\Resources\DatabaseClusters\GetDatabaseClusterRequest;
+use App\Client\Resources\Meta\GetOrganizationRequest;
+use App\ConfigRepository;
+use Illuminate\Support\Sleep;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+
+beforeEach(function () {
+    Sleep::fake();
+
+    $config = Mockery::mock(ConfigRepository::class);
+    $config->shouldReceive('apiTokens')->andReturn(collect(['test-api-token']));
+    $this->app->instance(ConfigRepository::class, $config);
+});
+
+afterEach(function () {
+    MockClient::destroyGlobal();
+});
+
+it('requests databases before deleting a cluster', function () {
+    MockClient::global([
+        GetOrganizationRequest::class => MockResponse::make(organizationResponse(), 200),
+        GetDatabaseClusterRequest::class => MockResponse::make(databaseClusterResponse(), 200),
+        DeleteDatabaseClusterRequest::class => MockResponse::make([], 204),
+    ]);
+
+    $this->artisan('database-cluster:delete', [
+        'database' => 'db-123',
+        '--force' => true,
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+
+    $clusterRequests = collect(MockClient::global()->getRecordedResponses())
+        ->map(fn ($response) => $response->getRequest())
+        ->filter(fn ($request) => $request instanceof GetDatabaseClusterRequest);
+
+    expect($clusterRequests)->toHaveCount(2);
+
+    $clusterRequests->each(
+        fn ($request) => expect($request->query()->get('include'))->toBe('databases'),
+    );
+});

--- a/tests/Feature/DatabaseClusterDeleteTest.php
+++ b/tests/Feature/DatabaseClusterDeleteTest.php
@@ -2,6 +2,7 @@
 
 use App\Client\Resources\DatabaseClusters\DeleteDatabaseClusterRequest;
 use App\Client\Resources\DatabaseClusters\GetDatabaseClusterRequest;
+use App\Client\Resources\Databases\DeleteDatabaseRequest;
 use App\Client\Resources\Meta\GetOrganizationRequest;
 use App\ConfigRepository;
 use Illuminate\Support\Sleep;
@@ -24,6 +25,7 @@ it('requests databases before deleting a cluster', function () {
     MockClient::global([
         GetOrganizationRequest::class => MockResponse::make(organizationResponse(), 200),
         GetDatabaseClusterRequest::class => MockResponse::make(databaseClusterResponse(), 200),
+        DeleteDatabaseRequest::class => MockResponse::make([], 204),
         DeleteDatabaseClusterRequest::class => MockResponse::make([], 204),
     ]);
 
@@ -42,4 +44,35 @@ it('requests databases before deleting a cluster', function () {
     $clusterRequests->each(
         fn ($request) => expect($request->query()->get('include'))->toBe('databases'),
     );
+});
+
+it('deletes the schemas returned under the databases include', function () {
+    MockClient::global([
+        GetOrganizationRequest::class => MockResponse::make(organizationResponse(), 200),
+        GetDatabaseClusterRequest::class => MockResponse::make(databaseClusterResponse([
+            'included' => [
+                databaseSchemaResponse(['id' => 'schema-1', 'attributes' => ['name' => 'first']]),
+                databaseSchemaResponse(['id' => 'schema-2', 'attributes' => ['name' => 'second']]),
+            ],
+        ]), 200),
+        DeleteDatabaseRequest::class => MockResponse::make([], 204),
+        DeleteDatabaseClusterRequest::class => MockResponse::make([], 204),
+    ]);
+
+    $this->artisan('database-cluster:delete', [
+        'database' => 'db-123',
+        '--force' => true,
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+
+    $deleted = collect(MockClient::global()->getRecordedResponses())
+        ->map(fn ($response) => $response->getRequest())
+        ->filter(fn ($request) => $request instanceof DeleteDatabaseRequest)
+        ->map(fn ($request) => $request->resolveEndpoint())
+        ->values();
+
+    expect($deleted->all())->toBe([
+        '/databases/clusters/db-123/databases/schema-1',
+        '/databases/clusters/db-123/databases/schema-2',
+    ]);
 });

--- a/tests/Feature/DatabaseClusterListTest.php
+++ b/tests/Feature/DatabaseClusterListTest.php
@@ -3,6 +3,7 @@
 use App\Client\Resources\DatabaseClusters\ListDatabaseClustersRequest;
 use App\Client\Resources\Meta\GetOrganizationRequest;
 use App\ConfigRepository;
+use Illuminate\Support\Facades\Artisan;
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
 
@@ -35,4 +36,36 @@ it('requests databases when listing database clusters', function () {
         return $request instanceof ListDatabaseClustersRequest
             && $request->query()->get('include') === 'databases';
     });
+});
+
+it('reads schemas out of the databases include', function () {
+    $cluster = databaseClusterResponse([
+        'included' => [
+            databaseSchemaResponse(['id' => 'schema-1', 'attributes' => ['name' => 'first']]),
+            databaseSchemaResponse(['id' => 'schema-2', 'attributes' => ['name' => 'second']]),
+        ],
+    ]);
+
+    MockClient::global([
+        GetOrganizationRequest::class => MockResponse::make(organizationResponse(), 200),
+        ListDatabaseClustersRequest::class => MockResponse::make([
+            'data' => [$cluster['data']],
+            'included' => $cluster['included'],
+            'links' => ['next' => null],
+        ], 200),
+    ]);
+
+    $exitCode = Artisan::call('database-cluster:list', [
+        '--json' => true,
+        '--no-interaction' => true,
+    ]);
+
+    expect($exitCode)->toBe(0);
+
+    $output = json_decode(Artisan::output(), true);
+
+    expect($output[0]['schemas'])->toBe([
+        ['id' => 'schema-1', 'name' => 'first', 'createdAt' => '2024-01-15T12:00:00.000000Z'],
+        ['id' => 'schema-2', 'name' => 'second', 'createdAt' => '2024-01-15T12:00:00.000000Z'],
+    ]);
 });

--- a/tests/Feature/DatabaseClusterListTest.php
+++ b/tests/Feature/DatabaseClusterListTest.php
@@ -69,3 +69,63 @@ it('reads schemas out of the databases include', function () {
         ['id' => 'schema-2', 'name' => 'second', 'createdAt' => '2024-01-15T12:00:00.000000Z'],
     ]);
 });
+
+it('scopes schemas to the cluster that owns them', function () {
+    $first = databaseClusterResponse([
+        'id' => 'db-1',
+        'attributes' => ['name' => 'first-cluster'],
+        'included' => [databaseSchemaResponse(['id' => 'schema-1', 'attributes' => ['name' => 'first']])],
+    ]);
+
+    $second = databaseClusterResponse([
+        'id' => 'db-2',
+        'attributes' => ['name' => 'second-cluster'],
+        'included' => [databaseSchemaResponse(['id' => 'schema-2', 'attributes' => ['name' => 'second']])],
+    ]);
+
+    MockClient::global([
+        GetOrganizationRequest::class => MockResponse::make(organizationResponse(), 200),
+        ListDatabaseClustersRequest::class => MockResponse::make([
+            'data' => [$first['data'], $second['data']],
+            'included' => [...$first['included'], ...$second['included']],
+            'links' => ['next' => null],
+        ], 200),
+    ]);
+
+    $exitCode = Artisan::call('database-cluster:list', [
+        '--json' => true,
+        '--no-interaction' => true,
+    ]);
+
+    expect($exitCode)->toBe(0);
+
+    $output = json_decode(Artisan::output(), true);
+
+    expect(collect($output[0]['schemas'])->pluck('name')->all())->toBe(['first']);
+    expect(collect($output[1]['schemas'])->pluck('name')->all())->toBe(['second']);
+});
+
+it('falls back to every included schema when the cluster has no relationships', function () {
+    $cluster = databaseClusterResponse();
+    unset($cluster['data']['relationships']);
+
+    MockClient::global([
+        GetOrganizationRequest::class => MockResponse::make(organizationResponse(), 200),
+        ListDatabaseClustersRequest::class => MockResponse::make([
+            'data' => [$cluster['data']],
+            'included' => $cluster['included'],
+            'links' => ['next' => null],
+        ], 200),
+    ]);
+
+    $exitCode = Artisan::call('database-cluster:list', [
+        '--json' => true,
+        '--no-interaction' => true,
+    ]);
+
+    expect($exitCode)->toBe(0);
+
+    $output = json_decode(Artisan::output(), true);
+
+    expect(collect($output[0]['schemas'])->pluck('name')->all())->toBe(['my_schema']);
+});

--- a/tests/Feature/DatabaseClusterListTest.php
+++ b/tests/Feature/DatabaseClusterListTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use App\Client\Resources\DatabaseClusters\ListDatabaseClustersRequest;
+use App\Client\Resources\Meta\GetOrganizationRequest;
+use App\ConfigRepository;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+
+beforeEach(function () {
+    $config = Mockery::mock(ConfigRepository::class);
+    $config->shouldReceive('apiTokens')->andReturn(collect(['test-api-token']));
+    $this->app->instance(ConfigRepository::class, $config);
+});
+
+afterEach(function () {
+    MockClient::destroyGlobal();
+});
+
+it('requests databases when listing database clusters', function () {
+    MockClient::global([
+        GetOrganizationRequest::class => MockResponse::make(organizationResponse(), 200),
+        ListDatabaseClustersRequest::class => MockResponse::make([
+            'data' => [],
+            'included' => [],
+            'links' => ['next' => null],
+        ], 200),
+    ]);
+
+    $this->artisan('database-cluster:list', [
+        '--json' => true,
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+
+    MockClient::global()->assertSent(function ($request) {
+        return $request instanceof ListDatabaseClustersRequest
+            && $request->query()->get('include') === 'databases';
+    });
+});

--- a/tests/Feature/DatabaseRestoreCreateTest.php
+++ b/tests/Feature/DatabaseRestoreCreateTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Client\Resources\DatabaseClusters\GetDatabaseClusterRequest;
+use App\Client\Resources\DatabaseClusters\ListDatabaseClustersRequest;
 use App\Client\Resources\DatabaseRestores\CreateDatabaseRestoreRequest;
 use App\Client\Resources\Meta\GetOrganizationRequest;
 use App\ConfigRepository;
@@ -44,6 +45,11 @@ it('creates a restore from a snapshot non-interactively', function () {
         '--snapshot' => 'snap-1',
         '--no-interaction' => true,
     ])->assertSuccessful();
+
+    MockClient::global()->assertSent(function ($request) {
+        return $request instanceof GetDatabaseClusterRequest
+            && $request->query()->get('include') === 'databases';
+    });
 });
 
 it('creates a restore from a point-in-time non-interactively', function () {
@@ -53,8 +59,43 @@ it('creates a restore from a point-in-time non-interactively', function () {
         'cluster' => 'db-123',
         'name' => 'my-restore',
         '--point-in-time' => '2024-01-15T12:00:00Z',
+        '--json' => true,
+        '--fields' => 'id,name,status',
         '--no-interaction' => true,
     ])->assertSuccessful();
+
+    MockClient::global()->assertSent(function ($request) {
+        return $request instanceof CreateDatabaseRestoreRequest
+            && $request->resolveEndpoint() === '/databases/clusters/db-123/restore';
+    });
+});
+
+it('requests databases when resolving an omitted cluster', function () {
+    $cluster = databaseClusterResponse();
+
+    MockClient::global([
+        GetOrganizationRequest::class => MockResponse::make(organizationResponse(), 200),
+        ListDatabaseClustersRequest::class => MockResponse::make([
+            'data' => [$cluster['data']],
+            'included' => [],
+            'links' => ['next' => null],
+        ], 200),
+        CreateDatabaseRestoreRequest::class => MockResponse::make(databaseClusterResponse([
+            'id' => 'db-456',
+            'attributes' => ['name' => 'my-restore'],
+        ]), 200),
+    ]);
+
+    $this->artisan('database-restore:create', [
+        'name' => 'my-restore',
+        '--snapshot' => 'snap-1',
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+
+    MockClient::global()->assertSent(function ($request) {
+        return $request instanceof ListDatabaseClustersRequest
+            && $request->query()->get('include') === 'databases';
+    });
 });
 
 it('fails when neither snapshot nor point-in-time is given non-interactively', function () {

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -107,8 +107,23 @@ function setupApplicationListMocks(?array $applications = null, int $status = 20
     ]);
 }
 
+function databaseSchemaResponse(array $overrides = []): array
+{
+    return [
+        'id' => $overrides['id'] ?? 'schema-1',
+        'type' => 'databaseSchemas',
+        'attributes' => array_merge([
+            'name' => 'my_schema',
+            'status' => 'available',
+            'created_at' => '2024-01-15T12:00:00.000000Z',
+        ], $overrides['attributes'] ?? []),
+    ];
+}
+
 function databaseClusterResponse(array $overrides = []): array
 {
+    $schemas = $overrides['included'] ?? [databaseSchemaResponse()];
+
     return [
         'data' => [
             'id' => $overrides['id'] ?? 'db-123',
@@ -121,8 +136,16 @@ function databaseClusterResponse(array $overrides = []): array
                 'config' => [],
                 'connection' => [],
             ], $overrides['attributes'] ?? []),
+            'relationships' => [
+                'databases' => [
+                    'data' => array_map(
+                        fn ($schema) => ['id' => $schema['id'], 'type' => $schema['type']],
+                        $schemas,
+                    ),
+                ],
+            ],
         ],
-        'included' => [],
+        'included' => $schemas,
     ];
 }
 


### PR DESCRIPTION
The CLI still used the deprecated `schemas` relationship for database cluster requests. Laravel Cloud rejects these requests because the accepted include is `databases`.

The database restore request also used the obsolete plural `/restores` endpoint. This route returned the Laravel Cloud HTML page with HTTP 200 instead of an API response. The current API uses the singular `/restore` endpoint.

This change:

- uses `include=databases` for all database cluster requests
- uses the current singular database restore endpoint
- adds feature tests for cluster list, cluster delete, and restore creation
- covers restore creation with a cluster ID and with automatic cluster resolution

A live point-in-time restore completed the request successfully and returned a new cluster with `restoring` status.

API reference: https://laravel.com/cloud/docs/api/database-restores/create-a-database-restore

## Tests

- `vendor/bin/pest tests/Feature/DatabaseClusterDeleteTest.php tests/Feature/DatabaseClusterListTest.php tests/Feature/DatabaseRestoreCreateTest.php`
- `vendor/bin/pint --test`
- `vendor/bin/phpstan analyse --no-progress`