### PR TITLE
Support Bitbucket as a source provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Laravel Zero CLI for deploying and managing applications on [Laravel Cloud](ht
 - **PHP 8.3+**
 - **Composer**
 - **Git** — for repository detection and `repo:config`
-- **GitHub CLI (`gh`) or GitLab CLI (`glab`)** — optional, and only to create a repository from a directory that has no remote yet. Install and sign in to the one matching your provider.
+- **GitHub CLI (`gh`) or GitLab CLI (`glab`)** — optional, and only to create a repository from a directory that has no remote yet. Bitbucket has no CLI, so create the repository yourself and add it as a remote.
 
 ## Installation
 

--- a/app/Commands/ApplicationCreate.php
+++ b/app/Commands/ApplicationCreate.php
@@ -26,7 +26,7 @@ class ApplicationCreate extends BaseCommand
     protected $signature = 'application:create
                             {--name= : Application name}
                             {--repository= : Repository (owner/repo format)}
-                            {--source-provider= : Source provider (github, gitlab, gitlab_self_hosted). Default: detected from the origin remote}
+                            {--source-provider= : Source provider (github, gitlab, gitlab_self_hosted, bitbucket). Default: detected from the origin remote}
                             {--region= : Application region}
                             {--root-directory= : Repository subdirectory containing the app (monorepos)}';
 

--- a/app/Commands/ApplicationUpdate.php
+++ b/app/Commands/ApplicationUpdate.php
@@ -29,7 +29,7 @@ class ApplicationUpdate extends BaseCommand
                             {--slug= : Application slug}
                             {--slack-channel= : Slack channel for notifications}
                             {--repository= : Repository URL}
-                            {--source-provider= : Source provider (github, gitlab, gitlab_self_hosted)}
+                            {--source-provider= : Source provider (github, gitlab, gitlab_self_hosted, bitbucket)}
                             {--avatar= : Avatar URL or full path to a file}
                             {--default-environment= : Default environment ID or name}
                             {--force : Force update without confirmation}';

--- a/app/Commands/Ship.php
+++ b/app/Commands/Ship.php
@@ -64,7 +64,7 @@ class Ship extends BaseCommand
                             {--name= : Application name (non-interactive). Default: derived from repository}
                             {--region= : Region (non-interactive). Default: most-used or us-east-2}
                             {--root-directory= : Repository subdirectory containing the app (monorepos)}
-                            {--source-provider= : Source provider (github, gitlab, gitlab_self_hosted). Default: detected from the origin remote}
+                            {--source-provider= : Source provider (github, gitlab, gitlab_self_hosted, bitbucket). Default: detected from the origin remote}
 ';
 
     protected $description = 'Ship a new application to Laravel Cloud';

--- a/app/Concerns/RequiresRemoteGitRepo.php
+++ b/app/Concerns/RequiresRemoteGitRepo.php
@@ -33,7 +33,7 @@ trait RequiresRemoteGitRepo
 
         if ($creators === []) {
             warning('This directory has no Git remote. A Git repository is required to deploy to Laravel Cloud.');
-            warning('Install and sign in to the GitHub CLI (gh) or the GitLab CLI (glab) to create one from here.');
+            warning('Create one and add it as a remote, or sign in to the GitHub CLI (gh) or GitLab CLI (glab) to create it from here.');
 
             throw new CommandExitException(1);
         }

--- a/app/Concerns/ResolvesSourceProvider.php
+++ b/app/Concerns/ResolvesSourceProvider.php
@@ -52,7 +52,7 @@ trait ResolvesSourceProvider
 
         $provider = SourceProvider::tryFrom($value);
 
-        if ($provider === null || ! $provider->supported()) {
+        if ($provider === null) {
             $this->failAndExit(
                 'Unknown source provider ['.$value.']. Use one of: '
                 .implode(', ', array_keys(SourceProvider::options())),

--- a/app/Enums/SourceProvider.php
+++ b/app/Enums/SourceProvider.php
@@ -23,24 +23,16 @@ enum SourceProvider: string
     }
 
     /**
-     * Whether the CLI has a driver for this provider. Unsupported cases still exist so
-     * the enum matches the API, and so --source-provider fails with a real message.
-     */
-    public function supported(): bool
-    {
-        return $this !== self::BITBUCKET;
-    }
-
-    /**
-     * Remote hosts that identify this provider. Self-hosted and unsupported providers
-     * claim none, so detection never lands on them.
+     * Remote hosts that identify this provider. A self-hosted instance can be any host,
+     * so it claims none and detection never lands on it.
      */
     public function hosts(): array
     {
         return match ($this) {
             self::GITHUB => ['github.com'],
             self::GITLAB => ['gitlab.com'],
-            self::GITLAB_SELF_HOSTED, self::BITBUCKET => [],
+            self::BITBUCKET => ['bitbucket.org'],
+            self::GITLAB_SELF_HOSTED => [],
         };
     }
 
@@ -65,7 +57,6 @@ enum SourceProvider: string
     public static function options(): array
     {
         return collect(self::cases())
-            ->filter(fn (self $case) => $case->supported())
             ->mapWithKeys(fn (self $case) => [$case->value => $case->label()])
             ->all();
     }

--- a/app/SourceProviders/BitbucketProvider.php
+++ b/app/SourceProviders/BitbucketProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\SourceProviders;
+
+use App\Enums\SourceProvider;
+
+/**
+ * Bitbucket ships no CLI we can create a repository with, so this is URLs only.
+ */
+class BitbucketProvider implements SourceProviderDriver
+{
+    public function provider(): SourceProvider
+    {
+        return SourceProvider::BITBUCKET;
+    }
+
+    public function baseUrl(): string
+    {
+        return 'https://bitbucket.org';
+    }
+
+    public function repositoryUrl(string $repository): string
+    {
+        return $this->baseUrl().'/'.$repository;
+    }
+
+    public function commitUrl(string $repository, string $commitHash): string
+    {
+        return $this->repositoryUrl($repository).'/commits/'.$commitHash;
+    }
+
+    public function branchUrl(string $repository, string $branchName): string
+    {
+        return $this->repositoryUrl($repository).'/branch/'.$branchName;
+    }
+}

--- a/app/SourceProviders/SourceProviderManager.php
+++ b/app/SourceProviders/SourceProviderManager.php
@@ -23,9 +23,7 @@ class SourceProviderManager
                     'Could not work out which GitLab instance this repository lives on.',
                 ),
             ),
-            SourceProvider::BITBUCKET => throw new UnsupportedSourceProviderException(
-                $provider->label().' is not supported by the CLI yet.',
-            ),
+            SourceProvider::BITBUCKET => new BitbucketProvider,
         };
     }
 

