### PR TITLE
Add commands for managing secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,13 +174,14 @@ Many commands accept an optional resource ID/name and support `--json` for machi
 
 Secrets are organization-wide encrypted values that can be attached to environments. Values are encrypted locally with the organization's public key before they are sent, so plaintext never leaves your machine.
 
-| Command                           | Description                      |
-| --------------------------------- | -------------------------------- |
-| `cloud secret:list`               | List secrets                     |
-| `cloud secret:create`             | Create a secret                  |
-| `cloud secret:update`             | Update a secret                  |
-| `cloud secret:delete`             | Delete a secret                  |
-| `cloud environment-secret:attach` | Attach secrets to an environment |
+| Command                           | Description                             |
+| --------------------------------- | --------------------------------------- |
+| `cloud secret:list`               | List secrets                            |
+| `cloud secret:create`             | Create a secret                         |
+| `cloud secret:update`             | Update a secret                         |
+| `cloud secret:delete`             | Delete a secret                         |
+| `cloud environment-secret:list`   | List secrets attached to an environment |
+| `cloud environment-secret:attach` | Attach secrets to an environment        |
 
 ### Deploy & ship
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,12 @@ Secrets are organization-wide encrypted values that can be attached to environme
 | `cloud environment-secret:list`   | List secrets attached to an environment |
 | `cloud environment-secret:attach` | Attach secrets to an environment        |
 
+`secret:create` and `secret:update` read the value from STDIN when `--value` is not given, which keeps it out of your shell history and out of the process list:
+
+```sh
+op read "op://vault/stripe/api-key" | cloud secret:create --name=STRIPE_KEY -n
+```
+
 ### Deploy & ship
 
 | Command                 | Description                                    |

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Secrets are organization-wide encrypted values that can be attached to environme
 
 | Command               | Description     |
 | --------------------- | --------------- |
+| `cloud secret:list`   | List secrets    |
 | `cloud secret:create` | Create a secret |
 
 ### Deploy & ship

--- a/README.md
+++ b/README.md
@@ -170,6 +170,14 @@ Many commands accept an optional resource ID/name and support `--json` for machi
 | `cloud environment:variables` | Manage environment variables (append, set, or replace) |
 | `cloud environment:logs`      | View environment logs                                  |
 
+### Secrets
+
+Secrets are organization-wide encrypted values that can be attached to environments. Values are encrypted locally with the organization's public key before they are sent, so plaintext never leaves your machine.
+
+| Command               | Description     |
+| --------------------- | --------------- |
+| `cloud secret:create` | Create a secret |
+
 ### Deploy & ship
 
 | Command                 | Description                                    |

--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ Secrets are organization-wide encrypted values that can be attached to environme
 | `cloud environment-secret:list`   | List secrets attached to an environment |
 | `cloud environment-secret:attach` | Attach secrets to an environment        |
 
+`secret:create` and `secret:update` encrypt with `ext-sodium`, which ships with PHP but is a separate package on some distributions. No other command needs it.
+
 `secret:create` and `secret:update` read the value from STDIN when `--value` is not given, which keeps it out of your shell history and out of the process list:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Secrets are organization-wide encrypted values that can be attached to environme
 | `cloud secret:list`   | List secrets    |
 | `cloud secret:create` | Create a secret |
 | `cloud secret:update` | Update a secret |
+| `cloud secret:delete` | Delete a secret |
 
 ### Deploy & ship
 

--- a/README.md
+++ b/README.md
@@ -174,12 +174,13 @@ Many commands accept an optional resource ID/name and support `--json` for machi
 
 Secrets are organization-wide encrypted values that can be attached to environments. Values are encrypted locally with the organization's public key before they are sent, so plaintext never leaves your machine.
 
-| Command               | Description     |
-| --------------------- | --------------- |
-| `cloud secret:list`   | List secrets    |
-| `cloud secret:create` | Create a secret |
-| `cloud secret:update` | Update a secret |
-| `cloud secret:delete` | Delete a secret |
+| Command                           | Description                      |
+| --------------------------------- | -------------------------------- |
+| `cloud secret:list`               | List secrets                     |
+| `cloud secret:create`             | Create a secret                  |
+| `cloud secret:update`             | Update a secret                  |
+| `cloud secret:delete`             | Delete a secret                  |
+| `cloud environment-secret:attach` | Attach secrets to an environment |
 
 ### Deploy & ship
 

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Secrets are organization-wide encrypted values that can be attached to environme
 | --------------------- | --------------- |
 | `cloud secret:list`   | List secrets    |
 | `cloud secret:create` | Create a secret |
+| `cloud secret:update` | Update a secret |
 
 ### Deploy & ship
 

--- a/app/Client/Connector.php
+++ b/app/Client/Connector.php
@@ -20,6 +20,7 @@ use App\Client\Resources\EnvironmentsResource;
 use App\Client\Resources\InstancesResource;
 use App\Client\Resources\MetaResource;
 use App\Client\Resources\ObjectStorageBucketsResource;
+use App\Client\Resources\SecretsResource;
 use App\Client\Resources\UsageResource;
 use App\Client\Resources\WebSocketApplicationsResource;
 use App\Client\Resources\WebSocketClustersResource;
@@ -209,6 +210,11 @@ class Connector extends SaloonConnector implements HasPagination
     public function websocketApplications(): WebSocketApplicationsResource
     {
         return new WebSocketApplicationsResource($this);
+    }
+
+    public function secrets(): SecretsResource
+    {
+        return new SecretsResource($this);
     }
 
     public function meta(): MetaResource

--- a/app/Client/Requests/AttachEnvironmentSecretsRequestData.php
+++ b/app/Client/Requests/AttachEnvironmentSecretsRequestData.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Client\Requests;
+
+class AttachEnvironmentSecretsRequestData extends RequestData
+{
+    /**
+     * @param  list<string>  $secrets
+     */
+    public function __construct(
+        public readonly string $environmentId,
+        public readonly array $secrets,
+    ) {
+        //
+    }
+
+    public function toRequestData(): array
+    {
+        return [
+            'secrets' => $this->secrets,
+        ];
+    }
+}

--- a/app/Client/Requests/CreateSecretRequestData.php
+++ b/app/Client/Requests/CreateSecretRequestData.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Client\Requests;
+
+use SensitiveParameter;
+
+class CreateSecretRequestData extends RequestData
+{
+    public function __construct(
+        public readonly string $keyPairId,
+        public readonly string $key,
+        #[SensitiveParameter]
+        public readonly string $value,
+        public readonly ?string $notes = null,
+    ) {
+        //
+    }
+
+    public function toRequestData(): array
+    {
+        return $this->filter([
+            'key_pair_id' => $this->keyPairId,
+            'key' => $this->key,
+            'value' => $this->value,
+            'notes' => $this->notes,
+        ]);
+    }
+}

--- a/app/Client/Requests/UpdateSecretRequestData.php
+++ b/app/Client/Requests/UpdateSecretRequestData.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Client\Requests;
+
+use SensitiveParameter;
+
+class UpdateSecretRequestData extends RequestData
+{
+    public function __construct(
+        public readonly string $secretId,
+        public readonly string $key,
+        #[SensitiveParameter]
+        public readonly ?string $value = null,
+        public readonly ?string $keyPairId = null,
+        public readonly ?string $notes = null,
+    ) {
+        //
+    }
+
+    public function toRequestData(): array
+    {
+        return $this->filter([
+            'key' => $this->key,
+            'value' => $this->value,
+            'key_pair_id' => $this->keyPairId,
+            'notes' => $this->notes,
+        ]);
+    }
+}

--- a/app/Client/Resources/Environments/AttachEnvironmentSecretsRequest.php
+++ b/app/Client/Resources/Environments/AttachEnvironmentSecretsRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Client\Resources\Environments;
+
+use App\Client\Requests\AttachEnvironmentSecretsRequestData;
+use App\Dto\Environment;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Http\Response;
+use Saloon\Traits\Body\HasJsonBody;
+
+class AttachEnvironmentSecretsRequest extends Request implements HasBody
+{
+    use HasJsonBody;
+
+    protected Method $method = Method::POST;
+
+    public function __construct(
+        protected AttachEnvironmentSecretsRequestData $data,
+    ) {
+        //
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return "/environments/{$this->data->environmentId}/secrets";
+    }
+
+    protected function defaultBody(): array
+    {
+        return $this->data->toRequestData();
+    }
+
+    public function createDtoFromResponse(Response $response): Environment
+    {
+        return Environment::createFromResponse($response->json());
+    }
+}

--- a/app/Client/Resources/EnvironmentsResource.php
+++ b/app/Client/Resources/EnvironmentsResource.php
@@ -3,12 +3,14 @@
 namespace App\Client\Resources;
 
 use App\Client\Requests\AddEnvironmentVariablesRequestData;
+use App\Client\Requests\AttachEnvironmentSecretsRequestData;
 use App\Client\Requests\CreateEnvironmentRequestData;
 use App\Client\Requests\ReplaceEnvironmentVariablesRequestData;
 use App\Client\Requests\StartEnvironmentRequestData;
 use App\Client\Requests\StopEnvironmentRequestData;
 use App\Client\Requests\UpdateEnvironmentRequestData;
 use App\Client\Resources\Environments\AddEnvironmentVariablesRequest;
+use App\Client\Resources\Environments\AttachEnvironmentSecretsRequest;
 use App\Client\Resources\Environments\CreateEnvironmentRequest;
 use App\Client\Resources\Environments\DeleteEnvironmentRequest;
 use App\Client\Resources\Environments\GetEnvironmentRequest;
@@ -78,6 +80,14 @@ class EnvironmentsResource extends Resource
     public function addVariables(AddEnvironmentVariablesRequestData $data): void
     {
         $this->send(new AddEnvironmentVariablesRequest($data));
+    }
+
+    public function attachSecrets(AttachEnvironmentSecretsRequestData $data): Environment
+    {
+        $request = new AttachEnvironmentSecretsRequest($data);
+        $response = $this->send($request);
+
+        return $request->createDtoFromResponse($response);
     }
 
     public function replaceVariables(ReplaceEnvironmentVariablesRequestData $data): void

--- a/app/Client/Resources/Secrets/CreateSecretRequest.php
+++ b/app/Client/Resources/Secrets/CreateSecretRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Client\Resources\Secrets;
+
+use App\Client\Requests\CreateSecretRequestData;
+use App\Dto\Secret;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Http\Response;
+use Saloon\Traits\Body\HasJsonBody;
+
+class CreateSecretRequest extends Request implements HasBody
+{
+    use HasJsonBody;
+
+    protected Method $method = Method::POST;
+
+    public function __construct(
+        protected CreateSecretRequestData $data,
+    ) {
+        //
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return '/secrets';
+    }
+
+    protected function defaultBody(): array
+    {
+        return $this->data->toRequestData();
+    }
+
+    public function createDtoFromResponse(Response $response): Secret
+    {
+        return Secret::createFromResponse($response->json());
+    }
+}

