### PR TITLE
Add --root-directory support to application:create and ship

### DIFF
--- a/app/Client/Requests/CreateApplicationRequestData.php
+++ b/app/Client/Requests/CreateApplicationRequestData.php
@@ -8,16 +8,23 @@ class CreateApplicationRequestData extends RequestData
         public readonly string $repository,
         public readonly string $name,
         public readonly string $region,
+        public readonly ?string $rootDirectory = null,
     ) {
         //
     }
 
     public function toRequestData(): array
     {
-        return [
+        $data = [
             'repository' => $this->repository,
             'name' => $this->name,
             'region' => $this->region,
         ];
+
+        if ($this->rootDirectory !== null) {
+            $data['root_directory'] = $this->rootDirectory;
+        }
+
+        return $data;
     }
 }

--- a/app/Client/Requests/CreateApplicationRequestData.php
+++ b/app/Client/Requests/CreateApplicationRequestData.php
@@ -4,13 +4,18 @@ namespace App\Client\Requests;
 
 class CreateApplicationRequestData extends RequestData
 {
+    public readonly ?string $rootDirectory;
+
     public function __construct(
         public readonly string $repository,
         public readonly string $name,
         public readonly string $region,
-        public readonly ?string $rootDirectory = null,
+        ?string $rootDirectory = null,
     ) {
-        //
+        // The API rejects a trailing slash, which is what shell completion gives you.
+        $rootDirectory = rtrim((string) $rootDirectory, '/');
+
+        $this->rootDirectory = $rootDirectory === '' ? null : $rootDirectory;
     }
 
     public function toRequestData(): array

--- a/app/Client/Requests/CreateApplicationRequestData.php
+++ b/app/Client/Requests/CreateApplicationRequestData.php
@@ -15,16 +15,11 @@ class CreateApplicationRequestData extends RequestData
 
     public function toRequestData(): array
     {
-        $data = [
+        return $this->filter([
             'repository' => $this->repository,
             'name' => $this->name,
             'region' => $this->region,
-        ];
-
-        if ($this->rootDirectory !== null) {
-            $data['root_directory'] = $this->rootDirectory;
-        }
-
-        return $data;
+            'root_directory' => $this->rootDirectory,
+        ]);
     }
 }

--- a/app/Commands/ApplicationCreate.php
+++ b/app/Commands/ApplicationCreate.php
@@ -24,7 +24,8 @@ class ApplicationCreate extends BaseCommand
     protected $signature = 'application:create
                             {--name= : Application name}
                             {--repository= : Repository (owner/repo format)}
-                            {--region= : Application region}';
+                            {--region= : Application region}
+                            {--root-directory= : Repository subdirectory containing the app (monorepos)}';
 
     protected $description = 'Create a new application';
 
@@ -100,6 +101,7 @@ class ApplicationCreate extends BaseCommand
                     repository: $this->form()->get('repository'),
                     name: $this->form()->get('name'),
                     region: $this->form()->get('region'),
+                    rootDirectory: $this->option('root-directory') ?: null,
                 ),
             ),
             'Creating application...',

--- a/app/Commands/ApplicationCreate.php
+++ b/app/Commands/ApplicationCreate.php
@@ -95,13 +95,15 @@ class ApplicationCreate extends BaseCommand
                 ->nonInteractively(fn () => $this->getDefaultRegion()),
         );
 
+        $rootDirectory = $this->option('root-directory');
+
         return spin(
             fn () => $this->client->applications()->create(
                 new CreateApplicationRequestData(
                     repository: $this->form()->get('repository'),
                     name: $this->form()->get('name'),
                     region: $this->form()->get('region'),
-                    rootDirectory: $this->option('root-directory') ?: null,
+                    rootDirectory: $rootDirectory === '' ? null : $rootDirectory,
                 ),
             ),
             'Creating application...',

--- a/app/Commands/ApplicationCreate.php
+++ b/app/Commands/ApplicationCreate.php
@@ -95,7 +95,10 @@ class ApplicationCreate extends BaseCommand
                 ->nonInteractively(fn () => $this->getDefaultRegion()),
         );
 
-        $rootDirectory = $this->option('root-directory');
+        // Defined but never prompted, so a validation error can name the value we sent.
+        $this->form()->define('root_directory', fn ($resolver) => $resolver);
+
+        $rootDirectory = $this->form()->get('root_directory');
 
         return spin(
             fn () => $this->client->applications()->create(

--- a/app/Commands/ApplicationGet.php
+++ b/app/Commands/ApplicationGet.php
@@ -26,15 +26,16 @@ class ApplicationGet extends BaseCommand
 
         $this->outputJsonIfWanted($application);
 
-        dataList([
+        dataList(array_filter([
             'ID' => $application->id,
             'Name' => $application->name,
             'Region' => $application->region,
             'Repository' => 'https://github.com/'.$application->repositoryFullName,
+            'Root Directory' => $application->rootDirectory,
             'Environments' => collect($application->environments)->map(fn ($env) => [$env->name, $env->id])->toArray(),
             'Organization' => [
                 [$application->organization->name, $application->organization->id],
             ],
-        ]);
+        ]));
     }
 }