--- a/tests/Feature/SourceProviderCommandsTest.php
+++ b/tests/Feature/SourceProviderCommandsTest.php
@@ -71,6 +71,7 @@ it('sends the provider the origin remote points at', function (string $host, str
 })->with([
     'GitHub' => ['github.com', 'github'],
     'GitLab' => ['gitlab.com', 'gitlab'],
+    'Bitbucket' => ['bitbucket.org', 'bitbucket'],
 ]);
 
 it('falls back to GitHub when the remote host is not one it knows', function () {
@@ -89,8 +90,8 @@ it('prefers an explicit --source-provider over the remote', function () {
     expect(sentSourceProvider())->toBe('gitlab_self_hosted');
 });
 
-it('rejects a provider it has no driver for', function (string $provider) {
+it('rejects a provider the API does not accept', function () {
     $this->mockGit->shouldReceive('remoteHost')->andReturn('github.com');
 
-    createApplicationWith(['--source-provider' => $provider])->assertFailed();
-})->with(['bitbucket', 'not-a-provider']);
+    createApplicationWith(['--source-provider' => 'not-a-provider'])->assertFailed();
+});

--- a/tests/Unit/SourceProviderTest.php
+++ b/tests/Unit/SourceProviderTest.php
@@ -3,6 +3,7 @@
 use App\Enums\SourceProvider;
 use App\Exceptions\UnsupportedSourceProviderException;
 use App\Git;
+use App\SourceProviders\BitbucketProvider;
 use App\SourceProviders\GitHubProvider;
 use App\SourceProviders\GitLabProvider;
 use App\SourceProviders\GitLabSelfHostedProvider;
@@ -13,38 +14,43 @@ it('detects a provider from a remote host', function (?string $host, ?SourceProv
 })->with([
     'GitHub' => ['github.com', SourceProvider::GITHUB],
     'GitLab' => ['gitlab.com', SourceProvider::GITLAB],
+    'Bitbucket' => ['bitbucket.org', SourceProvider::BITBUCKET],
     'self-hosted' => ['git.example.com', null],
-    'Bitbucket has no driver yet' => ['bitbucket.org', null],
     'no remote' => [null, null],
 ]);
 
-it('offers only providers it has a driver for', function () {
-    expect(SourceProvider::options())->not->toHaveKey('bitbucket')
-        ->and(SourceProvider::options())->toHaveKeys(['github', 'gitlab', 'gitlab_self_hosted']);
+it('offers every provider the API accepts', function () {
+    expect(SourceProvider::options())->toHaveKeys(['github', 'gitlab', 'gitlab_self_hosted', 'bitbucket']);
 });
 
 it('builds commit and branch URLs per provider', function () {
     $github = new GitHubProvider;
     $gitlab = new GitLabProvider;
     $selfHosted = new GitLabSelfHostedProvider('git.example.com');
+    $bitbucket = new BitbucketProvider;
 
     expect($github->commitUrl('user/repo', 'abc123'))->toBe('https://github.com/user/repo/commit/abc123')
         ->and($github->branchUrl('user/repo', 'main'))->toBe('https://github.com/user/repo/tree/main')
         ->and($gitlab->commitUrl('group/repo', 'abc123'))->toBe('https://gitlab.com/group/repo/-/commit/abc123')
         ->and($gitlab->branchUrl('group/repo', 'main'))->toBe('https://gitlab.com/group/repo/-/tree/main')
         ->and($selfHosted->commitUrl('group/sub/repo', 'abc123'))->toBe('https://git.example.com/group/sub/repo/-/commit/abc123')
-        ->and($selfHosted->repositoryUrl('group/sub/repo'))->toBe('https://git.example.com/group/sub/repo');
+        ->and($selfHosted->repositoryUrl('group/sub/repo'))->toBe('https://git.example.com/group/sub/repo')
+        ->and($bitbucket->commitUrl('workspace/repo', 'abc123'))->toBe('https://bitbucket.org/workspace/repo/commits/abc123')
+        ->and($bitbucket->branchUrl('workspace/repo', 'main'))->toBe('https://bitbucket.org/workspace/repo/branch/main');
 });
 
-it('resolves a driver for every supported provider', function (SourceProvider $provider) {
+it('resolves a driver for every provider', function (SourceProvider $provider) {
     $manager = new SourceProviderManager(app(Git::class));
 
     expect($manager->driver($provider, 'git.example.com')->provider())->toBe($provider);
-})->with(fn () => collect(SourceProvider::cases())->filter->supported()->all());
+})->with(SourceProvider::cases());
 
-it('refuses to build a driver for a provider it does not support', function () {
-    (new SourceProviderManager(app(Git::class)))->driver(SourceProvider::BITBUCKET);
-})->throws(UnsupportedSourceProviderException::class, 'Bitbucket is not supported by the CLI yet.');
+it('refuses to build a self-hosted driver with no instance to point at', function () {
+    $git = Mockery::mock(Git::class);
+    $git->shouldReceive('remoteHost')->andReturn(null);
+
+    (new SourceProviderManager($git))->driver(SourceProvider::GITLAB_SELF_HOSTED);
+})->throws(UnsupportedSourceProviderException::class);
 
 it('falls back to GitHub when the application is not the repository we are sitting in', function () {
     $git = Mockery::mock(Git::class);


### PR DESCRIPTION
A bitbucket.org remote is now detected, sent to the API, and linked correctly.

Bitbucket has no official CLI, so the driver only builds URLs and there is no repo creation path. Users create the repository themselves and add it as a remote. 