--- a/app/Client/Resources/Secrets/DeleteSecretRequest.php
+++ b/app/Client/Resources/Secrets/DeleteSecretRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Client\Resources\Secrets;
+
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+class DeleteSecretRequest extends Request
+{
+    protected Method $method = Method::DELETE;
+
+    public function __construct(
+        protected string $secretId,
+    ) {
+        //
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return "/secrets/{$this->secretId}";
+    }
+}

--- a/app/Client/Resources/Secrets/GetSecretPublicKeyRequest.php
+++ b/app/Client/Resources/Secrets/GetSecretPublicKeyRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Client\Resources\Secrets;
+
+use App\Dto\SecretPublicKey;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Http\Response;
+
+class GetSecretPublicKeyRequest extends Request
+{
+    protected Method $method = Method::GET;
+
+    public function resolveEndpoint(): string
+    {
+        return '/secrets/public-key';
+    }
+
+    public function createDtoFromResponse(Response $response): SecretPublicKey
+    {
+        return SecretPublicKey::createFromResponse($response->json());
+    }
+}

--- a/app/Client/Resources/Secrets/ListSecretsRequest.php
+++ b/app/Client/Resources/Secrets/ListSecretsRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Client\Resources\Secrets;
+
+use App\Dto\Secret;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Http\Response;
+use Saloon\PaginationPlugin\Contracts\Paginatable;
+
+class ListSecretsRequest extends Request implements Paginatable
+{
+    protected Method $method = Method::GET;
+
+    public function resolveEndpoint(): string
+    {
+        return '/secrets';
+    }
+
+    public function createDtoFromResponse(Response $response): array
+    {
+        $data = $response->json('data') ?? [];
+
+        return array_map(fn (array $item) => Secret::createFromResponse(['data' => $item]), $data);
+    }
+}

--- a/app/Client/Resources/Secrets/UpdateSecretRequest.php
+++ b/app/Client/Resources/Secrets/UpdateSecretRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Client\Resources\Secrets;
+
+use App\Client\Requests\UpdateSecretRequestData;
+use App\Dto\Secret;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Http\Response;
+use Saloon\Traits\Body\HasJsonBody;
+
+class UpdateSecretRequest extends Request implements HasBody
+{
+    use HasJsonBody;
+
+    protected Method $method = Method::PATCH;
+
+    public function __construct(
+        protected UpdateSecretRequestData $data,
+    ) {
+        //
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return "/secrets/{$this->data->secretId}";
+    }
+
+    protected function defaultBody(): array
+    {
+        return $this->data->toRequestData();
+    }
+
+    public function createDtoFromResponse(Response $response): Secret
+    {
+        return Secret::createFromResponse($response->json());
+    }
+}

--- a/app/Client/Resources/SecretsResource.php
+++ b/app/Client/Resources/SecretsResource.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Client\Resources;
+
+use App\Client\Requests\CreateSecretRequestData;
+use App\Client\Resources\Secrets\CreateSecretRequest;
+use App\Client\Resources\Secrets\GetSecretPublicKeyRequest;
+use App\Dto\Secret;
+use App\Dto\SecretPublicKey;
+
+class SecretsResource extends Resource
+{
+    public function publicKey(): SecretPublicKey
+    {
+        $request = new GetSecretPublicKeyRequest;
+        $response = $this->send($request);
+
+        return $request->createDtoFromResponse($response);
+    }
+
+    public function create(CreateSecretRequestData $data): Secret
+    {
+        $request = new CreateSecretRequest($data);
+        $response = $this->send($request);
+
+        return $request->createDtoFromResponse($response);
+    }
+}

--- a/app/Client/Resources/SecretsResource.php
+++ b/app/Client/Resources/SecretsResource.php
@@ -5,6 +5,7 @@ namespace App\Client\Resources;
 use App\Client\Requests\CreateSecretRequestData;
 use App\Client\Requests\UpdateSecretRequestData;
 use App\Client\Resources\Secrets\CreateSecretRequest;
+use App\Client\Resources\Secrets\DeleteSecretRequest;
 use App\Client\Resources\Secrets\GetSecretPublicKeyRequest;
 use App\Client\Resources\Secrets\ListSecretsRequest;
 use App\Client\Resources\Secrets\UpdateSecretRequest;
@@ -41,5 +42,12 @@ class SecretsResource extends Resource
         $response = $this->send($request);
 
         return $request->createDtoFromResponse($response);
+    }
+
+    public function delete(string $secretId): void
+    {
+        $this->send(new DeleteSecretRequest(
+            secretId: $secretId,
+        ));
     }
 }

--- a/app/Client/Resources/SecretsResource.php
+++ b/app/Client/Resources/SecretsResource.php
@@ -5,11 +5,18 @@ namespace App\Client\Resources;
 use App\Client\Requests\CreateSecretRequestData;
 use App\Client\Resources\Secrets\CreateSecretRequest;
 use App\Client\Resources\Secrets\GetSecretPublicKeyRequest;
+use App\Client\Resources\Secrets\ListSecretsRequest;
 use App\Dto\Secret;
 use App\Dto\SecretPublicKey;
