### PR TITLE
Fix bucket key secret never being returned

### DIFF
--- a/app/Commands/BucketKeyCreate.php
+++ b/app/Commands/BucketKeyCreate.php
@@ -5,6 +5,7 @@ namespace App\Commands;
 use App\Client\Requests\CreateBucketKeyRequestData;
 use App\Dto\BucketKey;
 use App\Dto\ObjectStorageBucket;
+use App\Support\SensitiveValues;
 
 use function Laravel\Prompts\intro;
 use function Laravel\Prompts\select;
@@ -35,6 +36,14 @@ class BucketKeyCreate extends BaseCommand
         $this->outputJsonIfWanted($key);
 
         success("Bucket key created: {$key->name}");
+
+        SensitiveValues::$reveal = (bool) $this->option('show-sensitive');
+
+        dataList([
+            'ID' => $key->id,
+            'Access Key ID' => $key->accessKeyId ?? '—',
+            'Secret Access Key' => SensitiveValues::mask($key->secretAccessKey) ?? '—',
+        ]);
     }
 
     protected function createBucketKey(ObjectStorageBucket $bucket)

--- a/app/Commands/BucketKeyGet.php
+++ b/app/Commands/BucketKeyGet.php
@@ -3,6 +3,7 @@
 namespace App\Commands;
 
 use App\Dto\BucketKey;
+use App\Support\SensitiveValues;
 
 use function Laravel\Prompts\intro;
 use function Laravel\Prompts\spin;
@@ -33,10 +34,14 @@ class BucketKeyGet extends BaseCommand
 
         $this->outputJsonIfWanted($key);
 
+        SensitiveValues::$reveal = (bool) $this->option('show-sensitive');
+
         dataList([
             'ID' => $key->id,
             'Name' => $key->name,
             'Permission' => $key->permission,
+            'Access Key ID' => $key->accessKeyId ?? '—',
+            'Secret Access Key' => SensitiveValues::mask($key->secretAccessKey) ?? '—',
             'Created At' => $key->createdAt?->toIso8601String() ?? '—',
         ]);
     }

--- a/app/Dto/BucketKey.php
+++ b/app/Dto/BucketKey.php
@@ -35,7 +35,7 @@ class BucketKey extends Data
             'permission' => $attributes['permission'] ?? 'read_write',
             'createdAt' => $attributes['created_at'] ?? null,
             'accessKeyId' => $attributes['access_key_id'] ?? null,
-            'secretAccessKey' => $attributes['secret_access_key'] ?? null,
+            'secretAccessKey' => $attributes['access_key_secret'] ?? null,
         ]);
     }
 }

--- a/app/Dto/Transformers/MaskSensitiveValue.php
+++ b/app/Dto/Transformers/MaskSensitiveValue.php
@@ -11,10 +11,6 @@ class MaskSensitiveValue implements Transformer
 {
     public function transform(DataProperty $property, mixed $value, TransformationContext $context): mixed
     {
-        if (SensitiveValues::$reveal || $value === null) {
-            return $value;
-        }
-
-        return SensitiveValues::MASK;
+        return SensitiveValues::mask($value);
     }
 }

--- a/app/Support/SensitiveValues.php
+++ b/app/Support/SensitiveValues.php
@@ -13,6 +13,15 @@ class SensitiveValues
         return (bool) preg_match('/pass|secret|token|credential|private|dsn|url|uri/i', $key);
     }
 
