### PR TITLE
Add the missing stopped websocket server status

### DIFF
--- a/app/Enums/WebsocketServerStatus.php
+++ b/app/Enums/WebsocketServerStatus.php
@@ -7,6 +7,7 @@ enum WebsocketServerStatus: string
     case CREATING = 'creating';
     case UPDATING = 'updating';
     case AVAILABLE = 'available';
+    case STOPPED = 'stopped';
     case DELETING = 'deleting';
     case DELETED = 'deleted';
     case UNKNOWN = 'unknown';

--- a/tests/Feature/WebsocketClusterCommandsTest.php
+++ b/tests/Feature/WebsocketClusterCommandsTest.php
@@ -1,0 +1,65 @@
+<?php
+
+use App\Client\Resources\Meta\GetOrganizationRequest;
+use App\Client\Resources\WebSocketClusters\GetWebSocketClusterRequest;
+use App\Client\Resources\WebSocketClusters\ListWebSocketClustersRequest;
+use App\ConfigRepository;
+use App\Dto\WebsocketCluster;
+use App\Enums\WebsocketServerStatus;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+
+beforeEach(function () {
+    $this->mockConfig = Mockery::mock(ConfigRepository::class);
+    $this->mockConfig->shouldReceive('apiTokens')->andReturn(collect(['test-api-token']));
+    $this->app->instance(ConfigRepository::class, $this->mockConfig);
+});
+
+afterEach(function () {
+    MockClient::destroyGlobal();
+});
+
+function setupWebsocketClusterMocks(?array $cluster = null): void
+{
+    $cluster ??= websocketClusterResponse();
+
+    MockClient::global([
+        GetOrganizationRequest::class => MockResponse::make(organizationResponse(), 200),
+        ListWebSocketClustersRequest::class => MockResponse::make([
+            'data' => [$cluster],
+            'links' => ['next' => null],
+        ], 200),
+        GetWebSocketClusterRequest::class => MockResponse::make(['data' => $cluster], 200),
+    ]);
+}
+
+it('builds the dto for every status the api can return', function (string $status) {
+    $cluster = WebsocketCluster::createFromResponse([
+        'data' => websocketClusterResponse(['attributes' => ['status' => $status]]),
+    ]);
+
+    expect($cluster->status)->toBe(WebsocketServerStatus::from($status));
+})->with(['creating', 'updating', 'available', 'stopped', 'deleting', 'deleted', 'unknown']);
+
+it('lists a stopped cluster', function () {
+    setupWebsocketClusterMocks(websocketClusterResponse([
+        'attributes' => ['status' => 'stopped'],
+    ]));
+
+    $this->artisan('websocket-cluster:list', ['--no-interaction' => true])
+        ->assertSuccessful()
+        ->expectsOutputToContain('stopped');
+});
+
+it('gets a stopped cluster', function () {
+    setupWebsocketClusterMocks(websocketClusterResponse([
+        'attributes' => ['status' => 'stopped'],
+    ]));
+
+    $this->artisan('websocket-cluster:get', [
+        'cluster' => 'wss-1',
+        '--no-interaction' => true,
+    ])
+        ->assertSuccessful()
+        ->expectsOutputToContain('stopped');
+});

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -200,6 +200,24 @@ function databaseSchemaResponse(array $overrides = []): array
     ];
 }
 
+function websocketClusterResponse(array $overrides = []): array
+{
+    return [
+        'id' => $overrides['id'] ?? 'wss-1',
+        'type' => 'websocketServers',
+        'attributes' => array_merge([
+            'name' => 'my-reverb',
+            'type' => 'reverb',
+            'region' => 'us-east-1',
+            'status' => 'available',
+            'max_connections' => 500,
+            'connection_distribution_strategy' => 'evenly',
+            'hostname' => 'my-reverb.cloud.laravel.com',
+            'created_at' => '2026-01-01T00:00:00.000000Z',
+        ], $overrides['attributes'] ?? []),
+    ];
+}
+
 function databaseSnapshotResponse(array $overrides = []): array
 {
     return [


### PR DESCRIPTION
`App\Enums\WebsocketServerStatus` was missing the `stopped` case that the API can return. The `WebsocketCluster` DTO casts status through it, so `websocket-cluster:list` and `websocket-cluster:get` threw a ValueError instead of rendering whenever an organization had a stopped Reverb server.