+use Saloon\PaginationPlugin\Paginator;
 
 class SecretsResource extends Resource
 {
+    public function list(): Paginator
+    {
+        return $this->paginate(new ListSecretsRequest);
+    }
+
     public function publicKey(): SecretPublicKey
     {
         $request = new GetSecretPublicKeyRequest;

--- a/app/Client/Resources/SecretsResource.php
+++ b/app/Client/Resources/SecretsResource.php
@@ -3,9 +3,11 @@
 namespace App\Client\Resources;
 
 use App\Client\Requests\CreateSecretRequestData;
+use App\Client\Requests\UpdateSecretRequestData;
 use App\Client\Resources\Secrets\CreateSecretRequest;
 use App\Client\Resources\Secrets\GetSecretPublicKeyRequest;
 use App\Client\Resources\Secrets\ListSecretsRequest;
+use App\Client\Resources\Secrets\UpdateSecretRequest;
 use App\Dto\Secret;
 use App\Dto\SecretPublicKey;
 use Saloon\PaginationPlugin\Paginator;
@@ -28,6 +30,14 @@ class SecretsResource extends Resource
     public function create(CreateSecretRequestData $data): Secret
     {
         $request = new CreateSecretRequest($data);
+        $response = $this->send($request);
+
+        return $request->createDtoFromResponse($response);
+    }
+
+    public function update(UpdateSecretRequestData $data): Secret
+    {
+        $request = new UpdateSecretRequest($data);
         $response = $this->send($request);
 
         return $request->createDtoFromResponse($response);

--- a/app/Commands/AuthToken.php
+++ b/app/Commands/AuthToken.php
@@ -4,12 +4,12 @@ namespace App\Commands;
 
 use App\Client\Connector;
 use App\Cloud;
+use App\Concerns\AcceptsPipedInput;
 use App\ConfigRepository;
 use App\Contracts\NoAuthRequired;
 use App\Dto\ApiToken;
 use App\Exceptions\CommandExitException;
 use App\Support\SensitiveValues;
-use App\Support\Stdin;
 use Illuminate\Support\Collection;
 
 use function Laravel\Prompts\info;
@@ -23,6 +23,8 @@ use function Laravel\Prompts\warning;
 
 class AuthToken extends BaseCommand implements NoAuthRequired
 {
+    use AcceptsPipedInput;
+
     protected $signature = 'auth:token
                             {--add : Add a new API token}
                             {--remove : Remove an API token}
@@ -201,7 +203,9 @@ class AuthToken extends BaseCommand implements NoAuthRequired
 
     protected function tokenFromInput(): ?string
     {
-        $token = $this->option('token') ?: app(Stdin::class)->read();
+        $this->fillOptionFromStdin('token');
+
+        $token = $this->option('token');
 
         if ($token === null || trim($token) === '') {
             return null;

--- a/app/Commands/EnvironmentSecretAttach.php
+++ b/app/Commands/EnvironmentSecretAttach.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\Commands;
+
+use App\Client\Requests\AttachEnvironmentSecretsRequestData;
+use App\Dto\Environment;
+use App\Dto\Secret;
+use Illuminate\Support\LazyCollection;
+
+use function Laravel\Prompts\intro;
+use function Laravel\Prompts\multiselect;
+use function Laravel\Prompts\spin;
+
+class EnvironmentSecretAttach extends BaseCommand
+{
+    protected ?string $jsonDataClass = Environment::class;
+
+    protected $signature = 'environment-secret:attach
+                            {environment? : The environment ID or name}
+                            {secrets?* : The secret IDs to attach}';
+
+    protected $description = 'Attach secrets to an environment';
+
+    public function handle()
+    {
+        $this->ensureClient();
+
+        intro('Attaching Secrets');
+
+        $environment = $this->resolvers()->environment()->from($this->argument('environment'));
+
+        $secrets = $this->resolveSecrets();
+
+        $updatedEnvironment = spin(
+            fn () => $this->client->environments()->attachSecrets(
+                new AttachEnvironmentSecretsRequestData(
+                    environmentId: $environment->id,
+                    secrets: collect($secrets)->pluck('id')->all(),
+                ),
+            ),
+            'Attaching secrets...',
+        );
+
+        $this->outputJsonIfWanted($updatedEnvironment);
+
+        success('Secrets attached: '.collect($secrets)->pluck('key')->join(', '));
+    }
+
+    /**
+     * @return list<Secret>
+     */
+    protected function resolveSecrets(): array
+    {
+        $secrets = spin(
+            fn () => $this->client->secrets()->list()->collect(),
+            'Fetching secrets...',
+        );
+
+        if ($secrets->isEmpty()) {
+            $this->failAndExit('No secrets found. Create one with `cloud secret:create`.');
+        }
+
+        $identifiers = $this->argument('secrets');
+
+        if ($identifiers === []) {
+            return $this->selectSecrets($secrets);
+        }
+
+        // Only IDs are accepted: secret names are not unique within an organization.
+        return collect($identifiers)->map(function (string $identifier) use ($secrets) {
+            $secret = $secrets->firstWhere('id', $identifier);
+
+            if (! $secret) {
+                $this->failAndExit("Unable to resolve secret: {$identifier}. Provide a secret ID; run `cloud secret:list --json` to see them.");
+            }
+
+            return $secret;
+        })->unique('id')->values()->all();
+    }
+
+    /**
+     * @return list<Secret>
+     */
+    protected function selectSecrets(LazyCollection $secrets): array
+    {
+        // Names are not unique, so each option carries its ID.
+        $options = $secrets->mapWithKeys(fn (Secret $secret) => [$secret->id => "{$secret->key} ({$secret->id})"])->toArray();
+
+        if (! $this->isInteractive()) {
+            $this->failAndExit('At least one secret is required. Provide secret IDs as arguments. Available secrets: '.implode(', ', array_keys($options)).'.');
+        }
+
+        $selected = multiselect(
+            label: 'Secrets',
+            options: $options,
+            required: true,
+        );
+
+        return $secrets->whereIn('id', $selected)->values()->all();
+    }
+}

--- a/app/Commands/EnvironmentSecretAttach.php
+++ b/app/Commands/EnvironmentSecretAttach.php
@@ -5,7 +5,7 @@ namespace App\Commands;
 use App\Client\Requests\AttachEnvironmentSecretsRequestData;
 use App\Dto\Environment;
 use App\Dto\Secret;
-use Illuminate\Support\LazyCollection;
+use Illuminate\Support\Collection;
 
 use function Laravel\Prompts\intro;
 use function Laravel\Prompts\multiselect;
@@ -52,7 +52,7 @@ class EnvironmentSecretAttach extends BaseCommand
     protected function resolveSecrets(): array
     {
         $secrets = spin(
-            fn () => $this->client->secrets()->list()->collect(),
+            fn () => collect($this->client->secrets()->list()->collect()),
             'Fetching secrets...',
         );
 
@@ -66,9 +66,11 @@ class EnvironmentSecretAttach extends BaseCommand
             return $this->selectSecrets($secrets);
         }
 
+        $resolver = $this->resolvers()->secret();
+
         // Only IDs are accepted: secret names are not unique within an organization.
-        return collect($identifiers)->map(function (string $identifier) use ($secrets) {
-            $secret = $secrets->firstWhere('id', $identifier);
+        return collect($identifiers)->map(function (string $identifier) use ($secrets, $resolver) {
+            $secret = $resolver->fromCollection($secrets, $identifier);
 
             if (! $secret) {
                 $this->failAndExit("Unable to resolve secret: {$identifier}. Provide a secret ID; run `cloud secret:list --json` to see them.");
@@ -81,7 +83,7 @@ class EnvironmentSecretAttach extends BaseCommand
     /**
      * @return list<Secret>
      */
-    protected function selectSecrets(LazyCollection $secrets): array
+    protected function selectSecrets(Collection $secrets): array
     {
         // Names are not unique, so each option carries its ID.
         $options = $secrets->mapWithKeys(fn (Secret $secret) => [$secret->id => "{$secret->key} ({$secret->id})"])->toArray();

--- a/app/Commands/EnvironmentSecretList.php
+++ b/app/Commands/EnvironmentSecretList.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Commands;
+
+use App\Dto\Secret;
+
+use function Laravel\Prompts\intro;
+use function Laravel\Prompts\spin;
+use function Laravel\Prompts\warning;
+
+class EnvironmentSecretList extends BaseCommand
+{
+    protected ?string $jsonDataClass = Secret::class;
+
+    protected bool $jsonDataIsCollection = true;
+
+    protected $signature = 'environment-secret:list
+                            {environment? : The environment ID or name}';
+
+    protected $description = 'List the secrets attached to an environment';
+
+    public function handle()
+    {
+        $this->ensureClient();
+
+        intro('Environment Secrets');
+
+        $environment = $this->resolvers()->environment()->from($this->argument('environment'));
+
+        // The environment carries its secrets as an include; there is no endpoint of their own.
+        $environment = spin(
+            fn () => $this->client->environments()->include('secrets')->get($environment->id),
+            'Fetching secrets...',
+        );
+
+        $items = collect($environment->secrets);
+
+        $this->outputJsonIfWanted($items->toArray());
+
+        if ($items->isEmpty()) {
+            warning('No secrets attached to this environment.');
+
+            return self::SUCCESS;
+        }
+
+        dataTable(
+            headers: ['ID', 'Name', 'Notes', 'Created At'],
+            rows: $items->map(fn (Secret $secret) => [
+                $secret->id,
+                $secret->key,
+                $secret->notes ?? '—',
+                $secret->createdAt?->toIso8601String() ?? '—',
+            ])->toArray(),
+        );
+    }
+}

--- a/app/Commands/SecretCreate.php
+++ b/app/Commands/SecretCreate.php
@@ -7,9 +7,9 @@ use App\Dto\Secret;
 use App\Dto\SecretPublicKey;
 
 use function Laravel\Prompts\intro;
+use function Laravel\Prompts\password;
 use function Laravel\Prompts\spin;
 use function Laravel\Prompts\text;
-use function Laravel\Prompts\textarea;
 
 class SecretCreate extends BaseCommand
 {
@@ -53,15 +53,21 @@ class SecretCreate extends BaseCommand
             'name',
         );
 
-        // A textarea so multi-line values (private keys, certificates) can be pasted in.
         $this->form()->prompt(
             'value',
-            fn ($resolver) => $resolver->fromInput(fn (?string $value) => textarea(
-                label: 'Value',
-                default: $value ?? '',
-                required: true,
-                hint: 'The value is encrypted before it leaves your machine.',
-            )),
+            fn ($resolver) => $resolver->fromInput(fn (?string $value) => $this->option('show-sensitive')
+                ? text(
+                    label: 'Value',
+                    default: $value ?? '',
+                    required: true,
+                    hint: 'The value is encrypted before it leaves your machine.',
+                )
+                : password(
+                    label: 'Value',
+                    required: true,
+                    hint: 'The value is encrypted before it leaves your machine.',
+                ),
+            ),
         );
 
         $this->form()->prompt(

--- a/app/Commands/SecretCreate.php
+++ b/app/Commands/SecretCreate.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Commands;
+
+use App\Client\Requests\CreateSecretRequestData;
+use App\Dto\Secret;
+use App\Dto\SecretPublicKey;
+
+use function Laravel\Prompts\intro;
+use function Laravel\Prompts\spin;
+use function Laravel\Prompts\text;
+use function Laravel\Prompts\textarea;
+
+class SecretCreate extends BaseCommand
+{
+    protected ?string $jsonDataClass = Secret::class;
+
+    protected $signature = 'secret:create
+                            {--name= : The secret name, e.g. STRIPE_KEY}
+                            {--value= : The secret value}
+                            {--notes= : Notes describing the secret (max 500 characters)}';
+
+    protected $description = 'Create a new secret';
+
+    public function handle()
+    {
+        $this->ensureClient();
+
+        intro('Creating Secret');
+
+        $publicKey = spin(
+            fn () => $this->client->secrets()->publicKey(),
+            'Fetching public key...',
+        );
+
+        $secret = $this->loopUntilValid(fn () => $this->createSecret($publicKey));
+
+        $this->outputJsonIfWanted($secret);
+
+        success("Secret created: {$secret->key}");
+    }
+
+    protected function createSecret(SecretPublicKey $publicKey)
+    {
+        $this->form()->prompt(
+            'key',
+            fn ($resolver) => $resolver->fromInput(fn (?string $value) => text(
+                label: 'Secret name',
+                placeholder: 'STRIPE_KEY',
+                default: $value ?? '',
+                required: true,
+            )),
+            'name',
+        );
+
+        // A textarea so multi-line values (private keys, certificates) can be pasted in.
+        $this->form()->prompt(
+            'value',
+            fn ($resolver) => $resolver->fromInput(fn (?string $value) => textarea(
+                label: 'Value',
+                default: $value ?? '',
+                required: true,
+                hint: 'The value is encrypted before it leaves your machine.',
+            )),
+        );
+
+        $this->form()->prompt(
+            'notes',
+            fn ($resolver) => $resolver
+                ->fromInput(fn (?string $value) => text(
+                    label: 'Notes',
+                    placeholder: 'Optional',
+                    default: $value ?? '',
+                    validate: fn (string $notes) => strlen($notes) > 500
+                        ? 'The notes cannot exceed 500 characters.'
+                        : null,
+                ))
+                ->nonInteractively(fn () => ''),
+        );
+
+        $notes = $this->form()->get('notes');
+
+        return spin(
+            fn () => $this->client->secrets()->create(
+                new CreateSecretRequestData(
+                    keyPairId: $publicKey->id,
+                    key: $this->form()->get('key'),
+                    value: $publicKey->encrypt($this->form()->get('value')),
+                    notes: $notes === '' ? null : $notes,
+                ),
+            ),
+            'Creating secret...',
+        );
+    }
+}

--- a/app/Commands/SecretCreate.php
+++ b/app/Commands/SecretCreate.php
@@ -3,6 +3,7 @@
 namespace App\Commands;
 
 use App\Client\Requests\CreateSecretRequestData;
+use App\Concerns\AcceptsPipedInput;
 use App\Dto\Secret;
 use App\Dto\SecretPublicKey;
 
@@ -13,11 +14,13 @@ use function Laravel\Prompts\text;
 
 class SecretCreate extends BaseCommand
 {
+    use AcceptsPipedInput;
+
     protected ?string $jsonDataClass = Secret::class;
 
     protected $signature = 'secret:create
                             {--name= : The secret name, e.g. STRIPE_KEY}
-                            {--value= : The secret value}
+                            {--value= : The secret value (may also be piped to STDIN)}
                             {--notes= : Notes describing the secret (max 500 characters)}';
 
     protected $description = 'Create a new secret';
@@ -27,6 +30,8 @@ class SecretCreate extends BaseCommand
         $this->ensureClient();
 
         intro('Creating Secret');
+
+        $this->fillOptionFromStdin('value');
 
         $publicKey = spin(
             fn () => $this->client->secrets()->publicKey(),

--- a/app/Commands/SecretDelete.php
+++ b/app/Commands/SecretDelete.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Commands;
+
+use function Laravel\Prompts\intro;
+use function Laravel\Prompts\spin;
+
+class SecretDelete extends BaseCommand
+{
+    protected $signature = 'secret:delete
+                            {secret? : The secret ID or name}
+                            {--force : Skip confirmation}';
+
+    protected $description = 'Delete a secret';
+
+    public function handle()
+    {
+        $this->ensureClient();
+
+        intro('Deleting Secret');
+
+        $secret = $this->resolvers()->secret()->from($this->argument('secret'));
+
+        $this->confirmDestructive("Delete secret '{$secret->key}'? It will be detached from every environment using it.");
+
+        spin(
+            fn () => $this->client->secrets()->delete($secret->id),
+            'Deleting secret...',
+        );
+
+        $this->outputJsonIfWanted('Secret deleted.');
+
+        success('Secret deleted');
+    }
+}

--- a/app/Commands/SecretDelete.php
+++ b/app/Commands/SecretDelete.php
@@ -8,7 +8,7 @@ use function Laravel\Prompts\spin;
 class SecretDelete extends BaseCommand
 {
     protected $signature = 'secret:delete
-                            {secret? : The secret ID or name}
+                            {secret? : The secret ID}
                             {--force : Skip confirmation}';
 
     protected $description = 'Delete a secret';

--- a/app/Commands/SecretList.php
+++ b/app/Commands/SecretList.php
@@ -27,7 +27,7 @@ class SecretList extends BaseCommand
         answered('Organization', $this->client->meta()->organization()->name);
 
         $items = spin(
-            fn () => $this->client->secrets()->list()->collect(),
+            fn () => collect($this->client->secrets()->list()->collect()),
             'Fetching secrets...',
         );
 

--- a/app/Commands/SecretList.php
+++ b/app/Commands/SecretList.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Commands;
+
+use App\Dto\Secret;
+
+use function Laravel\Prompts\intro;
+use function Laravel\Prompts\spin;
+use function Laravel\Prompts\warning;
+
+class SecretList extends BaseCommand
+{
+    protected ?string $jsonDataClass = Secret::class;
+
+    protected bool $jsonDataIsCollection = true;
+
+    protected $signature = 'secret:list';
+
+    protected $description = 'List secrets';
+
+    public function handle()
+    {
+        $this->ensureClient();
+
+        intro('Secrets');
+
+        answered('Organization', $this->client->meta()->organization()->name);
+
+        $items = spin(
+            fn () => $this->client->secrets()->list()->collect(),
+            'Fetching secrets...',
+        );
+
+        $this->outputJsonIfWanted($items->toArray());
+
+        if ($items->isEmpty()) {
+            warning('No secrets found.');
+
+            return self::SUCCESS;
+        }
+
+        dataTable(
+            headers: ['ID', 'Name', 'Notes', 'Created At'],
+            rows: $items->map(fn (Secret $secret) => [
+                $secret->id,
+                $secret->key,
+                $secret->notes ?? '—',
+                $secret->createdAt?->toIso8601String() ?? '—',
+            ])->toArray(),
+        );
+    }
+}

--- a/app/Commands/SecretUpdate.php
+++ b/app/Commands/SecretUpdate.php
@@ -3,6 +3,7 @@
 namespace App\Commands;
 
 use App\Client\Requests\UpdateSecretRequestData;
+use App\Concerns\AcceptsPipedInput;
 use App\Dto\Secret;
 use App\Exceptions\CommandExitException;
 
@@ -14,12 +15,14 @@ use function Laravel\Prompts\text;
 
 class SecretUpdate extends BaseCommand
 {
+    use AcceptsPipedInput;
+
     protected ?string $jsonDataClass = Secret::class;
 
     protected $signature = 'secret:update
                             {secret? : The secret ID}
                             {--name= : The secret name, e.g. STRIPE_KEY}
-                            {--value= : A new secret value}
+                            {--value= : A new secret value (may also be piped to STDIN)}
                             {--notes= : Notes describing the secret (max 500 characters)}
                             {--force : Force update without confirmation}';
 
@@ -30,6 +33,8 @@ class SecretUpdate extends BaseCommand
         $this->ensureClient();
 
         intro('Updating Secret');
+
+        $this->fillOptionFromStdin('value');
 
         $secret = $this->resolvers()->secret()->from($this->argument('secret'));
 

--- a/app/Commands/SecretUpdate.php
+++ b/app/Commands/SecretUpdate.php
@@ -17,7 +17,7 @@ class SecretUpdate extends BaseCommand
     protected ?string $jsonDataClass = Secret::class;
 
     protected $signature = 'secret:update
-                            {secret? : The secret ID or name}
+                            {secret? : The secret ID}
                             {--name= : The secret name, e.g. STRIPE_KEY}
                             {--value= : A new secret value}
                             {--notes= : Notes describing the secret (max 500 characters)}

--- a/app/Commands/SecretUpdate.php
+++ b/app/Commands/SecretUpdate.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace App\Commands;
+
+use App\Client\Requests\UpdateSecretRequestData;
+use App\Dto\Secret;
+use App\Exceptions\CommandExitException;
+
+use function Laravel\Prompts\intro;
+use function Laravel\Prompts\multiselect;
+use function Laravel\Prompts\spin;
+use function Laravel\Prompts\text;
+use function Laravel\Prompts\textarea;
+
+class SecretUpdate extends BaseCommand
+{
+    protected ?string $jsonDataClass = Secret::class;
+
+    protected $signature = 'secret:update
+                            {secret? : The secret ID or name}
+                            {--name= : The secret name, e.g. STRIPE_KEY}
+                            {--value= : A new secret value}
+                            {--notes= : Notes describing the secret (max 500 characters)}
+                            {--force : Force update without confirmation}';
+
+    protected $description = 'Update a secret';
+
+    public function handle()
+    {
+        $this->ensureClient();
+
+        intro('Updating Secret');
+
+        $secret = $this->resolvers()->secret()->from($this->argument('secret'));
+
+        $this->defineFields($secret);
+
+        foreach ($this->form()->filled() as $key => $field) {
+            // The plaintext value must never be echoed back to the terminal.
+            $this->reportChange(
+                $field->label(),
+                $key === 'value' ? null : $field->previousValue(),
+                $key === 'value' ? '••••••••' : $field->value(),
+            );
+        }
+
+        $updatedSecret = $this->runUpdate(
+            fn () => $this->updateSecret($secret),
+            fn () => $this->collectDataAndUpdate($secret),
+        );
+
+        $this->outputJsonIfWanted($updatedSecret);
+
+        success("Secret updated: {$updatedSecret->key}");
+    }
+
+    protected function updateSecret(Secret $secret): Secret
+    {
+        $value = $this->form()->get('value');
+
+        // The key pair is only needed when a new value is being encrypted.
+        $publicKey = $value === null ? null : spin(
+            fn () => $this->client->secrets()->publicKey(),
+            'Fetching public key...',
+        );
+
+        return spin(
+            fn () => $this->client->secrets()->update(
+                new UpdateSecretRequestData(
+                    secretId: $secret->id,
+                    // The API requires the name on every update, so resend the current one when it is unchanged.
+                    key: $this->form()->get('name') ?? $secret->key,
+                    value: $publicKey?->encrypt($value),
+                    keyPairId: $publicKey?->id,
+                    notes: $this->form()->get('notes'),
+                ),
+            ),
+            'Updating secret...',
+        );
+    }
+
+    protected function defineFields(Secret $secret): void
+    {
+        $this->form()->define(
+            'name',
+            fn ($resolver) => $resolver->fromInput(fn (?string $value) => text(
+                label: 'Secret name',
+                default: $value ?? $secret->key,
+                required: true,
+            )),
+        )->setPreviousValue($secret->key);
+
+        $this->form()->define(
+            'value',
+            fn ($resolver) => $resolver->fromInput(fn (?string $value) => textarea(
+                label: 'Value',
+                default: $value ?? '',
+                required: true,
+                hint: 'The value is encrypted before it leaves your machine.',
+            )),
+        );
+
+        $this->form()->define(
+            'notes',
+            fn ($resolver) => $resolver->fromInput(fn (?string $value) => text(
+                label: 'Notes',
+                placeholder: 'Optional',
+                default: $value ?? $secret->notes ?? '',
+                validate: fn (string $notes) => strlen($notes) > 500
+                    ? 'The notes cannot exceed 500 characters.'
+                    : null,
+            )),
+        )->setPreviousValue($secret->notes);
+    }
+
+    protected function collectDataAndUpdate(Secret $secret): Secret
+    {
+        $selection = multiselect(
+            label: 'What do you want to update?',
+            options: collect($this->form()->defined())->mapWithKeys(fn ($field) => [
+                $field->key => $field->label(),
+            ])->toArray(),
+        );
+
+        if (empty($selection)) {
+            $this->outputErrorOrThrow('No fields to update. Select at least one option.');
+
+            throw new CommandExitException(self::FAILURE);
+        }
+
+        foreach ($selection as $optionName) {
+            $this->form()->prompt($optionName);
+        }
+
+        return $this->updateSecret($secret);
+    }
+}

--- a/app/Commands/SecretUpdate.php
+++ b/app/Commands/SecretUpdate.php
@@ -8,9 +8,9 @@ use App\Exceptions\CommandExitException;
 
 use function Laravel\Prompts\intro;
 use function Laravel\Prompts\multiselect;
+use function Laravel\Prompts\password;
 use function Laravel\Prompts\spin;
 use function Laravel\Prompts\text;
-use function Laravel\Prompts\textarea;
 
 class SecretUpdate extends BaseCommand
 {
@@ -92,12 +92,19 @@ class SecretUpdate extends BaseCommand
 
         $this->form()->define(
             'value',
-            fn ($resolver) => $resolver->fromInput(fn (?string $value) => textarea(
-                label: 'Value',
-                default: $value ?? '',
-                required: true,
-                hint: 'The value is encrypted before it leaves your machine.',
-            )),
+            fn ($resolver) => $resolver->fromInput(fn (?string $value) => $this->option('show-sensitive')
+                ? text(
+                    label: 'Value',
+                    default: $value ?? '',
+                    required: true,
+                    hint: 'The value is encrypted before it leaves your machine.',
+                )
+                : password(
+                    label: 'Value',
+                    required: true,
+                    hint: 'The value is encrypted before it leaves your machine.',
+                ),
+            ),
         );
 
         $this->form()->define(

--- a/app/Concerns/AcceptsPipedInput.php
+++ b/app/Concerns/AcceptsPipedInput.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Concerns;
+
+use App\Support\Stdin;
+
+trait AcceptsPipedInput
+{
+    /**
+     * Let a sensitive option be piped in instead of typed, so its value never lands
+     * in shell history or the process list. Must run before form() is first built.
+     */
+    protected function fillOptionFromStdin(string $option): void
+    {
+        if (filled($this->option($option))) {
+            return;
+        }
+
+        $piped = app(Stdin::class)->read();
+
+        if ($piped === null) {
+            return;
+        }
+
+        $this->input->setOption($option, $piped);
+    }
+}

--- a/app/Dto/Environment.php
+++ b/app/Dto/Environment.php
@@ -5,6 +5,7 @@ namespace App\Dto;
 use App\Dto\Transformers\MaskEnvironmentVariables;
 use App\Enums\EnvironmentStatus;
 use Carbon\CarbonImmutable;
+use Spatie\LaravelData\Attributes\DataCollectionOf;
 use Spatie\LaravelData\Attributes\WithCast;
 use Spatie\LaravelData\Attributes\WithTransformer;
 use Spatie\LaravelData\Casts\DateTimeInterfaceCast;
@@ -49,6 +50,8 @@ class Environment extends Data
         public readonly ?string $databaseSchemaId = null,
         public readonly ?string $cacheId = null,
         public readonly ?string $websocketApplicationId = null,
+        #[DataCollectionOf(Secret::class)]
+        public readonly array $secrets = [],
     ) {
         //
     }
@@ -126,6 +129,16 @@ class Environment extends Data
 
         if (isset($relationships['websocketApplication']['data']['id'])) {
             $transformed['websocketApplicationId'] = $relationships['websocketApplication']['data']['id'];
+        }
+
+        if (isset($relationships['secrets']['data'])) {
+            $secretIds = array_column($relationships['secrets']['data'], 'id');
+
+            $transformed['secrets'] = collect($included)
+                ->filter(fn (array $item) => $item['type'] === 'secrets' && in_array($item['id'], $secretIds, true))
+                ->map(fn (array $item) => Secret::createFromResponse(['data' => $item]))
+                ->values()
+                ->all();
         }
 
         return self::from($transformed);

--- a/app/Dto/Secret.php
+++ b/app/Dto/Secret.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Dto;
+
+use Carbon\CarbonImmutable;
+use Spatie\LaravelData\Attributes\WithCast;
+use Spatie\LaravelData\Casts\DateTimeInterfaceCast;
+use Spatie\LaravelData\Data;
+
+class Secret extends Data
+{
+    public function __construct(
+        public readonly string $id,
+        public readonly string $key,
+        public readonly ?string $notes = null,
+        #[WithCast(DateTimeInterfaceCast::class, type: CarbonImmutable::class)]
+        public readonly ?CarbonImmutable $createdAt = null,
+        #[WithCast(DateTimeInterfaceCast::class, type: CarbonImmutable::class)]
+        public readonly ?CarbonImmutable $updatedAt = null,
+    ) {
+        //
+    }
+
+    public static function createFromResponse(array $response): self
+    {
+        $data = $response['data'] ?? [];
+        $attributes = $data['attributes'] ?? [];
+
+        return self::from([
+            'id' => $data['id'],
+            'key' => $attributes['key'] ?? '',
+            'notes' => $attributes['notes'] ?? null,
+            'createdAt' => $attributes['created_at'] ?? null,
+            'updatedAt' => $attributes['updated_at'] ?? null,
+        ]);
+    }
+}

--- a/app/Dto/SecretPublicKey.php
+++ b/app/Dto/SecretPublicKey.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Dto;
+
+use RuntimeException;
+use SensitiveParameter;
+use Spatie\LaravelData\Data;
+
+class SecretPublicKey extends Data
+{
+    public function __construct(
+        public readonly string $id,
+        public readonly string $publicKey,
+    ) {
+        //
+    }
+
+    public static function createFromResponse(array $response): self
+    {
+        $data = $response['data'] ?? [];
+        $attributes = $data['attributes'] ?? [];
+
+        return self::from([
+            'id' => $data['id'],
+            'publicKey' => $attributes['public_key'] ?? '',
+        ]);
+    }
+
+    /**
+     * Encrypt a value so only Cloud can decrypt it. Plaintext values are rejected by the API.
+     */
+    public function encrypt(#[SensitiveParameter] string $value): string
+    {
+        $publicKey = base64_decode($this->publicKey, strict: true);
+
+        if ($publicKey === false) {
+            throw new RuntimeException('The secrets public key returned by Cloud is not valid base64.');
+        }
+
+        return base64_encode(sodium_crypto_box_seal($value, $publicKey));
+    }
+}

--- a/app/Dto/SecretPublicKey.php
+++ b/app/Dto/SecretPublicKey.php
@@ -31,6 +31,10 @@ class SecretPublicKey extends Data
      */
     public function encrypt(#[SensitiveParameter] string $value): string
     {
+        if (! function_exists('sodium_crypto_box_seal')) {
+            throw new RuntimeException('The sodium extension is required to encrypt secrets. Install or enable ext-sodium for your PHP installation.');
+        }
+
         $publicKey = base64_decode($this->publicKey, strict: true);
 
         if ($publicKey === false) {

--- a/app/Resolvers/Resolvers.php
+++ b/app/Resolvers/Resolvers.php
@@ -80,6 +80,11 @@ class Resolvers
         return $this->make(BucketKeyResolver::class);
     }
 
+    public function secret(): SecretResolver
+    {
+        return $this->make(SecretResolver::class);
+    }
+
     public function websocketCluster(): WebSocketClusterResolver
     {
         return $this->make(WebSocketClusterResolver::class);

--- a/app/Resolvers/SecretResolver.php
+++ b/app/Resolvers/SecretResolver.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Resolvers;
+
+use App\Dto\Secret;
+use Illuminate\Support\Collection;
+use Illuminate\Support\LazyCollection;
+
+use function Laravel\Prompts\select;
+use function Laravel\Prompts\spin;
+
+class SecretResolver extends Resolver
+{
+    public function resolve(): ?Secret
+    {
+        return $this->from();
+    }
+
+    public function from(?string $idOrName = null): ?Secret
+    {
+        $secret = ($idOrName ? $this->fromIdentifier($idOrName) : null)
+            ?? $this->fromInput();
+
+        if (! $secret) {
+            $this->failAndExit('Unable to resolve secret: '.($idOrName ?? 'Provide a valid secret ID or name.').'. Run `cloud secret:list --json` to see available secrets.');
+        }
+
+        $this->displayResolved('Secret', $secret->key, $secret->id);
+
+        return $secret;
+    }
+
+    // The API has no endpoint for a single secret, so an ID is matched against the list too.
+    public function fromIdentifier(string $identifier): ?Secret
+    {
+        return $this->fromCollection($this->fetchAll(), $identifier);
+    }
+
+    public function fromInput(): ?Secret
+    {
+        $secrets = $this->fetchAll();
+
+        if ($secrets->isEmpty()) {
+            $this->failAndExit('No secrets found.');
+        }
+
+        if ($secrets->hasSole()) {
+            return $secrets->first();
+        }
+
+        $options = $secrets->mapWithKeys(fn (Secret $secret) => [$secret->id => $secret->key])->toArray();
+
+        $this->ensureInteractive('Multiple secrets found. Provide a secret ID or name.', ['options' => $options]);
+
+        $selected = select(
+            label: 'Secret',
+            options: $options,
+            info: fn ($id) => $id,
+        );
+
+        $this->displayResolved = false;
+
+        return $secrets->firstWhere('id', $selected);
+    }
+
+    public function fromCollection(Collection|LazyCollection $secrets, string $identifier): ?Secret
+    {
+        return $secrets->firstWhere('id', $identifier)
+            ?? $secrets->firstWhere('key', $identifier);
+    }
+
+    protected function fetchAll(): LazyCollection
+    {
+        return spin(
+            fn () => $this->client->secrets()->list()->collect(),
+            'Fetching secrets...',
+        );
+    }
+
+    protected function idPrefix(): string
+    {
+        return 'scrt-';
+    }
+}

--- a/app/Resolvers/SecretResolver.php
+++ b/app/Resolvers/SecretResolver.php
@@ -16,13 +16,13 @@ class SecretResolver extends Resolver
         return $this->from();
     }
 
-    public function from(?string $idOrName = null): ?Secret
+    public function from(?string $id = null): ?Secret
     {
-        $secret = ($idOrName ? $this->fromIdentifier($idOrName) : null)
-            ?? $this->fromInput();
+        // An unknown ID is not passed on to the picker: silently prompting would hide the typo.
+        $secret = $id ? $this->fromIdentifier($id) : $this->fromInput();
 
         if (! $secret) {
-            $this->failAndExit('Unable to resolve secret: '.($idOrName ?? 'Provide a valid secret ID or name.').'. Run `cloud secret:list --json` to see available secrets.');
+            $this->failAndExit('Unable to resolve secret: '.($id ?? 'Provide a valid secret ID.').'. Run `cloud secret:list --json` to see available secret IDs.');
         }
 
         $this->displayResolved('Secret', $secret->key, $secret->id);
@@ -30,7 +30,7 @@ class SecretResolver extends Resolver
         return $secret;
     }
 
-    // The API has no endpoint for a single secret, so an ID is matched against the list too.
+    // The API has no endpoint for a single secret, so the ID is matched against the list.
     public function fromIdentifier(string $identifier): ?Secret
     {
         return $this->fromCollection($this->fetchAll(), $identifier);
@@ -50,7 +50,7 @@ class SecretResolver extends Resolver
 
         $options = $secrets->mapWithKeys(fn (Secret $secret) => [$secret->id => $secret->key])->toArray();
 
-        $this->ensureInteractive('Multiple secrets found. Provide a secret ID or name.', ['options' => $options]);
+        $this->ensureInteractive('Multiple secrets found. Provide a secret ID.', ['options' => $options]);
 
         $selected = select(
             label: 'Secret',
@@ -63,10 +63,10 @@ class SecretResolver extends Resolver
         return $secrets->firstWhere('id', $selected);
     }
 
-    public function fromCollection(Collection|LazyCollection $secrets, string $identifier): ?Secret
+    // Only IDs are accepted: secret names are not unique within an organization.
+    public function fromCollection(Collection|LazyCollection $secrets, string $id): ?Secret
     {
-        return $secrets->firstWhere('id', $identifier)
-            ?? $secrets->firstWhere('key', $identifier);
+        return $secrets->firstWhere('id', $id);
     }
 
     protected function fetchAll(): LazyCollection

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,9 @@
         "saloonphp/saloon": "^4.0",
         "spatie/laravel-data": "^4.19"
     },
+    "suggest": {
+        "ext-sodium": "Required to create and update secrets"
+    },
     "autoload": {
         "psr-4": {
             "App\\": "app/",

--- a/skills/deploying-laravel-cloud/SKILL.md
+++ b/skills/deploying-laravel-cloud/SKILL.md
@@ -17,7 +17,7 @@ cloud auth -n
 
 Commands follow a CRUD pattern: `resource:list`, `resource:get`, `resource:create`, `resource:update`, `resource:delete`.
 
-Available resources: `application`, `environment`, `instance`, `database-cluster`, `database`, `cache`, `bucket`, `domain`, `websocket-cluster`, `background-process`, `command`, `deployment`.
+Available resources: `application`, `environment`, `instance`, `database-cluster`, `database`, `cache`, `bucket`, `domain`, `websocket-cluster`, `background-process`, `secret`, `command`, `deployment`.
 
 Some resources have additional commands (e.g., `domain:verify`, `database:open`, `instance:sizes`, `cache:types`). Discover these via `cloud -h`.
 
@@ -49,6 +49,8 @@ cloud deploy:monitor -n
 ```
 
 Environment variables? → `cloud environment:variables -n --force`
+
+Secrets? → `echo "$VALUE" | cloud secret:create --name=NAME --json -n` then `cloud environment-secret:attach`
 
 Provision infrastructure? → `cloud <resource>:create --json -n`
 
@@ -96,6 +98,25 @@ Use your judgment:
 - Which resources to provision — based on what the user describes
 - Order of provisioning — no strict sequence required
 - How to present output — summarize, show raw, or extract fields based on context
+
+## Secrets
+
+Encrypted values shared across the organization and attached to environments. The CLI encrypts the value locally, so plaintext never reaches the API.
+
+```sh
+cloud secret:list --json -n
+echo "$VALUE" | cloud secret:create --name=STRIPE_KEY --json -n
+cloud environment-secret:attach {environment} {secretId} -n
+cloud environment-secret:list {environment} --json -n
+```
+
+Pipe the value in. `--value=` works, but leaves the plaintext in shell history and the process list.
+
+`secret:update`, `secret:delete`, and `environment-secret:attach` take secret IDs, not names — names are not unique. Read IDs from `cloud secret:list --json -n`.
+
+There is no `secret:get`, and no way to detach a secret from a single environment. `secret:delete` removes it and detaches it everywhere.
+
+Secrets need the `sodium` PHP extension. No other command does.
 
 ## Remote Access
 

--- a/skills/deploying-laravel-cloud/reference/checklists.md
+++ b/skills/deploying-laravel-cloud/reference/checklists.md
@@ -10,6 +10,7 @@ Use these checklists when performing complex setups. Copy the relevant checklist
 - [ ] Provision the database (`database-cluster:create` then `database:create`)
 - [ ] Provision the cache (`cache:create`)
 - [ ] Set environment variables (`environment:variables`)
+- [ ] Create and attach any secrets (`secret:create` then `environment-secret:attach`)
 - [ ] Attach custom domain (`domain:create` then `domain:verify`)
 - [ ] Deploy (`deploy` then `deploy:monitor`)
 - [ ] Verify the deployment is live

--- a/tests/Feature/EnvironmentSecretAttachTest.php
+++ b/tests/Feature/EnvironmentSecretAttachTest.php
@@ -1,0 +1,120 @@
+<?php
+
+use App\Client\Resources\Environments\AttachEnvironmentSecretsRequest;
+use App\Client\Resources\Environments\GetEnvironmentRequest;
+use App\Client\Resources\Meta\GetOrganizationRequest;
+use App\Client\Resources\Secrets\ListSecretsRequest;
+use App\ConfigRepository;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+use Saloon\Http\PendingRequest;
+
+beforeEach(function () {
+    $this->mockConfig = Mockery::mock(ConfigRepository::class);
+    $this->mockConfig->shouldReceive('apiTokens')->andReturn(collect(['test-api-token']));
+    $this->app->instance(ConfigRepository::class, $this->mockConfig);
+});
+
+afterEach(function () {
+    MockClient::destroyGlobal();
+});
+
+function setupEnvironmentSecretAttachMocks(?array $secrets = null): Closure
+{
+    $sentBody = new stdClass;
+
+    $secrets ??= [
+        secretResponse(),
+        secretResponse(['id' => 'secret-2', 'attributes' => ['key' => 'MAILGUN_SECRET']]),
+    ];
+
+    MockClient::global([
+        GetOrganizationRequest::class => MockResponse::make(organizationResponse(), 200),
+        GetEnvironmentRequest::class => MockResponse::make(['data' => createEnvironmentResponse()], 200),
+        ListSecretsRequest::class => MockResponse::make([
+            'data' => $secrets,
+            'links' => ['next' => null],
+        ], 200),
+        AttachEnvironmentSecretsRequest::class => function (PendingRequest $request) use ($sentBody) {
+            $sentBody->value = $request->body()->all();
+            $sentBody->url = $request->getUrl();
+
+            return MockResponse::make(['data' => createEnvironmentResponse()], 200);
+        },
+    ]);
+
+    return fn () => $sentBody;
+}
+
+it('attaches secrets by ID', function () {
+    $sent = setupEnvironmentSecretAttachMocks();
+
+    $this->artisan('environment-secret:attach', [
+        'environment' => 'env-1',
+        'secrets' => ['secret-1', 'secret-2'],
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+
+    expect($sent()->value)->toBe(['secrets' => ['secret-1', 'secret-2']]);
+    expect($sent()->url)->toEndWith('/environments/env-1/secrets');
+});
+
+it('attaches a single secret', function () {
+    $sent = setupEnvironmentSecretAttachMocks();
+
+    $this->artisan('environment-secret:attach', [
+        'environment' => 'env-1',
+        'secrets' => ['secret-2'],
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+
+    expect($sent()->value)->toBe(['secrets' => ['secret-2']]);
+});
+
+it('sends a secret only once when it is repeated', function () {
+    $sent = setupEnvironmentSecretAttachMocks();
+
+    $this->artisan('environment-secret:attach', [
+        'environment' => 'env-1',
+        'secrets' => ['secret-1', 'secret-1'],
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+
+    expect($sent()->value)->toBe(['secrets' => ['secret-1']]);
+});
+
+it('rejects a secret name', function () {
+    $sent = setupEnvironmentSecretAttachMocks();
+
+    $this->artisan('environment-secret:attach', [
+        'environment' => 'env-1',
+        // Names are not unique, so only IDs are accepted.
+        'secrets' => ['STRIPE_KEY'],
+        '--no-interaction' => true,
+    ])->assertFailed();
+
+    expect($sent()->value ?? null)->toBeNull();
+});
+
+it('fails when no secrets are given non-interactively', function () {
+    $sent = setupEnvironmentSecretAttachMocks();
+
+    $this->artisan('environment-secret:attach', [
+        'environment' => 'env-1',
+        '--no-interaction' => true,
+    ])->assertFailed();
+
+    expect($sent()->value ?? null)->toBeNull();
+});
+
+it('fails when the organization has no secrets', function () {
+    $sent = setupEnvironmentSecretAttachMocks([]);
+
+    $this->artisan('environment-secret:attach', [
+        'environment' => 'env-1',
+        'secrets' => ['secret-1'],
+        '--no-interaction' => true,
+    ])->assertFailed();
+
+    expect($sent()->value ?? null)->toBeNull();
+});

--- a/tests/Feature/EnvironmentSecretListTest.php
+++ b/tests/Feature/EnvironmentSecretListTest.php
@@ -1,0 +1,75 @@
+<?php
+
+use App\Client\Resources\Environments\GetEnvironmentRequest;
+use App\Client\Resources\Meta\GetOrganizationRequest;
+use App\ConfigRepository;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+use Saloon\Http\PendingRequest;
+
+beforeEach(function () {
+    $this->mockConfig = Mockery::mock(ConfigRepository::class);
+    $this->mockConfig->shouldReceive('apiTokens')->andReturn(collect(['test-api-token']));
+    $this->app->instance(ConfigRepository::class, $this->mockConfig);
+});
+
+afterEach(function () {
+    MockClient::destroyGlobal();
+});
+
+function setupEnvironmentSecretListMocks(array $secrets): Closure
+{
+    $requested = new stdClass;
+
+    $environment = createEnvironmentResponse([
+        'relationships' => [
+            'secrets' => ['data' => array_map(fn (array $secret) => [
+                'id' => $secret['id'],
+                'type' => 'secrets',
+            ], $secrets)],
+        ],
+    ]);
+
+    MockClient::global([
+        GetOrganizationRequest::class => MockResponse::make(organizationResponse(), 200),
+        GetEnvironmentRequest::class => function (PendingRequest $request) use ($environment, $secrets, $requested) {
+            $requested->includes[] = $request->query()->get('include');
+
+            return MockResponse::make(['data' => $environment, 'included' => $secrets], 200);
+        },
+    ]);
+
+    return fn () => $requested->includes ?? [];
+}
+
+it('lists the secrets attached to an environment', function () {
+    setupEnvironmentSecretListMocks([
+        secretResponse(['attributes' => ['notes' => 'Used by billing.']]),
+        secretResponse(['id' => 'secret-2', 'attributes' => ['key' => 'MAILGUN_SECRET']]),
+    ]);
+
+    $this->artisan('environment-secret:list', [
+        'environment' => 'env-1',
+        '--no-interaction' => true,
+    ])->assertSuccessful()->expectsOutputToContain('MAILGUN_SECRET');
+});
+
+it('requests the secrets include', function () {
+    $includes = setupEnvironmentSecretListMocks([secretResponse()]);
+
+    $this->artisan('environment-secret:list', [
+        'environment' => 'env-1',
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+
+    expect($includes())->toContain('secrets');
+});
+
+it('warns when no secrets are attached', function () {
+    setupEnvironmentSecretListMocks([]);
+
+    $this->artisan('environment-secret:list', [
+        'environment' => 'env-1',
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+});

--- a/tests/Feature/SecretCreateTest.php
+++ b/tests/Feature/SecretCreateTest.php
@@ -18,38 +18,6 @@ afterEach(function () {
     MockClient::destroyGlobal();
 });
 
-/**
- * The key pair the command's encrypted values can be decrypted with, so the suite never
- * needs a real organization key pair.
- */
-function secretKeyPair(): string
-{
-    static $keyPair = null;
-
-    return $keyPair ??= sodium_crypto_box_keypair();
-}
-
-function secretPublicKeyResponse(): array
-{
-    return [
-        'data' => [
-            'id' => 'keypair-1',
-            'type' => 'organization-key-pairs',
-            'attributes' => [
-                'public_key' => base64_encode(sodium_crypto_box_publickey(secretKeyPair())),
-            ],
-        ],
-    ];
-}
-
-function decryptSecretValue(string $value): string
-{
-    return sodium_crypto_box_seal_open(
-        base64_decode($value, strict: true),
-        secretKeyPair(),
-    );
-}
-
 function setupSecretCreateMocks(): Closure
 {
     $sentBody = new stdClass;

--- a/tests/Feature/SecretCreateTest.php
+++ b/tests/Feature/SecretCreateTest.php
@@ -42,22 +42,6 @@ function secretPublicKeyResponse(): array
     ];
 }
 
-function createdSecretResponse(array $attributes = []): array
-{
-    return [
-        'data' => [
-            'id' => 'secret-1',
-            'type' => 'secrets',
-            'attributes' => array_merge([
-                'key' => 'STRIPE_KEY',
-                'notes' => null,
-                'created_at' => '2026-01-01T00:00:00.000000Z',
-                'updated_at' => '2026-01-01T00:00:00.000000Z',
-            ], $attributes),
-        ],
-    ];
-}
-
 function decryptSecretValue(string $value): string
 {
     return sodium_crypto_box_seal_open(
@@ -76,7 +60,7 @@ function setupSecretCreateMocks(): Closure
         CreateSecretRequest::class => function (PendingRequest $request) use ($sentBody) {
             $sentBody->value = $request->body()->all();
 
-            return MockResponse::make(createdSecretResponse(), 201);
+            return MockResponse::make(['data' => secretResponse()], 201);
         },
     ]);
 

--- a/tests/Feature/SecretCreateTest.php
+++ b/tests/Feature/SecretCreateTest.php
@@ -4,6 +4,7 @@ use App\Client\Resources\Meta\GetOrganizationRequest;
 use App\Client\Resources\Secrets\CreateSecretRequest;
 use App\Client\Resources\Secrets\GetSecretPublicKeyRequest;
 use App\ConfigRepository;
+use App\Support\Stdin;
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
 use Saloon\Http\PendingRequest;
@@ -12,6 +13,10 @@ beforeEach(function () {
     $this->mockConfig = Mockery::mock(ConfigRepository::class);
     $this->mockConfig->shouldReceive('apiTokens')->andReturn(collect(['test-api-token']));
     $this->app->instance(ConfigRepository::class, $this->mockConfig);
+
+    $this->mockStdin = Mockery::mock(Stdin::class);
+    $this->mockStdin->shouldReceive('read')->andReturn(null)->byDefault();
+    $this->app->instance(Stdin::class, $this->mockStdin);
 });
 
 afterEach(function () {
@@ -89,4 +94,62 @@ it('encrypts multi-line values', function () {
     ])->assertSuccessful();
 
     expect(decryptSecretValue($sentBody()['value']))->toBe($value);
+});
+
+function pipeSecretValue(?string $value): void
+{
+    test()->mockStdin->shouldReceive('read')->andReturn($value);
+}
+
+it('reads the value from STDIN when --value is not given', function () {
+    $sentBody = setupSecretCreateMocks();
+
+    pipeSecretValue('sk_test_piped');
+
+    $this->artisan('secret:create', [
+        '--name' => 'STRIPE_KEY',
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+
+    expect(decryptSecretValue($sentBody()['value']))->toBe('sk_test_piped');
+});
+
+it('prefers --value over STDIN', function () {
+    $sentBody = setupSecretCreateMocks();
+
+    pipeSecretValue('sk_test_piped');
+
+    $this->artisan('secret:create', [
+        '--name' => 'STRIPE_KEY',
+        '--value' => 'sk_test_option',
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+
+    expect(decryptSecretValue($sentBody()['value']))->toBe('sk_test_option');
+});
+
+it('encrypts a multi-line value piped to STDIN', function () {
+    $sentBody = setupSecretCreateMocks();
+
+    $value = "-----BEGIN PRIVATE KEY-----\nline-one\nline-two\n-----END PRIVATE KEY-----";
+
+    pipeSecretValue($value);
+
+    $this->artisan('secret:create', [
+        '--name' => 'SSH_KEY',
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+
+    expect(decryptSecretValue($sentBody()['value']))->toBe($value);
+});
+
+it('fails when neither --value nor STDIN provides a value', function () {
+    $sentBody = setupSecretCreateMocks();
+
+    $this->artisan('secret:create', [
+        '--name' => 'STRIPE_KEY',
+        '--no-interaction' => true,
+    ])->assertFailed();
+
+    expect($sentBody())->toBeNull();
 });

--- a/tests/Feature/SecretCreateTest.php
+++ b/tests/Feature/SecretCreateTest.php
@@ -1,0 +1,140 @@
+<?php
+
+use App\Client\Resources\Meta\GetOrganizationRequest;
+use App\Client\Resources\Secrets\CreateSecretRequest;
+use App\Client\Resources\Secrets\GetSecretPublicKeyRequest;
+use App\ConfigRepository;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+use Saloon\Http\PendingRequest;
+
+beforeEach(function () {
+    $this->mockConfig = Mockery::mock(ConfigRepository::class);
+    $this->mockConfig->shouldReceive('apiTokens')->andReturn(collect(['test-api-token']));
+    $this->app->instance(ConfigRepository::class, $this->mockConfig);
+});
+
+afterEach(function () {
+    MockClient::destroyGlobal();
+});
+
+/**
+ * The key pair the command's encrypted values can be decrypted with, so the suite never
+ * needs a real organization key pair.
+ */
+function secretKeyPair(): string
+{
+    static $keyPair = null;
+
+    return $keyPair ??= sodium_crypto_box_keypair();
+}
+
+function secretPublicKeyResponse(): array
+{
+    return [
+        'data' => [
+            'id' => 'keypair-1',
+            'type' => 'organization-key-pairs',
+            'attributes' => [
+                'public_key' => base64_encode(sodium_crypto_box_publickey(secretKeyPair())),
+            ],
+        ],
+    ];
+}
+
+function createdSecretResponse(array $attributes = []): array
+{
+    return [
+        'data' => [
+            'id' => 'secret-1',
+            'type' => 'secrets',
+            'attributes' => array_merge([
+                'key' => 'STRIPE_KEY',
+                'notes' => null,
+                'created_at' => '2026-01-01T00:00:00.000000Z',
+                'updated_at' => '2026-01-01T00:00:00.000000Z',
+            ], $attributes),
+        ],
+    ];
+}
+
+function decryptSecretValue(string $value): string
+{
+    return sodium_crypto_box_seal_open(
+        base64_decode($value, strict: true),
+        secretKeyPair(),
+    );
+}
+
+function setupSecretCreateMocks(): Closure
+{
+    $sentBody = new stdClass;
+
+    MockClient::global([
+        GetOrganizationRequest::class => MockResponse::make(organizationResponse(), 200),
+        GetSecretPublicKeyRequest::class => MockResponse::make(secretPublicKeyResponse(), 200),
+        CreateSecretRequest::class => function (PendingRequest $request) use ($sentBody) {
+            $sentBody->value = $request->body()->all();
+
+            return MockResponse::make(createdSecretResponse(), 201);
+        },
+    ]);
+
+    return fn () => $sentBody->value ?? null;
+}
+
+it('creates a secret non-interactively', function () {
+    $sentBody = setupSecretCreateMocks();
+
+    $this->artisan('secret:create', [
+        '--name' => 'STRIPE_KEY',
+        '--value' => 'sk_test_123',
+        '--notes' => 'Used by billing.',
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+
+    expect($sentBody())->toMatchArray([
+        'key_pair_id' => 'keypair-1',
+        'key' => 'STRIPE_KEY',
+        'notes' => 'Used by billing.',
+    ]);
+});
+
+it('encrypts the value with the public key before sending it', function () {
+    $sentBody = setupSecretCreateMocks();
+
+    $this->artisan('secret:create', [
+        '--name' => 'STRIPE_KEY',
+        '--value' => 'sk_test_123',
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+
+    expect($sentBody()['value'])->not->toBe('sk_test_123');
+    expect(decryptSecretValue($sentBody()['value']))->toBe('sk_test_123');
+});
+
+it('omits notes when none are given', function () {
+    $sentBody = setupSecretCreateMocks();
+
+    $this->artisan('secret:create', [
+        '--name' => 'STRIPE_KEY',
+        '--value' => 'sk_test_123',
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+
+    expect($sentBody())->not->toHaveKey('notes');
+});
+
+it('encrypts multi-line values', function () {
+    $sentBody = setupSecretCreateMocks();
+
+    $value = "-----BEGIN PRIVATE KEY-----\nline-one\nline-two\n-----END PRIVATE KEY-----";
+
+    $this->artisan('secret:create', [
+        '--name' => 'SSH_KEY',
+        '--value' => $value,
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+
+    expect(decryptSecretValue($sentBody()['value']))->toBe($value);
+});

--- a/tests/Feature/SecretDeleteTest.php
+++ b/tests/Feature/SecretDeleteTest.php
@@ -53,16 +53,17 @@ it('deletes a secret by ID with --force', function () {
     expect($deletedUrl())->toEndWith('/secrets/secret-2');
 });
 
-it('deletes a secret resolved by name', function () {
+it('rejects a secret name', function () {
     $deletedUrl = setupSecretDeleteMocks();
 
+    // Names are not unique, so only IDs are accepted.
     $this->artisan('secret:delete', [
         'secret' => 'MAILGUN_SECRET',
         '--force' => true,
         '--no-interaction' => true,
-    ])->assertSuccessful();
+    ])->assertFailed();
 
-    expect($deletedUrl())->toEndWith('/secrets/secret-2');
+    expect($deletedUrl())->toBeNull();
 });
 
 it('requires --force when non-interactive', function () {

--- a/tests/Feature/SecretDeleteTest.php
+++ b/tests/Feature/SecretDeleteTest.php
@@ -1,0 +1,77 @@
+<?php
+
+use App\Client\Resources\Meta\GetOrganizationRequest;
+use App\Client\Resources\Secrets\DeleteSecretRequest;
+use App\Client\Resources\Secrets\ListSecretsRequest;
+use App\ConfigRepository;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+use Saloon\Http\PendingRequest;
+
+beforeEach(function () {
+    $this->mockConfig = Mockery::mock(ConfigRepository::class);
+    $this->mockConfig->shouldReceive('apiTokens')->andReturn(collect(['test-api-token']));
+    $this->app->instance(ConfigRepository::class, $this->mockConfig);
+});
+
+afterEach(function () {
+    MockClient::destroyGlobal();
+});
+
+function setupSecretDeleteMocks(): Closure
+{
+    $deleted = new stdClass;
+
+    MockClient::global([
+        GetOrganizationRequest::class => MockResponse::make(organizationResponse(), 200),
+        ListSecretsRequest::class => MockResponse::make([
+            'data' => [
+                secretResponse(),
+                secretResponse(['id' => 'secret-2', 'attributes' => ['key' => 'MAILGUN_SECRET']]),
+            ],
+            'links' => ['next' => null],
+        ], 200),
+        DeleteSecretRequest::class => function (PendingRequest $request) use ($deleted) {
+            $deleted->url = $request->getUrl();
+
+            return MockResponse::make('', 204);
+        },
+    ]);
+
+    return fn () => $deleted->url ?? null;
+}
+
+it('deletes a secret by ID with --force', function () {
+    $deletedUrl = setupSecretDeleteMocks();
+
+    $this->artisan('secret:delete', [
+        'secret' => 'secret-2',
+        '--force' => true,
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+
+    expect($deletedUrl())->toEndWith('/secrets/secret-2');
+});
+
+it('deletes a secret resolved by name', function () {
+    $deletedUrl = setupSecretDeleteMocks();
+
+    $this->artisan('secret:delete', [
+        'secret' => 'MAILGUN_SECRET',
+        '--force' => true,
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+
+    expect($deletedUrl())->toEndWith('/secrets/secret-2');
+});
+
+it('requires --force when non-interactive', function () {
+    $deletedUrl = setupSecretDeleteMocks();
+
+    $this->artisan('secret:delete', [
+        'secret' => 'secret-2',
+        '--no-interaction' => true,
+    ])->assertFailed();
+
+    expect($deletedUrl())->toBeNull();
+});

--- a/tests/Feature/SecretListTest.php
+++ b/tests/Feature/SecretListTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use App\Client\Resources\Meta\GetOrganizationRequest;
+use App\Client\Resources\Secrets\ListSecretsRequest;
+use App\ConfigRepository;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+
+beforeEach(function () {
+    $this->mockConfig = Mockery::mock(ConfigRepository::class);
+    $this->mockConfig->shouldReceive('apiTokens')->andReturn(collect(['test-api-token']));
+    $this->app->instance(ConfigRepository::class, $this->mockConfig);
+});
+
+afterEach(function () {
+    MockClient::destroyGlobal();
+});
+
+function setupSecretListMocks(?array $secrets = null, int $status = 200): void
+{
+    $secrets ??= [
+        secretResponse(['attributes' => ['notes' => 'Used by billing.']]),
+        secretResponse(['id' => 'secret-2', 'attributes' => ['key' => 'MAILGUN_SECRET']]),
+    ];
+
+    MockClient::global([
+        GetOrganizationRequest::class => MockResponse::make(organizationResponse(), 200),
+        ListSecretsRequest::class => MockResponse::make([
+            'data' => $secrets,
+            'links' => ['next' => null],
+        ], $status),
+    ]);
+}
+
+it('lists secrets', function () {
+    setupSecretListMocks();
+
+    // One substring per run: several expectsOutputToContain() calls cannot all match a single write.
+    $this->artisan('secret:list', ['--no-interaction' => true])
+        ->assertSuccessful()
+        ->expectsOutputToContain('STRIPE_KEY');
+
+    $this->artisan('secret:list', ['--no-interaction' => true])
+        ->assertSuccessful()
+        ->expectsOutputToContain('MAILGUN_SECRET');
+});
+
+it('warns when there are no secrets', function () {
+    setupSecretListMocks([]);
+
+    $this->artisan('secret:list', ['--no-interaction' => true])->assertSuccessful();
+});

--- a/tests/Feature/SecretUpdateTest.php
+++ b/tests/Feature/SecretUpdateTest.php
@@ -52,11 +52,24 @@ it('updates the name and resends it as the key', function () {
     expect($sentBody())->toMatchArray(['key' => 'STRIPE_SECRET']);
 });
 
-it('resolves a secret by name', function () {
+it('rejects a secret name', function () {
+    $sentBody = setupSecretUpdateMocks();
+
+    // Names are not unique, so only IDs are accepted.
+    $this->artisan('secret:update', [
+        'secret' => 'STRIPE_KEY',
+        '--notes' => 'Rotated quarterly.',
+        '--no-interaction' => true,
+    ])->assertFailed();
+
+    expect($sentBody())->toBeNull();
+});
+
+it('updates the notes', function () {
     $sentBody = setupSecretUpdateMocks();
 
     $this->artisan('secret:update', [
-        'secret' => 'STRIPE_KEY',
+        'secret' => 'secret-1',
         '--notes' => 'Rotated quarterly.',
         '--no-interaction' => true,
     ])->assertSuccessful();

--- a/tests/Feature/SecretUpdateTest.php
+++ b/tests/Feature/SecretUpdateTest.php
@@ -1,0 +1,113 @@
+<?php
+
+use App\Client\Resources\Meta\GetOrganizationRequest;
+use App\Client\Resources\Secrets\GetSecretPublicKeyRequest;
+use App\Client\Resources\Secrets\ListSecretsRequest;
+use App\Client\Resources\Secrets\UpdateSecretRequest;
+use App\ConfigRepository;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+use Saloon\Http\PendingRequest;
+
+beforeEach(function () {
+    $this->mockConfig = Mockery::mock(ConfigRepository::class);
+    $this->mockConfig->shouldReceive('apiTokens')->andReturn(collect(['test-api-token']));
+    $this->app->instance(ConfigRepository::class, $this->mockConfig);
+});
+
+afterEach(function () {
+    MockClient::destroyGlobal();
+});
+
+function setupSecretUpdateMocks(): Closure
+{
+    $sentBody = new stdClass;
+
+    MockClient::global([
+        GetOrganizationRequest::class => MockResponse::make(organizationResponse(), 200),
+        ListSecretsRequest::class => MockResponse::make([
+            'data' => [secretResponse(['attributes' => ['notes' => 'Used by billing.']])],
+            'links' => ['next' => null],
+        ], 200),
+        GetSecretPublicKeyRequest::class => MockResponse::make(secretPublicKeyResponse(), 200),
+        UpdateSecretRequest::class => function (PendingRequest $request) use ($sentBody) {
+            $sentBody->value = $request->body()->all();
+
+            return MockResponse::make(['data' => secretResponse()], 200);
+        },
+    ]);
+
+    return fn () => $sentBody->value ?? null;
+}
+
+it('updates the name and resends it as the key', function () {
+    $sentBody = setupSecretUpdateMocks();
+
+    $this->artisan('secret:update', [
+        'secret' => 'secret-1',
+        '--name' => 'STRIPE_SECRET',
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+
+    expect($sentBody())->toMatchArray(['key' => 'STRIPE_SECRET']);
+});
+
+it('resolves a secret by name', function () {
+    $sentBody = setupSecretUpdateMocks();
+
+    $this->artisan('secret:update', [
+        'secret' => 'STRIPE_KEY',
+        '--notes' => 'Rotated quarterly.',
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+
+    expect($sentBody())->toMatchArray(['notes' => 'Rotated quarterly.']);
+});
+
+it('sends the current name when only other fields change', function () {
+    $sentBody = setupSecretUpdateMocks();
+
+    $this->artisan('secret:update', [
+        'secret' => 'secret-1',
+        '--notes' => 'Rotated quarterly.',
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+
+    // The API requires the key on every update.
+    expect($sentBody())->toMatchArray(['key' => 'STRIPE_KEY']);
+});
+
+it('encrypts a new value and sends the key pair it was encrypted with', function () {
+    $sentBody = setupSecretUpdateMocks();
+
+    $this->artisan('secret:update', [
+        'secret' => 'secret-1',
+        '--value' => 'sk_test_rotated',
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+
+    expect($sentBody())->toMatchArray(['key_pair_id' => 'keypair-1']);
+    expect(decryptSecretValue($sentBody()['value']))->toBe('sk_test_rotated');
+});
+
+it('omits the value and key pair when the value is unchanged', function () {
+    $sentBody = setupSecretUpdateMocks();
+
+    $this->artisan('secret:update', [
+        'secret' => 'secret-1',
+        '--name' => 'STRIPE_SECRET',
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+
+    expect($sentBody())->not->toHaveKey('value');
+    expect($sentBody())->not->toHaveKey('key_pair_id');
+});
+
+it('fails when no fields are given', function () {
+    setupSecretUpdateMocks();
+
+    $this->artisan('secret:update', [
+        'secret' => 'secret-1',
+        '--no-interaction' => true,
+    ])->assertFailed();
+});

--- a/tests/Feature/SecretUpdateTest.php
+++ b/tests/Feature/SecretUpdateTest.php
@@ -5,6 +5,7 @@ use App\Client\Resources\Secrets\GetSecretPublicKeyRequest;
 use App\Client\Resources\Secrets\ListSecretsRequest;
 use App\Client\Resources\Secrets\UpdateSecretRequest;
 use App\ConfigRepository;
+use App\Support\Stdin;
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
 use Saloon\Http\PendingRequest;
@@ -13,6 +14,10 @@ beforeEach(function () {
     $this->mockConfig = Mockery::mock(ConfigRepository::class);
     $this->mockConfig->shouldReceive('apiTokens')->andReturn(collect(['test-api-token']));
     $this->app->instance(ConfigRepository::class, $this->mockConfig);
+
+    $this->mockStdin = Mockery::mock(Stdin::class);
+    $this->mockStdin->shouldReceive('read')->andReturn(null)->byDefault();
+    $this->app->instance(Stdin::class, $this->mockStdin);
 });
 
 afterEach(function () {
@@ -123,4 +128,32 @@ it('fails when no fields are given', function () {
         'secret' => 'secret-1',
         '--no-interaction' => true,
     ])->assertFailed();
+});
+
+it('reads a new value from STDIN when --value is not given', function () {
+    $sentBody = setupSecretUpdateMocks();
+
+    test()->mockStdin->shouldReceive('read')->andReturn('sk_test_piped');
+
+    $this->artisan('secret:update', [
+        'secret' => 'secret-1',
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+
+    expect($sentBody())->toMatchArray(['key_pair_id' => 'keypair-1']);
+    expect(decryptSecretValue($sentBody()['value']))->toBe('sk_test_piped');
+});
+
+it('prefers --value over STDIN', function () {
+    $sentBody = setupSecretUpdateMocks();
+
+    test()->mockStdin->shouldReceive('read')->andReturn('sk_test_piped');
+
+    $this->artisan('secret:update', [
+        'secret' => 'secret-1',
+        '--value' => 'sk_test_option',
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+
+    expect(decryptSecretValue($sentBody()['value']))->toBe('sk_test_option');
 });

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -107,6 +107,20 @@ function setupApplicationListMocks(?array $applications = null, int $status = 20
     ]);
 }
 
+function secretResponse(array $overrides = []): array
+{
+    return [
+        'id' => $overrides['id'] ?? 'secret-1',
+        'type' => 'secrets',
+        'attributes' => array_merge([
+            'key' => 'STRIPE_KEY',
+            'notes' => null,
+            'created_at' => '2026-01-01T00:00:00.000000Z',
+            'updated_at' => '2026-01-01T00:00:00.000000Z',
+        ], $overrides['attributes'] ?? []),
+    ];
+}
+
 function databaseClusterResponse(array $overrides = []): array
 {
     return [

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -107,6 +107,38 @@ function setupApplicationListMocks(?array $applications = null, int $status = 20
     ]);
 }
 
+/**
+ * The key pair the command's encrypted values can be decrypted with, so the suite never
+ * needs a real organization key pair.
+ */
+function secretKeyPair(): string
+{
+    static $keyPair = null;
+
+    return $keyPair ??= sodium_crypto_box_keypair();
+}
+
+function secretPublicKeyResponse(): array
+{
+    return [
+        'data' => [
+            'id' => 'keypair-1',
+            'type' => 'organization-key-pairs',
+            'attributes' => [
+                'public_key' => base64_encode(sodium_crypto_box_publickey(secretKeyPair())),
+            ],
+        ],
+    ];
+}
+
+function decryptSecretValue(string $value): string
+{
+    return sodium_crypto_box_seal_open(
+        base64_decode($value, strict: true),
+        secretKeyPair(),
+    );
+}
+
 function secretResponse(array $overrides = []): array
 {
     return [


### PR DESCRIPTION
Adding support for the new secret management API endpoints.

The nice part about the CLI is that it handles the encryption side of things automatically 🪄 

**Demo of all commands:**

https://github.com/user-attachments/assets/a0d9385d-d95b-43d5-aee1-66f979700b5b