--- a/app/Commands/ApplicationGet.php
+++ b/app/Commands/ApplicationGet.php
@@ -36,6 +36,6 @@ class ApplicationGet extends BaseCommand
             'Organization' => [
                 [$application->organization->name, $application->organization->id],
             ],
-        ]));
+        ], fn ($value) => $value !== null));
     }
 }

--- a/app/Commands/Ship.php
+++ b/app/Commands/Ship.php
@@ -61,6 +61,7 @@ class Ship extends BaseCommand
                             {--database-preset= : Preset tier for the database (dev, prod, scale — case-insensitive). Default: dev}
                             {--name= : Application name (non-interactive). Default: derived from repository}
                             {--region= : Region (non-interactive). Default: most-used or us-east-2}
+                            {--root-directory= : Repository subdirectory containing the app (monorepos)}
 ';
 
     protected $description = 'Ship a new application to Laravel Cloud';
@@ -237,6 +238,7 @@ class Ship extends BaseCommand
             repository: $repository,
             name: $name,
             region: $region,
+            rootDirectory: $this->rootDirectoryOption(),
         );
 
         try {
@@ -304,9 +306,17 @@ class Ship extends BaseCommand
                     repository: $repository,
                     name: $this->form()->get('name'),
                     region: $this->form()->get('region'),
+                    rootDirectory: $this->rootDirectoryOption(),
                 ),
             ),
         );
+    }
+
+    protected function rootDirectoryOption(): ?string
+    {
+        $rootDirectory = $this->option('root-directory');
+
+        return $rootDirectory === '' ? null : $rootDirectory;
     }
 
     protected function collectOptionsToEnable(Environment $environment): void

--- a/app/Commands/Ship.php
+++ b/app/Commands/Ship.php
@@ -255,7 +255,7 @@ class Ship extends BaseCommand
 
                 $values = collect($errors)
                     ->keys()
-                    ->mapWithKeys(fn ($field) => [$field => $data->{$field} ?? null])
+                    ->mapWithKeys(fn ($field) => [$field => $data->toRequestData()[$field] ?? null])
                     ->filter()
                     ->all();
 
@@ -314,8 +314,7 @@ class Ship extends BaseCommand
 
     protected function rootDirectoryOption(): ?string
     {
-        $rootDirectory = trim((string) $this->option('root-directory'));
-        $rootDirectory = trim($rootDirectory, '/');
+        $rootDirectory = $this->option('root-directory');
 
         return $rootDirectory === '' ? null : $rootDirectory;
     }

--- a/app/Commands/Ship.php
+++ b/app/Commands/Ship.php
@@ -90,18 +90,25 @@ class Ship extends BaseCommand
             'Checking for existing application...',
         );
 
+        $rootDirectory = $this->rootDirectoryOption();
+
+        // A repository can hold an application per root directory, so only apps rooted at the
+        // same directory are duplicates of the one we are about to create.
         $existingApps = $applications->collect()->filter(
-            fn (Application $app) => $app->repositoryFullName === $repository,
+            fn (Application $app) => $app->repositoryFullName === $repository
+                && $this->normalizeRootDirectory($app->rootDirectory) === $rootDirectory,
         );
