### PR TITLE
Document managed-queue, tinker and skills:install commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,23 @@ op read "op://vault/stripe/api-key" | cloud secret:create --name=STRIPE_KEY -n
 | `cloud command:get`  | Get command details              |
 | `cloud command:run`  | Run a command on an environment  |
 
+### Managed queues
+
+Managed queues are a special kind of instance. Pass the instance ID directly or let the CLI prompt for one.
+
+| Command                                 | Description                              |
+| --------------------------------------- | ---------------------------------------- |
+| `cloud managed-queue:create`            | Create a managed queue in an environment |
+| `cloud managed-queue:pause`             | Pause a managed queue                    |
+| `cloud managed-queue:resume`            | Resume a managed queue                   |
+| `cloud managed-queue:purge`             | Purge all messages from a managed queue  |
+| `cloud managed-queue:set-default`       | Set a managed queue as the default       |
+| `cloud managed-queue:failed-jobs`       | List failed jobs for a managed queue     |
+| `cloud managed-queue:retry-failed-job`  | Retry a failed job on a managed queue    |
+| `cloud managed-queue:delete-failed-job` | Delete a failed job from a managed queue |
+
+`managed-queue:create` accepts `--name`, `--size`, `--max-workers`, `--visibility-timeout`, `--polling-interval` and `--shutdown-timeout` so it can run non-interactively. `pause`, `purge` and `delete-failed-job` accept `--force` to skip the confirmation prompt.
+
 ### Usage
 
 | Command                          | Description                                                  |
@@ -319,7 +336,11 @@ op read "op://vault/stripe/api-key" | cloud secret:create --name=STRIPE_KEY -n
 | `cloud browser`                | Open the application in the browser      |
 | `cloud ip:addresses`           | Get Laravel Cloud IP addresses by region |
 | `cloud dedicated-cluster:list` | List dedicated clusters                  |
+| `cloud tinker`                 | Tinker in your Laravel Cloud environment |
+| `cloud skills:install`         | Install Laravel Cloud CLI agent skills   |
 | `cloud completions`            | Generate and install shell completions   |
+
+`cloud tinker` runs code against an environment, either interactively or via `--code=` for scripting (`--timeout=` caps how long to wait for output, default 60s). `cloud skills:install` installs the CLI's agent skills for supported coding agents; use `--global` or `--project` to choose the location and `--agent=` (repeatable) to pick specific agents.
 
 ## Configuration
 


### PR DESCRIPTION
adds the ten shipped-but-undocumented commands to the README command reference:

- A new **Managed queues** section covering `managed-queue:create`, `pause`, `resume`, `purge`, `set-default`, `failed-jobs`, `retry-failed-job` and `delete-failed-job`, with a short note on the non-interactive options `create` accepts and which commands take `--force`.
- `cloud tinker` and `cloud skills:install` added to the **Other** table, with a one-line note each on `--code` / `--timeout` and `--global` / `--project` / `--agent`.

All ten commands are public (none are hidden) and each is already in the CHANGELOG, managed queues in #164, `tinker` in #141 / #142, `skills:install` in #143, but none appear anywhere in the README. Someone reading the command reference has no way to discover them.

## Notes

- Descriptions are taken from each command's `$description`.
- Option names come from the command signatures.
- Docs only, no code changes.
