### PR TITLE
Fix database-snapshot:get and :delete hitting a 404

### DIFF
--- a/app/Client/Resources/DatabaseSnapshots/DeleteDatabaseSnapshotRequest.php
+++ b/app/Client/Resources/DatabaseSnapshots/DeleteDatabaseSnapshotRequest.php
@@ -10,7 +10,6 @@ class DeleteDatabaseSnapshotRequest extends Request
     protected Method $method = Method::DELETE;
 
     public function __construct(
-        protected string $clusterId,
         protected string $snapshotId,
     ) {
         //
@@ -18,6 +17,6 @@ class DeleteDatabaseSnapshotRequest extends Request
 
     public function resolveEndpoint(): string
     {
-        return "/databases/clusters/{$this->clusterId}/snapshots/{$this->snapshotId}";
+        return "/database-snapshots/{$this->snapshotId}";
     }
 }

--- a/app/Client/Resources/DatabaseSnapshots/GetDatabaseSnapshotRequest.php
+++ b/app/Client/Resources/DatabaseSnapshots/GetDatabaseSnapshotRequest.php
@@ -15,7 +15,6 @@ class GetDatabaseSnapshotRequest extends Request
     protected Method $method = Method::GET;
 
     public function __construct(
-        protected string $clusterId,
         protected string $snapshotId,
     ) {
         //
@@ -23,7 +22,7 @@ class GetDatabaseSnapshotRequest extends Request
 
     public function resolveEndpoint(): string
     {
-        return "/databases/clusters/{$this->clusterId}/snapshots/{$this->snapshotId}";
+        return "/database-snapshots/{$this->snapshotId}";
     }
 
     public function createDtoFromResponse(Response $response): DatabaseSnapshot

--- a/app/Client/Resources/DatabaseSnapshotsResource.php
+++ b/app/Client/Resources/DatabaseSnapshotsResource.php
@@ -19,10 +19,9 @@ class DatabaseSnapshotsResource extends Resource
         return $this->paginate($request);
     }
 
-    public function get(string $clusterId, string $snapshotId): DatabaseSnapshot
+    public function get(string $snapshotId): DatabaseSnapshot
     {
         $request = new GetDatabaseSnapshotRequest(
-            clusterId: $clusterId,
             snapshotId: $snapshotId,
         );
         $response = $this->send($request);
@@ -38,10 +37,9 @@ class DatabaseSnapshotsResource extends Resource
         return $request->createDtoFromResponse($response);
     }
 
-    public function delete(string $clusterId, string $snapshotId): void
+    public function delete(string $snapshotId): void
     {
         $this->send(new DeleteDatabaseSnapshotRequest(
-            clusterId: $clusterId,
             snapshotId: $snapshotId,
         ));
     }

--- a/app/Commands/DatabaseSnapshotDelete.php
+++ b/app/Commands/DatabaseSnapshotDelete.php
@@ -28,7 +28,7 @@ class DatabaseSnapshotDelete extends BaseCommand
         $this->confirmDestructive("Delete snapshot '{$snapshot->name}'?");
 
         spin(
-            fn () => $this->client->databaseSnapshots()->delete($cluster->id, $snapshot->id),
+            fn () => $this->client->databaseSnapshots()->delete($snapshot->id),
             'Deleting snapshot...',
         );
 

--- a/app/Commands/DatabaseSnapshotGet.php
+++ b/app/Commands/DatabaseSnapshotGet.php
@@ -29,7 +29,7 @@ class DatabaseSnapshotGet extends BaseCommand
         $snapshot = $this->resolvers()->databaseSnapshot()->from($cluster, $this->argument('snapshot'));
 
         $snapshot = spin(
-            fn () => $this->client->databaseSnapshots()->get($cluster->id, $snapshot->id),
+            fn () => $this->client->databaseSnapshots()->get($snapshot->id),
             'Fetching snapshot...',
         );
 