+
+        $location = $rootDirectory === null ? 'this repository' : 'this repository with root directory `'.$rootDirectory.'`';
 
         if ($existingApps->isNotEmpty()) {
             if (! $this->isInteractive()) {
                 $this->outputErrorOrThrow(
-                    'Repository already has an application. Use deploy <application-id> to deploy. Existing: '.$existingApps->pluck('id')->join(', '),
+                    'An application already exists for '.$location.'. Use deploy <application-id> to deploy. Existing: '.$existingApps->pluck('id')->join(', '),
                 );
             }
 
-            info('Found '.$existingApps->count().' existing '.str('application')->plural($existingApps->count()).' for this repository.');
+            info('Found '.$existingApps->count().' existing '.str('application')->plural($existingApps->count()).' for '.$location.'.');
 
             $options = $existingApps
                 ->mapWithKeys(fn (Application $app) => [$app->id => 'Deploy '.$app->name])
@@ -314,7 +321,15 @@ class Ship extends BaseCommand
 
     protected function rootDirectoryOption(): ?string
     {
-        $rootDirectory = $this->option('root-directory');
+        return $this->normalizeRootDirectory($this->option('root-directory'));
+    }
+
+    /**
+     * The API stores the directory without a trailing slash, which is what shell completion gives you.
+     */
+    protected function normalizeRootDirectory(?string $rootDirectory): ?string
+    {
+        $rootDirectory = rtrim((string) $rootDirectory, '/');
 
         return $rootDirectory === '' ? null : $rootDirectory;
     }

--- a/app/Commands/Ship.php
+++ b/app/Commands/Ship.php
@@ -314,14 +314,48 @@ class Ship extends BaseCommand
 
     protected function rootDirectoryOption(): ?string
     {
-        $rootDirectory = $this->option('root-directory');
+        $rootDirectory = trim((string) $this->option('root-directory'));
+        $rootDirectory = trim($rootDirectory, '/');
 
         return $rootDirectory === '' ? null : $rootDirectory;
     }
 
+    /**
+     * Where the application actually lives on disk.
+     *
+     * Shipping a monorepo means the command can be run from the repository root, so the
+     * project this command inspects is not necessarily the directory it was invoked from.
+     */
+    protected function projectPath(): string
+    {
+        $rootDirectory = $this->rootDirectoryOption();
+
+        if ($rootDirectory === null) {
+            return (string) getcwd();
+        }
+
+        $repositoryRoot = $this->git->getRoot() ?? (string) getcwd();
+
+        return $repositoryRoot.'/'.$rootDirectory;
+    }
+
+    /**
+     * Package detection is a convenience, so a project we cannot read should not stop the ship.
+     */
+    protected function composer(): ?Composer
+    {
+        $path = $this->projectPath();
+
+        if (! file_exists($path.'/composer.json')) {
+            return null;
+        }
+
+        return new Composer(app('files'), $path);
+    }
+
     protected function collectOptionsToEnable(Environment $environment): void
     {
-        $composer = new Composer(app('files'), getcwd());
+        $composer = $this->composer();
 
         $enableOptions = [
             'scheduler' => 'Laravel Scheduler',
@@ -336,7 +370,7 @@ class Ship extends BaseCommand
         ];
 
         foreach ($packages as $package => $options) {
-            if ($composer->hasPackage($package)) {
+            if ($composer?->hasPackage($package)) {
                 $enableOptions = array_merge($enableOptions, $options);
             }
         }
@@ -453,13 +487,13 @@ class Ship extends BaseCommand
 
     protected function applyOpinionatedOptions(Environment $environment): void
     {
-        $composer = new Composer(app('files'), getcwd());
+        $composer = $this->composer();
 
         $instanceParams = [
             'uses_scheduler' => true,
             'uses_sleep_mode' => false,
             // 'sleep_timeout' => 5,
-            'uses_octane' => $composer->hasPackage('laravel/octane'),
+            'uses_octane' => $composer?->hasPackage('laravel/octane') ?? false,
         ];
 
         $environmentParams = [];
@@ -470,7 +504,7 @@ class Ship extends BaseCommand
             $environmentParams['database_schema_id'] = $databaseSchemaId;
         }
 
-        if ($composer->hasPackage('laravel/reverb')) {
+        if ($composer?->hasPackage('laravel/reverb')) {
             $websocketAppId = $this->provisionWebsocketOpinionated();
 
             if ($websocketAppId !== null) {
@@ -791,7 +825,7 @@ class Ship extends BaseCommand
 
     protected function pushCustomEnvironmentVariables(Application $application): void
     {
-        $envPath = getcwd().'/.env';
+        $envPath = $this->projectPath().'/.env';
 
         if (! file_exists($envPath)) {
             return;

--- a/app/Commands/Ship.php
+++ b/app/Commands/Ship.php
@@ -353,6 +353,11 @@ class Ship extends BaseCommand
         return $repositoryRoot.'/'.$rootDirectory;
     }
 
+    protected function avatarSearchRoot(): ?string
+    {
+        return $this->projectPath();
+    }
+
     /**
      * Package detection is a convenience, so a project we cannot read should not stop the ship.
      */

--- a/app/Concerns/HandlesAvatars.php
+++ b/app/Concerns/HandlesAvatars.php
@@ -13,7 +13,7 @@ trait HandlesAvatars
 {
     protected function getAvatarCandidatesFromRepo(): Collection
     {
-        $root = app(Git::class)->getRoot();
+        $root = $this->avatarSearchRoot();
 
         $possiblePaths = collect([
             'favicon.png',
@@ -51,6 +51,16 @@ trait HandlesAvatars
         return $possiblePaths
             ->filter(fn ($path) => pathinfo($path, PATHINFO_EXTENSION) === 'png')
             ->values();
+    }
+
+    /**
+     * Where to look for an icon to use as the avatar.
+     *
+     * A command that knows the application lives in a subdirectory overrides this.
+     */
+    protected function avatarSearchRoot(): ?string
+    {
+        return app(Git::class)->getRoot();
     }
 
     protected function normalizeSvg(string $content): string

--- a/app/Dto/Application.php
+++ b/app/Dto/Application.php
@@ -22,6 +22,7 @@ class Application extends Data
         public readonly ?string $repositoryBranch = null,
         public readonly ?string $slackChannel = null,
         public readonly ?string $avatarUrl = null,
+        public readonly ?string $rootDirectory = null,
         #[WithCast(DateTimeInterfaceCast::class, type: CarbonImmutable::class)]
         public readonly ?CarbonImmutable $createdAt = null,
         public readonly ?string $repositoryId = null,
@@ -50,6 +51,7 @@ class Application extends Data
             'region' => $attributes['region'],
             'slackChannel' => $attributes['slack_channel'] ?? null,
             'avatarUrl' => $attributes['avatar_url'] ?? null,
+            'rootDirectory' => $attributes['root_directory'] ?? null,
             'createdAt' => $attributes['created_at'] ?? null,
         ];
 

--- a/skills/deploying-laravel-cloud/SKILL.md
+++ b/skills/deploying-laravel-cloud/SKILL.md
@@ -52,6 +52,8 @@ Environment variables? → `cloud environment:variables -n --force`
 
 Provision infrastructure? → `cloud <resource>:create --json -n`
 
+Monorepo (app in a subdirectory)? → `cloud application:create --root-directory=<subdir> --json -n`
+
 Custom domain? → `cloud domain:create --json -n` then `cloud domain:verify -n`
 
 For multi-step operations, see [reference/checklists.md](reference/checklists.md).

--- a/skills/deploying-laravel-cloud/SKILL.md
+++ b/skills/deploying-laravel-cloud/SKILL.md
@@ -52,7 +52,7 @@ Environment variables? → `cloud environment:variables -n --force`
 
 Provision infrastructure? → `cloud <resource>:create --json -n`
 
-Monorepo (app in a subdirectory)? → `cloud application:create --root-directory=<subdir> --json -n`
+Monorepo (app in a subdirectory)? → add `--root-directory=<subdir>` to `cloud ship` or `cloud application:create`
 
 Custom domain? → `cloud domain:create --json -n` then `cloud domain:verify -n`
 

--- a/tests/Feature/ApplicationCreateRootDirectoryTest.php
+++ b/tests/Feature/ApplicationCreateRootDirectoryTest.php
@@ -1,0 +1,129 @@
+<?php
+
+use App\Client\Resources\Applications\CreateApplicationRequest;
+use App\Client\Resources\Meta\GetOrganizationRequest;
+use App\Client\Resources\Meta\ListRegionsRequest;
+use App\ConfigRepository;
+use App\Git;
+use Illuminate\Support\Facades\Artisan;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+
+beforeEach(function () {
+    $this->mockGit = Mockery::mock(Git::class);
+    $this->mockGit->shouldReceive('isRepo')->andReturn(true)->byDefault();
+    $this->mockGit->shouldReceive('getRoot')->andReturn('/tmp/test-repo')->byDefault();
+    $this->mockGit->shouldReceive('hasGitHubRemote')->andReturn(true)->byDefault();
+    $this->mockGit->shouldReceive('remoteRepo')->andReturn('laravel/cloud-cli')->byDefault();
+    $this->app->instance(Git::class, $this->mockGit);
+
+    $this->mockConfig = Mockery::mock(ConfigRepository::class);
+    $this->mockConfig->shouldReceive('apiTokens')->andReturn(collect(['test-api-token']));
+    $this->app->instance(ConfigRepository::class, $this->mockConfig);
+});
+
+afterEach(function () {
+    MockClient::destroyGlobal();
+});
+
+function mockApplicationCreateRequests(array $attributeOverrides = [], ?MockResponse $createResponse = null): void
+{
+    MockClient::global([
+        GetOrganizationRequest::class => MockResponse::make(organizationResponse(), 200),
+        ListRegionsRequest::class => MockResponse::make(regionsResponse(), 200),
+        CreateApplicationRequest::class => $createResponse ?? MockResponse::make([
+            'data' => createApplicationResponse(['attributes' => $attributeOverrides]),
+            'included' => [
+                ['id' => 'org-1', 'type' => 'organizations', 'attributes' => ['name' => 'My Org', 'slug' => 'my-org']],
+                ['id' => 'env-1', 'type' => 'environments', 'attributes' => ['name' => 'production', 'slug' => 'production', 'vanity_domain' => 'my-app.cloud.laravel.com', 'status' => 'running', 'php_major_version' => '8.3']],
+            ],
+        ], 200),
+    ]);
+}
+
+it('sends the root directory when the option is passed', function (string $rootDirectory) {
+    mockApplicationCreateRequests(['root_directory' => $rootDirectory]);
+
+    $this->artisan('application:create', [
+        '--name' => 'My App',
+        '--repository' => 'user/my-app',
+        '--region' => 'us-east-1',
+        '--root-directory' => $rootDirectory,
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+
+    MockClient::global()->assertSent(function ($request) use ($rootDirectory) {
+        return $request instanceof CreateApplicationRequest
+            && $request->body()->all()['root_directory'] === $rootDirectory;
+    });
+})->with(['backend', 'apps/api']);
+
+it('omits the root directory from the request body when the option is not passed', function () {
+    mockApplicationCreateRequests();
+
+    $this->artisan('application:create', [
+        '--name' => 'My App',
+        '--repository' => 'user/my-app',
+        '--region' => 'us-east-1',
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+
+    MockClient::global()->assertSent(function ($request) {
+        return $request instanceof CreateApplicationRequest
+            && ! array_key_exists('root_directory', $request->body()->all());
+    });
+});
+
+it('outputs the root directory in the JSON representation', function () {
+    mockApplicationCreateRequests(['root_directory' => 'backend']);
+
+    $exitCode = Artisan::call('application:create', [
+        '--name' => 'My App',
+        '--repository' => 'user/my-app',
+        '--region' => 'us-east-1',
+        '--root-directory' => 'backend',
+        '--json' => true,
+        '--no-interaction' => true,
+    ]);
+
+    expect($exitCode)->toBe(0);
+
+    $decoded = json_decode(Artisan::output(), true);
+
+    expect($decoded)->toBeArray()
+        ->and($decoded['rootDirectory'])->toBe('backend');
+});
+
+it('parses responses without a root directory attribute as null', function () {
+    mockApplicationCreateRequests();
+
+    $exitCode = Artisan::call('application:create', [
+        '--name' => 'My App',
+        '--repository' => 'user/my-app',
+        '--region' => 'us-east-1',
+        '--json' => true,
+        '--no-interaction' => true,
+    ]);
+
+    expect($exitCode)->toBe(0);
+
+    $decoded = json_decode(Artisan::output(), true);
+
+    expect($decoded)->toBeArray()
+        ->and($decoded['rootDirectory'])->toBeNull();
+});
+
+it('fails when the API rejects the root directory', function () {
+    mockApplicationCreateRequests(createResponse: MockResponse::make([
+        'message' => 'Validation failed',
+        'errors' => ['root_directory' => ['The selected directory is invalid.']],
+    ], 422));
+
+    $this->artisan('application:create', [
+        '--name' => 'My App',
+        '--repository' => 'user/my-app',
+        '--region' => 'us-east-1',
+        '--root-directory' => '/invalid/',
+        '--no-interaction' => true,
+    ])->assertFailed();
+});

--- a/tests/Feature/ApplicationCreateRootDirectoryTest.php
+++ b/tests/Feature/ApplicationCreateRootDirectoryTest.php
@@ -26,7 +26,7 @@ afterEach(function () {
     MockClient::destroyGlobal();
 });
 
-function mockApplicationCreateRequests(array $attributeOverrides = [], ?MockResponse $createResponse = null): void
+function setupApplicationCreateMocks(array $attributeOverrides = [], ?MockResponse $createResponse = null): void
 {
     MockClient::global([
         GetOrganizationRequest::class => MockResponse::make(organizationResponse(), 200),
@@ -42,7 +42,7 @@ function mockApplicationCreateRequests(array $attributeOverrides = [], ?MockResp
 }
 
 it('sends the root directory when the option is passed', function (string $rootDirectory) {
-    mockApplicationCreateRequests(['root_directory' => $rootDirectory]);
+    setupApplicationCreateMocks(['root_directory' => $rootDirectory]);
 
     $this->artisan('application:create', [
         '--name' => 'My App',
@@ -59,7 +59,7 @@ it('sends the root directory when the option is passed', function (string $rootD
 })->with(['backend', 'apps/api']);
 
 it('omits the root directory from the request body when the option is not passed', function () {
-    mockApplicationCreateRequests();
+    setupApplicationCreateMocks();
 
     $this->artisan('application:create', [
         '--name' => 'My App',
@@ -75,7 +75,7 @@ it('omits the root directory from the request body when the option is not passed
 });
 
 it('outputs the root directory in the JSON representation', function () {
-    mockApplicationCreateRequests(['root_directory' => 'backend']);
+    setupApplicationCreateMocks(['root_directory' => 'backend']);
 
     $exitCode = Artisan::call('application:create', [
         '--name' => 'My App',
@@ -95,7 +95,7 @@ it('outputs the root directory in the JSON representation', function () {
 });
 
 it('parses responses without a root directory attribute as null', function () {
-    mockApplicationCreateRequests();
+    setupApplicationCreateMocks();
 
     $exitCode = Artisan::call('application:create', [
         '--name' => 'My App',
@@ -114,7 +114,7 @@ it('parses responses without a root directory attribute as null', function () {
 });
 
 it('fails when the API rejects the root directory', function () {
-    mockApplicationCreateRequests(createResponse: MockResponse::make([
+    setupApplicationCreateMocks(createResponse: MockResponse::make([
         'message' => 'Validation failed',
         'errors' => ['root_directory' => ['The selected directory is invalid.']],
     ], 422));

--- a/tests/Feature/ApplicationCreateRootDirectoryTest.php
+++ b/tests/Feature/ApplicationCreateRootDirectoryTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Client\Requests\CreateApplicationRequestData;
 use App\Client\Resources\Applications\CreateApplicationRequest;
 use App\Client\Resources\Meta\GetOrganizationRequest;
 use App\Client\Resources\Meta\ListRegionsRequest;
@@ -127,3 +128,21 @@ it('fails when the API rejects the root directory', function () {
         '--no-interaction' => true,
     ])->assertFailed();
 });
+
+it('strips a trailing slash from the root directory', function (?string $given, ?string $expected) {
+    $data = new CreateApplicationRequestData(
+        repository: 'user/my-app',
+        name: 'My App',
+        region: 'us-east-1',
+        rootDirectory: $given,
+    );
+
+    expect($data->rootDirectory)->toBe($expected);
+})->with([
+    ['backend', 'backend'],
+    ['backend/', 'backend'],
+    ['apps/api/', 'apps/api'],
+    ['/', null],
+    ['', null],
+    [null, null],
+]);

--- a/tests/Feature/ShipRootDirectoryTest.php
+++ b/tests/Feature/ShipRootDirectoryTest.php
@@ -1,0 +1,84 @@
+<?php
+
+use App\Client\Resources\Applications\CreateApplicationRequest;
+use App\Client\Resources\Applications\ListApplicationsRequest;
+use App\Client\Resources\Meta\GetOrganizationRequest;
+use App\ConfigRepository;
+use App\Git;
+use Illuminate\Support\Facades\Artisan;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+
+beforeEach(function () {
+    $this->mockGit = Mockery::mock(Git::class);
+    $this->mockGit->shouldReceive('isRepo')->andReturn(true)->byDefault();
+    $this->mockGit->shouldReceive('getRoot')->andReturn('/tmp/test-repo')->byDefault();
+    $this->mockGit->shouldReceive('hasGitHubRemote')->andReturn(true)->byDefault();
+    $this->mockGit->shouldReceive('remoteRepo')->andReturn('user/my-app')->byDefault();
+    $this->app->instance(Git::class, $this->mockGit);
+
+    $this->mockConfig = Mockery::mock(ConfigRepository::class);
+    $this->mockConfig->shouldReceive('apiTokens')->andReturn(collect(['test-api-token']));
+    $this->app->instance(ConfigRepository::class, $this->mockConfig);
+});
+
+afterEach(function () {
+    MockClient::destroyGlobal();
+});
+
+function setupShipCreateMocks(): void
+{
+    MockClient::global([
+        GetOrganizationRequest::class => MockResponse::make(organizationResponse(), 200),
+        ListApplicationsRequest::class => MockResponse::make([
+            'data' => [],
+            'included' => [],
+            'links' => ['next' => null],
+        ], 200),
+        CreateApplicationRequest::class => MockResponse::make([
+            'data' => createApplicationResponse(),
+            'included' => [
+                ['id' => 'org-1', 'type' => 'organizations', 'attributes' => ['name' => 'My Org', 'slug' => 'my-org']],
+                ['id' => 'env-1', 'type' => 'environments', 'attributes' => ['name' => 'production', 'slug' => 'production', 'vanity_domain' => 'my-app.cloud.laravel.com', 'status' => 'running', 'php_major_version' => '8.3']],
+            ],
+        ], 200),
+    ]);
+}
+
+function runShipUntilItLeavesTheMockedFlow(array $options): void
+{
+    try {
+        Artisan::call('ship', [...$options, '--no-interaction' => true]);
+    } catch (Throwable) {
+        // Only the creation step is mocked. The rest of the ship flow is out of scope here.
+    }
+}
+
+it('sends the root directory when shipping with the option', function () {
+    setupShipCreateMocks();
+
+    runShipUntilItLeavesTheMockedFlow([
+        '--name' => 'My App',
+        '--region' => 'us-east-1',
+        '--root-directory' => 'backend',
+    ]);
+
+    MockClient::global()->assertSent(function ($request) {
+        return $request instanceof CreateApplicationRequest
+            && $request->body()->all()['root_directory'] === 'backend';
+    });
+});
+
+it('omits the root directory when shipping without the option', function () {
+    setupShipCreateMocks();
+
+    runShipUntilItLeavesTheMockedFlow([
+        '--name' => 'My App',
+        '--region' => 'us-east-1',
+    ]);
+
+    MockClient::global()->assertSent(function ($request) {
+        return $request instanceof CreateApplicationRequest
+            && ! array_key_exists('root_directory', $request->body()->all());
+    });
+});

--- a/tests/Feature/ShipRootDirectoryTest.php
+++ b/tests/Feature/ShipRootDirectoryTest.php
@@ -157,13 +157,6 @@ it('resolves the project path to the working directory without a root directory'
     expect((fn () => $this->projectPath())->call($command))->toBe(getcwd());
 });
 
-it('ignores surrounding slashes and whitespace in the root directory', function (string $given) {
-    $command = shipCommandWithRootDirectory($given, '/tmp/test-repo');
-
-    expect((fn () => $this->rootDirectoryOption())->call($command))->toBe('apps/api')
-        ->and((fn () => $this->projectPath())->call($command))->toBe('/tmp/test-repo/apps/api');
-})->with(['/apps/api', 'apps/api/', ' apps/api ']);
-
 it('reads composer.json from the root directory rather than the working directory', function () {
     $repository = temporaryMonorepo(['laravel/octane' => '^2.0']);
 

--- a/tests/Feature/ShipRootDirectoryTest.php
+++ b/tests/Feature/ShipRootDirectoryTest.php
@@ -3,11 +3,14 @@
 use App\Client\Resources\Applications\CreateApplicationRequest;
 use App\Client\Resources\Applications\ListApplicationsRequest;
 use App\Client\Resources\Meta\GetOrganizationRequest;
+use App\Commands\Ship;
 use App\ConfigRepository;
 use App\Git;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
+use Symfony\Component\Console\Input\ArrayInput;
 
 beforeEach(function () {
     $this->mockGit = Mockery::mock(Git::class);
@@ -24,6 +27,12 @@ beforeEach(function () {
 
 afterEach(function () {
     MockClient::destroyGlobal();
+
+    foreach (temporaryMonorepos() as $path) {
+        File::deleteDirectory($path);
+    }
+
+    temporaryMonorepos(reset: true);
 });
 
 function setupShipCreateMocks(): void
@@ -81,4 +90,95 @@ it('omits the root directory when shipping without the option', function () {
         return $request instanceof CreateApplicationRequest
             && ! array_key_exists('root_directory', $request->body()->all());
     });
+});
+
+/**
+ * @return array<int, string>
+ */
+function temporaryMonorepos(?string $add = null, bool $reset = false): array
+{
+    static $paths = [];
+
+    if ($reset) {
+        $paths = [];
+    }
+
+    if ($add !== null) {
+        $paths[] = $add;
+    }
+
+    return $paths;
+}
+
+function temporaryMonorepo(?array $composerRequire = null): string
+{
+    $repository = sys_get_temp_dir().'/ship-monorepo-'.uniqid();
+
+    temporaryMonorepos(add: $repository);
+
+    File::ensureDirectoryExists($repository.'/backend');
+
+    if ($composerRequire !== null) {
+        File::put($repository.'/backend/composer.json', json_encode(['require' => $composerRequire]));
+    }
+
+    return $repository;
+}
+
+function shipCommandWithRootDirectory(?string $rootDirectory, ?string $gitRoot): Ship
+{
+    $command = app(Ship::class);
+
+    $input = new ArrayInput(
+        $rootDirectory === null ? [] : ['--root-directory' => $rootDirectory],
+        $command->getDefinition(),
+    );
+
+    $git = Mockery::mock(Git::class);
+    $git->shouldReceive('getRoot')->andReturn($gitRoot)->byDefault();
+
+    (function () use ($input, $git) {
+        $this->input = $input;
+        $this->git = $git;
+    })->call($command);
+
+    return $command;
+}
+
+it('resolves the project path against the repository root when a root directory is given', function () {
+    $command = shipCommandWithRootDirectory('backend', '/tmp/test-repo');
+
+    expect((fn () => $this->projectPath())->call($command))->toBe('/tmp/test-repo/backend');
+});
+
+it('resolves the project path to the working directory without a root directory', function () {
+    $command = shipCommandWithRootDirectory(null, '/tmp/test-repo');
+
+    expect((fn () => $this->projectPath())->call($command))->toBe(getcwd());
+});
+
+it('ignores surrounding slashes and whitespace in the root directory', function (string $given) {
+    $command = shipCommandWithRootDirectory($given, '/tmp/test-repo');
+
+    expect((fn () => $this->rootDirectoryOption())->call($command))->toBe('apps/api')
+        ->and((fn () => $this->projectPath())->call($command))->toBe('/tmp/test-repo/apps/api');
+})->with(['/apps/api', 'apps/api/', ' apps/api ']);
+
+it('reads composer.json from the root directory rather than the working directory', function () {
+    $repository = temporaryMonorepo(['laravel/octane' => '^2.0']);
+
+    $command = shipCommandWithRootDirectory('backend', $repository);
+
+    $composer = (fn () => $this->composer())->call($command);
+
+    expect($composer)->not->toBeNull()
+        ->and($composer->hasPackage('laravel/octane'))->toBeTrue();
+});
+
+it('skips package detection instead of crashing when the project has no composer.json', function () {
+    $repository = temporaryMonorepo();
+
+    $command = shipCommandWithRootDirectory('backend', $repository);
+
+    expect((fn () => $this->composer())->call($command))->toBeNull();
 });

--- a/tests/Feature/ShipRootDirectoryTest.php
+++ b/tests/Feature/ShipRootDirectoryTest.php
@@ -175,3 +175,83 @@ it('skips package detection instead of crashing when the project has no composer
 
     expect((fn () => $this->composer())->call($command))->toBeNull();
 });
+
+function listApplicationsResponseWith(?string $rootDirectory): array
+{
+    return [
+        'data' => [createApplicationResponse([
+            'id' => 'app-existing',
+            'attributes' => ['root_directory' => $rootDirectory],
+        ])],
+        'included' => [
+            ['id' => 'org-1', 'type' => 'organizations', 'attributes' => ['name' => 'My Org', 'slug' => 'my-org']],
+            ['id' => 'env-1', 'type' => 'environments', 'attributes' => ['name' => 'production', 'slug' => 'production', 'vanity_domain' => 'my-app.cloud.laravel.com', 'status' => 'running', 'php_major_version' => '8.3']],
+        ],
+        'links' => ['next' => null],
+    ];
+}
+
+it('creates a second application for a repository when it is rooted at another directory', function () {
+    setupShipCreateMocks();
+
+    MockClient::global()->addResponse(
+        MockResponse::make(listApplicationsResponseWith('backend'), 200),
+        ListApplicationsRequest::class,
+    );
+
+    runShipUntilItLeavesTheMockedFlow([
+        '--name' => 'My App',
+        '--region' => 'us-east-1',
+        '--root-directory' => 'frontend',
+    ]);
+
+    MockClient::global()->assertSent(function ($request) {
+        return $request instanceof CreateApplicationRequest
+            && $request->body()->all()['root_directory'] === 'frontend';
+    });
+});
+
+it('refuses to create a second application rooted at the same directory', function () {
+    setupShipCreateMocks();
+
+    MockClient::global()->addResponse(
+        MockResponse::make(listApplicationsResponseWith('backend'), 200),
+        ListApplicationsRequest::class,
+    );
+
+    $this->artisan('ship', [
+        '--root-directory' => 'backend/',
+        '--no-interaction' => true,
+    ])->assertFailed();
+
+    MockClient::global()->assertNotSent(CreateApplicationRequest::class);
+});
+
+it('ignores applications rooted in a subdirectory when shipping the repository root', function () {
+    setupShipCreateMocks();
+
+    MockClient::global()->addResponse(
+        MockResponse::make(listApplicationsResponseWith('backend'), 200),
+        ListApplicationsRequest::class,
+    );
+
+    runShipUntilItLeavesTheMockedFlow([
+        '--name' => 'My App',
+        '--region' => 'us-east-1',
+    ]);
+
+    MockClient::global()->assertSent(CreateApplicationRequest::class);
+});
+
+it('refuses to ship the repository root twice', function () {
+    setupShipCreateMocks();
+
+    MockClient::global()->addResponse(
+        MockResponse::make(listApplicationsResponseWith(null), 200),
+        ListApplicationsRequest::class,
+    );
+
+    $this->artisan('ship', ['--no-interaction' => true])->assertFailed();
+
+    MockClient::global()->assertNotSent(CreateApplicationRequest::class);
+});

--- a/tests/Feature/ShipRootDirectoryTest.php
+++ b/tests/Feature/ShipRootDirectoryTest.php
@@ -110,7 +110,7 @@ function temporaryMonorepos(?string $add = null, bool $reset = false): array
     return $paths;
 }
 
-function temporaryMonorepo(?array $composerRequire = null): string
+function temporaryMonorepo(?array $composerRequire = null, array $favicons = []): string
 {
     $repository = sys_get_temp_dir().'/ship-monorepo-'.uniqid();
 
@@ -120,6 +120,11 @@ function temporaryMonorepo(?array $composerRequire = null): string
 
     if ($composerRequire !== null) {
         File::put($repository.'/backend/composer.json', json_encode(['require' => $composerRequire]));
+    }
+
+    foreach ($favicons as $path => $contents) {
+        File::ensureDirectoryExists($repository.'/'.dirname($path));
+        File::put($repository.'/'.$path, $contents);
     }
 
     return $repository;
@@ -254,4 +259,17 @@ it('refuses to ship the repository root twice', function () {
     $this->artisan('ship', ['--no-interaction' => true])->assertFailed();
 
     MockClient::global()->assertNotSent(CreateApplicationRequest::class);
+});
+
+it('finds the avatar in the root directory rather than the repository root', function () {
+    $repository = temporaryMonorepo(favicons: [
+        'public/favicon.png' => 'the wrong app',
+        'backend/public/favicon.png' => 'the app being shipped',
+    ]);
+
+    $command = shipCommandWithRootDirectory('backend', $repository);
+
+    $candidates = (fn () => $this->getAvatarCandidatesFromRepo())->call($command);
+
+    expect($candidates->all())->toBe([$repository.'/backend/public/favicon.png']);
 });


### PR DESCRIPTION
## Overview

The public API accepts `root_directory` when creating an application, but the CLI had no way to send it. Anyone with an app living in a repository subdirectory (a monorepo) could only create it from the dashboard or with raw curl.

## Solution

Add a `--root-directory` option to `application:create` and `ship`, send it only when provided so existing requests stay unchanged, and expose `rootDirectory` in the JSON output. The shipped deploy skill now mentions the flag for monorepos.

## Examples

```sh
cloud application:create --repository acme/monorepo --root-directory=backend --json -n
cloud ship --root-directory=backend -n
```