+    public static function mask(?string $value): ?string
+    {
+        if (static::$reveal || $value === null) {
+            return $value;
+        }
+
+        return static::MASK;
+    }
+
     /** Keeps the last few characters so tokens sharing an organization stay tellable apart. */
     public static function maskWithSuffix(string $value, int $suffix = 4): string
     {

--- a/tests/Feature/BucketKeyCommandsTest.php
+++ b/tests/Feature/BucketKeyCommandsTest.php
@@ -1,0 +1,114 @@
+<?php
+
+use App\Client\Resources\BucketKeys\CreateBucketKeyRequest;
+use App\Client\Resources\BucketKeys\GetBucketKeyRequest;
+use App\Client\Resources\BucketKeys\ListBucketKeysRequest;
+use App\Client\Resources\Meta\GetOrganizationRequest;
+use App\Client\Resources\ObjectStorageBuckets\ListObjectStorageBucketsRequest;
+use App\ConfigRepository;
+use App\Dto\BucketKey;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+
+beforeEach(function () {
+    $this->mockConfig = Mockery::mock(ConfigRepository::class);
+    $this->mockConfig->shouldReceive('apiTokens')->andReturn(collect(['test-api-token']));
+    $this->app->instance(ConfigRepository::class, $this->mockConfig);
+});
+
+afterEach(function () {
+    MockClient::destroyGlobal();
+});
+
+function setupBucketKeyMocks(?array $key = null): void
+{
+    $key ??= bucketKeyResponse();
+
+    MockClient::global([
+        GetOrganizationRequest::class => MockResponse::make(organizationResponse(), 200),
+        ListObjectStorageBucketsRequest::class => MockResponse::make([
+            'data' => [bucketResponse()],
+            'links' => ['next' => null],
+        ], 200),
+        ListBucketKeysRequest::class => MockResponse::make([
+            'data' => [$key],
+            'links' => ['next' => null],
+        ], 200),
+        GetBucketKeyRequest::class => MockResponse::make(['data' => $key], 200),
+        CreateBucketKeyRequest::class => MockResponse::make(['data' => $key], 201),
+    ]);
+}
+
+it('maps the secret from the api access_key_secret attribute', function () {
+    $key = BucketKey::createFromResponse(['data' => bucketKeyResponse()]);
+
+    expect($key->accessKeyId)->toBe('AKIAEXAMPLE123');
+    expect($key->secretAccessKey)->toBe('super-secret-value');
+});
+
+it('leaves the credentials null when the api withholds them', function () {
+    $key = BucketKey::createFromResponse(['data' => bucketKeyResponse([
+        'attributes' => ['access_key_id' => null, 'access_key_secret' => null],
+    ])]);
+
+    expect($key->accessKeyId)->toBeNull();
+    expect($key->secretAccessKey)->toBeNull();
+});
+
+it('reveals the secret in bucket-key:get json with --show-sensitive', function () {
+    setupBucketKeyMocks();
+
+    $this->artisan('bucket-key:get', [
+        'bucket' => 'fls-1',
+        'key' => 'flsk-1',
+        '--json' => true,
+        '--show-sensitive' => true,
+        '--no-interaction' => true,
+    ])
+        ->assertSuccessful()
+        ->expectsOutputToContain('super-secret-value');
+});
+
+it('masks the secret in bucket-key:get json by default', function () {
+    setupBucketKeyMocks();
+
+    $this->artisan('bucket-key:get', [
+        'bucket' => 'fls-1',
+        'key' => 'flsk-1',
+        '--json' => true,
+        '--no-interaction' => true,
+    ])
+        ->assertSuccessful()
+        ->doesntExpectOutputToContain('super-secret-value')
+        ->expectsOutputToContain('*****');
+});
+
+it('reveals the secret in bucket-key:create json with --show-sensitive', function () {
+    setupBucketKeyMocks();
+
+    $this->artisan('bucket-key:create', [
+        'bucket' => 'fls-1',
+        '--name' => 'my-key',
+        '--permission' => 'read_write',
+        '--json' => true,
+        '--show-sensitive' => true,
+        '--no-interaction' => true,
+    ])
+        ->assertSuccessful()
+        ->expectsOutputToContain('super-secret-value');
+});
+
+it('masks the secret in bucket-key:create json by default', function () {
+    setupBucketKeyMocks();
+
+    $this->artisan('bucket-key:create', [
+        'bucket' => 'fls-1',
+        '--name' => 'my-key',
+        '--permission' => 'read_write',
+        '--json' => true,
+        '--no-interaction' => true,
+    ])
+        ->assertSuccessful()
+        ->doesntExpectOutputToContain('super-secret-value')
+        ->expectsOutputToContain('*****');
+});

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -153,6 +153,40 @@ function secretResponse(array $overrides = []): array
     ];
 }
 
+function bucketKeyResponse(array $overrides = []): array
+{
+    return [
+        'id' => $overrides['id'] ?? 'flsk-1',
+        'type' => 'filesystemKeys',
+        'attributes' => array_merge([
+            'name' => 'my-key',
+            'permission' => 'read_write',
+            'access_key_id' => 'AKIAEXAMPLE123',
+            'access_key_secret' => 'super-secret-value',
+            'created_at' => '2026-01-01T00:00:00.000000Z',
+        ], $overrides['attributes'] ?? []),
+    ];
+}
+
+function bucketResponse(array $overrides = []): array
+{
+    return [
+        'id' => $overrides['id'] ?? 'fls-1',
+        'type' => 'filesystems',
+        'attributes' => array_merge([
+            'name' => 'my-bucket',
+            'type' => 'cloudflare_r2',
+            'status' => 'available',
+            'visibility' => 'private',
+            'jurisdiction' => 'default',
+            'endpoint' => 'https://example.r2.cloudflarestorage.com',
+            'url' => null,
+            'allowed_origins' => null,
+            'created_at' => '2026-01-01T00:00:00.000000Z',
+        ], $overrides['attributes'] ?? []),
+    ];
+}
+
 function databaseSchemaResponse(array $overrides = []): array
 {
     return [


### PR DESCRIPTION
The API returns a bucket key's secret as `access_key_secret`, but the DTO read `secret_access_key`. The null coalesce swallowed it, so `secretAccessKey` was always null and there was no way to get a key's secret out of the CLI.

While in there, `bucket-key:create` and `bucket-key:get` now print the access key ID and secret, masked unless you pass `--show-sensitive`, the same way `auth:token` handles API tokens. Creating a key and not being shown the credentials was the main thing that made this worth reporting.

There were no bucket key tests, which is why the wrong field name went unnoticed: the only coverage built the DTO from its PHP property names and never went through `createFromResponse()`. Added tests that use real API response fixtures.