--- a/tests/Feature/DatabaseSnapshotCommandsTest.php
+++ b/tests/Feature/DatabaseSnapshotCommandsTest.php
@@ -1,0 +1,81 @@
+<?php
+
+use App\Client\Resources\DatabaseClusters\GetDatabaseClusterRequest;
+use App\Client\Resources\DatabaseSnapshots\DeleteDatabaseSnapshotRequest;
+use App\Client\Resources\DatabaseSnapshots\GetDatabaseSnapshotRequest;
+use App\Client\Resources\DatabaseSnapshots\ListDatabaseSnapshotsRequest;
+use App\Client\Resources\Meta\GetOrganizationRequest;
+use App\ConfigRepository;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+
+beforeEach(function () {
+    $this->mockConfig = Mockery::mock(ConfigRepository::class);
+    $this->mockConfig->shouldReceive('apiTokens')->andReturn(collect(['test-api-token']));
+    $this->app->instance(ConfigRepository::class, $this->mockConfig);
+});
+
+afterEach(function () {
+    MockClient::destroyGlobal();
+});
+
+function setupDatabaseSnapshotMocks(): void
+{
+    $snapshot = databaseSnapshotResponse();
+
+    MockClient::global([
+        GetOrganizationRequest::class => MockResponse::make(organizationResponse(), 200),
+        GetDatabaseClusterRequest::class => MockResponse::make(databaseClusterResponse(), 200),
+        ListDatabaseSnapshotsRequest::class => MockResponse::make([
+            'data' => [$snapshot],
+            'links' => ['next' => null],
+        ], 200),
+        GetDatabaseSnapshotRequest::class => MockResponse::make(['data' => $snapshot], 200),
+        DeleteDatabaseSnapshotRequest::class => MockResponse::make([], 204),
+    ]);
+}
+
+it('fetches a snapshot from the canonical endpoint', function () {
+    setupDatabaseSnapshotMocks();
+
+    $this->artisan('database-snapshot:get', [
+        'cluster' => 'db-123',
+        'snapshot' => 'snap-1',
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+
+    MockClient::global()->assertSent(function ($request) {
+        return $request instanceof GetDatabaseSnapshotRequest
+            && $request->resolveEndpoint() === '/database-snapshots/snap-1';
+    });
+});
+
+it('deletes a snapshot at the canonical endpoint', function () {
+    setupDatabaseSnapshotMocks();
+
+    $this->artisan('database-snapshot:delete', [
+        'cluster' => 'db-123',
+        'snapshot' => 'snap-1',
+        '--force' => true,
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+
+    MockClient::global()->assertSent(function ($request) {
+        return $request instanceof DeleteDatabaseSnapshotRequest
+            && $request->resolveEndpoint() === '/database-snapshots/snap-1';
+    });
+});
+
+it('still lists snapshots under the cluster', function () {
+    setupDatabaseSnapshotMocks();
+
+    $this->artisan('database-snapshot:list', [
+        'cluster' => 'db-123',
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+
+    MockClient::global()->assertSent(function ($request) {
+        return $request instanceof ListDatabaseSnapshotsRequest
+            && $request->resolveEndpoint() === '/databases/clusters/db-123/snapshots';
+    });
+});

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -166,6 +166,19 @@ function databaseSchemaResponse(array $overrides = []): array
     ];
 }
 
+function databaseSnapshotResponse(array $overrides = []): array
+{
+    return [
+        'id' => $overrides['id'] ?? 'snap-1',
+        'type' => 'databaseSnapshots',
+        'attributes' => array_merge([
+            'name' => 'nightly',
+            'status' => 'available',
+            'created_at' => '2026-01-01T00:00:00.000000Z',
+        ], $overrides['attributes'] ?? []),
+    ];
+}
+
 function databaseClusterResponse(array $overrides = []): array
 {
     $schemas = $overrides['included'] ?? [databaseSchemaResponse()];


### PR DESCRIPTION
Both commands called `/databases/clusters/{cluster}/snapshots/{snapshot}`, which does not exist. The nested snapshot routes only cover listing and creating; show and destroy live at `/database-snapshots/{snapshot}`.